### PR TITLE
Update BBC.yaml

### DIFF
--- a/Clash/RuleSet/BBC.yaml
+++ b/Clash/RuleSet/BBC.yaml
@@ -3,7 +3,6 @@ payload:
   # USER-AGENT,BBCiPlayer*
   - PROCESS-NAME,bbc.iplayer.android
   - DOMAIN-KEYWORD,bbcfmt
-  - DOMAIN-KEYWORD,co.uk
   - DOMAIN-KEYWORD,uk-live
   - DOMAIN-SUFFIX,bbc.com
   - DOMAIN-SUFFIX,bbc.co


### PR DESCRIPTION
Removed .co.uk TLD as not all .co.uk domains belong to BBC.