### PR TITLE
Update AD.list

### DIFF
--- a/Surge/RULE-SET/AD.list
+++ b/Surge/RULE-SET/AD.list
@@ -63,7 +63,6 @@ DOMAIN-KEYWORD,-ad-sign.byteimg.com
 DOMAIN-KEYWORD,-be-pack-sign.pglstatp-toutiao.com
 DOMAIN-KEYWORD,-be-pack.pglstatp-toutiao.com
 DOMAIN-KEYWORD,-fe-tos.pglstatp-toutiao.com
-DOMAIN-KEYWORD,-sign.douyinpic.com
 DOMAIN-KEYWORD,api-access.pangolin-sdk-toutiao
 DOMAIN-KEYWORD,asiad.byteactivity
 DOMAIN-KEYWORD,log-api.pangolin-sdk-toutiao


### PR DESCRIPTION
Remove a rule that prevents images from loading in the TikTok comment section.