### PR TITLE
feat: add /v1/card HTML fallback for IPPure IP type detection

### DIFF
--- a/Surge/Module/Scripts/ip-security.js
+++ b/Surge/Module/Scripts/ip-security.js
@@ -315,11 +315,16 @@ async function fetchIPs() {
     ])
   ]);
 
+  const v6ip = exit6?.ip;
+  // 仅当返回的 IP 确实是 IPv6 格式（含 :）时才视为有效 IPv6
+  // api64.ip.sb 无 IPv6 连接时会通过 IPv4 访回相同的 IPv4 地址
+  const hasIPv6 = v6ip && v6ip.includes(":");
+
   return {
     inIP: enter?.data?.addr || null,
     outIP: exit?.ip || null,
-    outIPv6: exit6?.ip || null,
-    outIPv6Data: exit6
+    outIPv6: hasIPv6 ? v6ip : null,
+    outIPv6Data: hasIPv6 ? exit6 : null
   };
 }
 


### PR DESCRIPTION
When /v1/info no longer returns isResidential/isBroadcast fields, fall back to scraping /v1/card HTML for keywords (住宅/Residential, 广播/Broadcast/Announced) to determine IP type.

https://claude.ai/code/session_018ApHMnwKnkwDAwWPYFRb7K