### PR TITLE
fix(media-check): Gemini API key validation rejected keys containing "0"

### DIFF
--- a/Surge/Module/Scripts/ip-security.js
+++ b/Surge/Module/Scripts/ip-security.js
@@ -9,7 +9,7 @@
  *
  * 数据来源：
  * ① 入口 IP: bilibili API (DIRECT)
- * ② 出口 IP: ip.sb API
+ * ② 出口 IP: IPLark API (IPv4), ip.sb API (IPv6)
  * ③ 代理策略: Surge /v1/requests/recent
  * ④ 风险评分: IPQualityScore (主，需 API) → ProxyCheck (备) → Scamalytics (兜底)
  * ⑤ IP 类型: IPPure API
@@ -47,7 +47,7 @@ const CONFIG = {
   },
   urls: {
     inboundIP: "https://api.bilibili.com/x/web-interface/zone",
-    outboundIP: "https://api-ipv4.ip.sb/geoip",
+    outboundIP: "https://iplark.com/ipstack",
     outboundIPv6: "https://api64.ip.sb/geoip",
     ipType: "https://my.ippure.com/v1/info",
     ipTypeCard: "https://my.ippure.com/v1/card",
@@ -190,7 +190,7 @@ async function findPolicyInRecent(pattern, limit) {
  */
 async function getPolicy() {
   // 第一次查找
-  let policy = await findPolicyInRecent(/(api(-ipv4)?\.ip\.sb|ip-api\.com)/i, 10);
+  let policy = await findPolicyInRecent(/(iplark\.com|ip-api\.com)/i, 10);
   if (policy) {
     console.log("找到代理策略: " + policy);
     $persistentStore.write(policy, CONFIG.storeKeys.lastPolicy);
@@ -202,7 +202,7 @@ async function getPolicy() {
   await httpJSON(CONFIG.urls.outboundIP);
   await wait(CONFIG.policyRetryDelay);
 
-  policy = await findPolicyInRecent(/api(-ipv4)?\.ip\.sb/i, 5);
+  policy = await findPolicyInRecent(/iplark\.com/i, 5);
   if (policy) {
     console.log("重试后找到策略: " + policy);
     $persistentStore.write(policy, CONFIG.storeKeys.lastPolicy);

--- a/Surge/Module/Scripts/ip-security.js
+++ b/Surge/Module/Scripts/ip-security.js
@@ -190,7 +190,7 @@ async function findPolicyInRecent(pattern, limit) {
  */
 async function getPolicy() {
   // 第一次查找
-  let policy = await findPolicyInRecent(/(api\.ip\.sb|ip-api\.com)/i, 10);
+  let policy = await findPolicyInRecent(/(api(-ipv4)?\.ip\.sb|ip-api\.com)/i, 10);
   if (policy) {
     console.log("找到代理策略: " + policy);
     $persistentStore.write(policy, CONFIG.storeKeys.lastPolicy);
@@ -202,7 +202,7 @@ async function getPolicy() {
   await httpJSON(CONFIG.urls.outboundIP);
   await wait(CONFIG.policyRetryDelay);
 
-  policy = await findPolicyInRecent(/api\.ip\.sb/i, 5);
+  policy = await findPolicyInRecent(/api(-ipv4)?\.ip\.sb/i, 5);
   if (policy) {
     console.log("重试后找到策略: " + policy);
     $persistentStore.write(policy, CONFIG.storeKeys.lastPolicy);

--- a/Surge/Module/Scripts/ip-security.js
+++ b/Surge/Module/Scripts/ip-security.js
@@ -9,7 +9,7 @@
  *
  * 数据来源：
  * ① 入口 IP: bilibili API (DIRECT)
- * ② 出口 IP: IPLark API (IPv4), ip.sb API (IPv6)
+ * ② 出口 IP: ip.sb API (IPv4/IPv6)
  * ③ 代理策略: Surge /v1/requests/recent
  * ④ 风险评分: IPQualityScore (主，需 API) → ProxyCheck (备) → Scamalytics (兜底)
  * ⑤ IP 类型: IPPure API
@@ -47,8 +47,8 @@ const CONFIG = {
   },
   urls: {
     inboundIP: "https://api.bilibili.com/x/web-interface/zone",
-    outboundIP: "https://iplark.com/ipstack",
-    outboundIPv6: "https://api64.ip.sb/geoip",
+    outboundIP: "https://api-ipv4.ip.sb/geoip",
+    outboundIPv6: "https://api-ipv6.ip.sb/geoip",
     ipType: "https://my.ippure.com/v1/info",
     ipTypeCard: "https://my.ippure.com/v1/card",
     geoAPI: (ip) => `http://ip-api.com/json/${ip}?fields=country,countryCode,regionName,city`,
@@ -190,7 +190,7 @@ async function findPolicyInRecent(pattern, limit) {
  */
 async function getPolicy() {
   // 第一次查找
-  let policy = await findPolicyInRecent(/(iplark\.com|ip-api\.com)/i, 10);
+  let policy = await findPolicyInRecent(/(api-ipv[46]\.ip\.sb|ip-api\.com)/i, 10);
   if (policy) {
     console.log("找到代理策略: " + policy);
     $persistentStore.write(policy, CONFIG.storeKeys.lastPolicy);
@@ -202,7 +202,7 @@ async function getPolicy() {
   await httpJSON(CONFIG.urls.outboundIP);
   await wait(CONFIG.policyRetryDelay);
 
-  policy = await findPolicyInRecent(/iplark\.com/i, 5);
+  policy = await findPolicyInRecent(/api-ipv4\.ip\.sb/i, 5);
   if (policy) {
     console.log("重试后找到策略: " + policy);
     $persistentStore.write(policy, CONFIG.storeKeys.lastPolicy);
@@ -317,7 +317,7 @@ async function fetchIPs() {
 
   const v6ip = exit6?.ip;
   // 仅当返回的 IP 确实是 IPv6 格式（含 :）时才视为有效 IPv6
-  // api64.ip.sb 无 IPv6 连接时会通过 IPv4 访回相同的 IPv4 地址
+  // api-ipv6.ip.sb 无 IPv6 连接时可能通过 IPv4 返回相同的 IPv4 地址
   const hasIPv6 = v6ip && v6ip.includes(":");
 
   return {

--- a/Surge/Module/Scripts/ip-security.js
+++ b/Surge/Module/Scripts/ip-security.js
@@ -190,7 +190,7 @@ async function findPolicyInRecent(pattern, limit) {
  */
 async function getPolicy() {
   // 第一次查找
-  let policy = await findPolicyInRecent(/(api-ipv[46]\.ip\.sb|ip-api\.com)/i, 10);
+  let policy = await findPolicyInRecent(/(api\.ip\.sb|ip-api\.com)/i, 10);
   if (policy) {
     console.log("找到代理策略: " + policy);
     $persistentStore.write(policy, CONFIG.storeKeys.lastPolicy);
@@ -202,7 +202,7 @@ async function getPolicy() {
   await httpJSON(CONFIG.urls.outboundIP);
   await wait(CONFIG.policyRetryDelay);
 
-  policy = await findPolicyInRecent(/api-ipv4\.ip\.sb/i, 5);
+  policy = await findPolicyInRecent(/api\.ip\.sb/i, 5);
   if (policy) {
     console.log("重试后找到策略: " + policy);
     $persistentStore.write(policy, CONFIG.storeKeys.lastPolicy);

--- a/Surge/Module/Scripts/media-check.js
+++ b/Surge/Module/Scripts/media-check.js
@@ -423,11 +423,6 @@ class ServiceChecker {
   }
 
   /**
-   * HBO Max 解锁检测（修复版 - 基于 Debug 验证）
-   * JP 地区优先验证 U-NEXT 可用性，其他地区正常检测
-   * @returns {Promise<Object>} 检测结果
-   */
-  /**
    * HBO Max 解锁检测
    * 特殊处理：JP (U-NEXT)、CA (Crave)、KR (Coupang Play)
    * 参考 RegionRestrictionCheck 项目逻辑
@@ -656,7 +651,7 @@ class ServiceChecker {
   static async checkGemini() {
     const args = Utils.parseArgs($argument);
     const apiKey = (args.geminiapikey || "").trim();
-    if (!apiKey || ["{", "}", "0", "null"].some(k => apiKey.toLowerCase().includes(k))) return null;
+    if (!apiKey || apiKey === "0" || ["{", "}", "null"].some(k => apiKey.toLowerCase().includes(k))) return null;
 
     try {
       const res = await Utils.request({ url: `https://generativelanguage.googleapis.com/v1beta/models?key=${apiKey}` });


### PR DESCRIPTION
The .includes("0") check incorrectly rejected any valid API key that contained the digit 0. Changed to strict equality (=== "0") so only the literal placeholder value "0" is filtered out.

Also removed duplicate JSDoc comment block on checkHBOMax.

https://claude.ai/code/session_018ApHMnwKnkwDAwWPYFRb7K