### PR TITLE
feat: add lang argument for Chinese geo info via ip-api.com

### DIFF
--- a/Surge/Module/Pannel/ip-security-panel.sgmodule
+++ b/Surge/Module/Pannel/ip-security-panel.sgmodule
@@ -2,15 +2,15 @@
 #!desc=显示 IP 风险评分、类型、代理策略和入口/出口 IP 地理信息，支持网络变化自动通知
 #!author=HotKids&ChatGPT&Claude
 #!system=ios
-#!arguments=ipqs_key:null,event_delay:2
-#!arguments-desc=ipqs_key:(可选) IPQualityScore API Key，留空使用免费服务\nevent_delay:(可选) 网络变化后延迟检测时间（秒），默认 2 秒
+#!arguments=ipqs_key:null,lang:en,event_delay:2
+#!arguments-desc=ipqs_key:(可选) IPQualityScore API Key，留空使用免费服务\nlang:(可选) 地理信息语言，en=英文(ipinfo.io)，zh=中文(ip-api.com)，默认 en\nevent_delay:(可选) 网络变化后延迟检测时间（秒），默认 2 秒
 
 [Panel]
 ip-security-panel = script-name=ip-security-panel,update-interval=600
 
 [Script]
 # 面板手动触发
-ip-security-panel = type=generic,timeout=10,script-path=https://raw.githubusercontent.com/HotKids/Rules/master/Surge/Module/Scripts/ip-security.js,argument=ipqs_key={{{ipqs_key}}}
+ip-security-panel = type=generic,timeout=10,script-path=https://raw.githubusercontent.com/HotKids/Rules/master/Surge/Module/Scripts/ip-security.js,argument=ipqs_key={{{ipqs_key}}}&lang={{{lang}}}
 
 # 网络变化自动触发
-ip-security-event = type=event,event-name=network-changed,timeout=10,script-path=https://raw.githubusercontent.com/HotKids/Rules/master/Surge/Module/Scripts/ip-security.js,argument=TYPE=EVENT&ipqs_key={{{ipqs_key}}}&event_delay={{{event_delay}}}
+ip-security-event = type=event,event-name=network-changed,timeout=10,script-path=https://raw.githubusercontent.com/HotKids/Rules/master/Surge/Module/Scripts/ip-security.js,argument=TYPE=EVENT&ipqs_key={{{ipqs_key}}}&lang={{{lang}}}&event_delay={{{event_delay}}}


### PR DESCRIPTION
Support lang=zh to switch geo data source from ipinfo.io to ip-api.com with lang=zh-CN, returning Chinese city/region/country names. Default lang=en uses existing ipinfo.io + ip.sb.

https://claude.ai/code/session_018ApHMnwKnkwDAwWPYFRb7K