### PR TITLE
fix: YouTube region detection fallback to contentRegion

### DIFF
--- a/Surge/Module/Scripts/media-check.js
+++ b/Surge/Module/Scripts/media-check.js
@@ -574,8 +574,9 @@ class ServiceChecker {
         return Utils.createResult(STATUS.FAIL, "CN");
       }
       
-      // 提取地区码
-      const region = combinedBody.match(/"countryCode":"([A-Z]{2})"/)?.[1];
+      // 提取地区码：countryCode 不一定有，contentRegion 一定有
+      const region = combinedBody.match(/"countryCode":"([A-Z]{2})"/)?.[1]
+                  || combinedBody.match(/"contentRegion":"([A-Z]{2})"/)?.[1];
       
       // 检查可用性标识
       const hasPurchaseButton = combinedBody.includes('purchaseButtonOverride');


### PR DESCRIPTION
countryCode is not always present in YouTube response, but contentRegion always is. Fall back to contentRegion when countryCode is missing to avoid showing bare "Premium" without region.

https://claude.ai/code/session_018ApHMnwKnkwDAwWPYFRb7K