### PR TITLE
feat: add entrance IP detection, rename inbound to local IP

### DIFF
--- a/Surge/Module/Pannel/ip-security-panel.sgmodule
+++ b/Surge/Module/Pannel/ip-security-panel.sgmodule
@@ -1,5 +1,5 @@
 #!name=IP Security Monitor
-#!desc=显示 IP 风险评分、类型、代理策略和入口/出口 IP 地理信息，支持网络变化自动通知
+#!desc=显示 IP 风险评分、类型、代理策略和本地/入口/出口 IP 地理信息，支持网络变化自动通知
 #!author=HotKids&ChatGPT&Claude
 #!system=ios
 #!arguments=ipqs_key:null,lang:en,mask_ip:0,event_delay:2


### PR DESCRIPTION
- Extract proxy server entrance IP from Surge /v1/requests/recent remoteAddress(Proxy), displayed when different from exit IP
- Rename "入口 IP" → "本地 IP" (bilibili DIRECT, user's real IP)
- New "入口 IP" shows the actual proxy relay node IP (ipinfo.io)
- Simplify geo logic: local IP uses bilibili(zh)/ip.sb(en), entrance and exit IP always use ipinfo.io (English)
- Deduplicate province/city when identical in formatGeo
- Remove ipwho.is and bilibili geo queries for exit/entrance

https://claude.ai/code/session_01P3PRZvHF4wcRBrit1kf6hh