### PR TITLE
fix: strip port from entrance IP remoteAddress

### DIFF
--- a/Surge/Module/Scripts/ip-security.js
+++ b/Surge/Module/Scripts/ip-security.js
@@ -247,7 +247,7 @@ async function getPolicyAndEntrance() {
 
   let entranceIP = null;
   if (/\(Proxy\)/.test(hit.remoteAddress)) {
-    entranceIP = hit.remoteAddress.replace(/\s*\(Proxy\)\s*/, "");
+    entranceIP = hit.remoteAddress.replace(/\s*\(Proxy\)\s*/, "").replace(/:\d+$/, "");
     console.log("找到入口 IP: " + entranceIP);
   }
 


### PR DESCRIPTION
Surge remoteAddress may include port (e.g. 103.135.248.180:443(Proxy)). After removing (Proxy) suffix, also strip trailing :port to get clean IP for ipinfo.io geo lookup.

https://claude.ai/code/session_01P3PRZvHF4wcRBrit1kf6hh