### PR TITLE
fix: 主 IIFE 加 try-catch、flag 强制大写、自动刷新检测边界修正

### DIFF
--- a/Surge/Module/Scripts/ip-security.js
+++ b/Surge/Module/Scripts/ip-security.js
@@ -155,7 +155,8 @@ function surgeAPI(method, path) {
 // ==================== 数据处理工具 ====================
 function flag(cc) {
   if (!cc || cc.length !== 2) return "";
-  if (cc.toUpperCase() === "TW" && args.twFlag !== "tw") cc = "CN";
+  cc = cc.toUpperCase();
+  if (cc === "TW" && args.twFlag !== "tw") cc = "CN";
   const b = 0x1f1e6;
   return String.fromCodePoint(b + cc.charCodeAt(0) - 65, b + cc.charCodeAt(1) - 65);
 }
@@ -466,6 +467,7 @@ function sendNetworkChangeNotification({ useBilibili, policy, localIP, outIP, en
 
 // ==================== 主执行函数 ====================
 (async () => {
+  try {
   console.log("=== IP 安全检测开始 ===");
 
   // 1. EVENT 触发时延迟等待网络稳定
@@ -563,7 +565,7 @@ function sendNetworkChangeNotification({ useBilibili, policy, localIP, outIP, en
     const tolerance = 15;
     const remainder = elapsed % interval;
     const isAutoRefresh = lastRun > 0 && elapsed > tolerance
-      && (remainder < tolerance || remainder > interval - tolerance);
+      && (remainder <= tolerance || remainder >= interval - tolerance);
     if (!isAutoRefresh) {
       isMask = !isMask;
       $persistentStore.write(isMask ? "1" : "0", CONFIG.storeKeys.maskToggle);
@@ -582,5 +584,9 @@ function sendNetworkChangeNotification({ useBilibili, policy, localIP, outIP, en
       icon: "leaf.fill",
       "icon-color": riskResult.color
     });
+  }
+  } catch (e) {
+    console.log("未捕获异常: " + (e.message || e));
+    done({ title: "检测异常", content: e.message || String(e), icon: "leaf", "icon-color": "#9E9E9E" });
   }
 })();


### PR DESCRIPTION
- 主 IIFE 包裹 try-catch，异常时面板显示具体错误而非卡住等超时
- flag() 先 toUpperCase()，防止小写 country_code 输出乱码 emoji
- 自动刷新检测 remainder < tolerance 改为 <=，消除边界误判

https://claude.ai/code/session_01Y6yVshQ6hnzRtxnkFM6Kby