### PR TITLE
fix(spotify): 参考 check.sh 改用 geoCountry 字段检测地区

### DIFF
--- a/Surge/Module/Scripts/media-check.js
+++ b/Surge/Module/Scripts/media-check.js
@@ -604,25 +604,17 @@ class ServiceChecker {
 
   /**
    * Spotify 解锁检测
-   * 不能用通用 checkByRegex，因为页面 body 中存在大量 spotify.com/us/ 链接，
-   * 正则会先命中 us，与实际代理地区无关。
-   * 改为匹配 canonical URL，该标签直接反映服务器认定的当前地区。
+   * 参考 1-stream/RegionRestrictionCheck check.sh 写法：
+   * 请求 signup 页，提取嵌入 JSON 中的 "geoCountry":"XX" 字段
    * @returns {Promise<Object>} 检测结果
    */
   static async checkSpotify() {
     try {
-      const res = await Utils.request({ url: "https://www.spotify.com/premium/" });
-      const body = res.body || "";
-      // canonical URL 是最可靠的地区指示符，形如：
-      // <link rel="canonical" href="https://www.spotify.com/tw/premium/" />
-      const canonical = body.match(/<link[^>]+rel="canonical"[^>]+href="https:\/\/www\.spotify\.com\/([a-z]{2})\//i)
-                     || body.match(/href="https:\/\/www\.spotify\.com\/([a-z]{2})\/premium\/"[^>]+rel="canonical"/i);
-      if (canonical) return Utils.createResult(STATUS.OK, canonical[1].toUpperCase());
-      // 次选：og:url
-      const ogUrl = body.match(/property="og:url"\s+content="https:\/\/www\.spotify\.com\/([a-z]{2})\//i)
-                 || body.match(/content="https:\/\/www\.spotify\.com\/([a-z]{2})\/[^"]*"\s+property="og:url"/i);
-      if (ogUrl) return Utils.createResult(STATUS.OK, ogUrl[1].toUpperCase());
-      return Utils.createResult(STATUS.FAIL, "No");
+      const res = await Utils.request({ url: "https://www.spotify.com/tw/signup" });
+      const match = (res.body || "").match(/"geoCountry":"([A-Z]{2})","geoCountryMarket"/);
+      return match
+        ? Utils.createResult(STATUS.OK, match[1])
+        : Utils.createResult(STATUS.FAIL, "No");
     } catch { return Utils.createResult(STATUS.FAIL, "No"); }
   }
 


### PR DESCRIPTION
请求 /tw/signup 页面，从嵌入 JSON 中提取 "geoCountry":"XX" 字段， 与 1-stream/RegionRestrictionCheck 保持一致，解决始终返回 No 的问题。

https://claude.ai/code/session_01Fjt5pKAiuyTPJjGX9E6NaS