### PR TITLE
fix: restore HBO Max, only remove HBO GO Asia and Max

### DIFF
--- a/.github/scripts/sync-rules.py
+++ b/.github/scripts/sync-rules.py
@@ -48,6 +48,7 @@ SECTION_TO_FILE = {
     "Hulu JP":            "Hulu_JP",
     "iQIYI Intl":         "IQ",
     "LINE TV":            "LINETV",
+    "HBO Max":            "HBO_Max",
     "Amazon Prime Video": "Prime Video",
     "BBC iPlayer":        "BBC",
     "SBS On Demand":      "SBS",
@@ -74,7 +75,7 @@ REGIONAL_MEMBERS = {
     "Streaming_JP": ["AbemaTV", "FOD", "Hulu_JP", "Paravi", "TVer", "U-NEXT"],
     "Streaming_TW": ["Bahamut", "CATCHPLAY+", "friDay", "IQ",
                       "KKBOX&KKTV", "LINETV", "myVideo", "Readmoo", "Spotify"],
-    "Streaming_US": ["Crunchyroll", "Discovery+", "Hulu",
+    "Streaming_US": ["Crunchyroll", "Discovery+", "HBO_Max", "Hulu",
                       "MGM+", "PBS", "Paramount+", "Peacock", "Roku", "T-Mobile"],
 }
 
@@ -82,7 +83,7 @@ REGIONAL_MEMBERS = {
 # Movies Anywhere 不在此列，内联保留
 STREAMING_MEMBERS = [
     "AbemaTV", "Prime Video", "BBC", "Bahamut", "Britbox", "Crunchyroll",
-    "DAZN", "Discovery+", "Disney+", "Hulu", "MGM+",
+    "DAZN", "Discovery+", "Disney+", "HBO_Max", "Hulu", "MGM+",
     "MUBI", "Netflix", "Paramount+", "Peacock", "SBS", "Spotify",
     "Stan", "TVBAnywhere", "TVer", "U-NEXT", "YouTube",
 ]

--- a/Clash/RuleSet/HBO_Max.yaml
+++ b/Clash/RuleSet/HBO_Max.yaml
@@ -1,0 +1,6 @@
+payload:
+  # > HBO Max
+  - PROCESS-NAME,com.wbd.stream
+  - DOMAIN-SUFFIX,max.com
+  - DOMAIN-SUFFIX,hbomax.com
+  - DOMAIN-SUFFIX,discomax.com

--- a/Quantumult/X/Filter/HBO_Max.list
+++ b/Quantumult/X/Filter/HBO_Max.list
@@ -1,0 +1,7 @@
+# > HBO Max
+USER-AGENT,HBOMAX*,HBO_Max
+USER-AGENT,Max*,HBO_Max
+PROCESS-NAME,com.wbd.stream,HBO_Max
+DOMAIN-SUFFIX,max.com,HBO_Max
+DOMAIN-SUFFIX,hbomax.com,HBO_Max
+DOMAIN-SUFFIX,discomax.com,HBO_Max

--- a/Surge/RULE-SET/HBO_Max.list
+++ b/Surge/RULE-SET/HBO_Max.list
@@ -1,0 +1,7 @@
+# > HBO Max
+USER-AGENT,HBOMAX*
+USER-AGENT,Max*
+PROCESS-NAME,com.wbd.stream
+DOMAIN-SUFFIX,max.com
+DOMAIN-SUFFIX,hbomax.com
+DOMAIN-SUFFIX,discomax.com

--- a/sing-box/source/HBO_Max.json
+++ b/sing-box/source/HBO_Max.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "rules": [
+    {
+      "domain_suffix": [
+        "discomax.com",
+        "hbomax.com",
+        "max.com"
+      ]
+    },
+    {
+      "process_name": [
+        "com.wbd.stream"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Previous commit incorrectly removed HBO Max. Restore:
- Surge/RULE-SET/HBO_Max.list
- QX/Clash/sing-box HBO_Max output files
- HBO Max in SECTION_TO_FILE, REGIONAL_MEMBERS, STREAMING_MEMBERS

https://claude.ai/code/session_019j9D1BNCX8GSCLqEeQiyRf