### PR TITLE
fix: prepend '# > Name' header to fetched Surge rules if source has none

### DIFF
--- a/.github/scripts/sync-rules.py
+++ b/.github/scripts/sync-rules.py
@@ -784,6 +784,10 @@ def fetch_external_rules():
         if normalized is None:
             print(f"    [WARN] {name} 规范化后为空，跳过")
             continue
+        # 若来源文件没有 section header，自动补上 # > Name
+        first = normalized.splitlines()[0] if normalized.strip() else ""
+        if not re.match(r"^#\s*>\s*\S", first):
+            normalized = f"# > {name}\n{normalized}"
         content = f"### fork from {url}\n{normalized}"
         if write_if_changed(SURGE_DIR / f"{name}.list", content):
             print(f"    ✓ Surge/RULE-SET/{name}.list")


### PR DESCRIPTION
Sources like Clash YAML payloads don't contain a section header. After normalize_surge_rules(), auto-insert '# > {name}' when the first line isn't already a '# > ...' header.

https://claude.ai/code/session_019j9D1BNCX8GSCLqEeQiyRf