### PR TITLE
fix: move ConnersHua skip to Clash-only, sync to Loon

### DIFF
--- a/.github/scripts/sync-config.txt
+++ b/.github/scripts/sync-config.txt
@@ -22,6 +22,7 @@ Gateway
 # Clash
 >> Clash/Sample.yaml
 # > Skip
+ConnersHua
 iCloud
 Apple News
 Apple TV

--- a/Surge/Balloon.lcf
+++ b/Surge/Balloon.lcf
@@ -108,6 +108,11 @@ https://raw.githubusercontent.com/VirgilClyne/GetSomeFries/main/ruleset/HTTPDNS.
 # Advertising 广告
 https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/reject.txt, policy=🚧 AdGuard, tag=reject, enabled=true
 https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/AD.list, policy=🚧 AdGuard, tag=AD, enabled=true
+https://raw.githubusercontent.com/ConnersHua/RuleGo/master/Surge/Ruleset/Extra/Reject/Advertising.list, policy=🚧 AdGuard, tag=Advertising, enabled=true
+# Privacy 隐私
+https://raw.githubusercontent.com/ConnersHua/RuleGo/master/Surge/Ruleset/Extra/Reject/Tracking.list, policy=🚧 AdGuard, tag=Tracking, enabled=true
+# Hijacking 运营商劫持或恶意网站
+https://raw.githubusercontent.com/ConnersHua/RuleGo/master/Surge/Ruleset/Extra/Reject/Malicious.list, policy=🚧 AdGuard, tag=Malicious, enabled=true
 # 自定义多区域媒体应用
 # > 一些无需验证地区的分流 HOST
 https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Streaming+.list, policy=🔰 Proxy, tag=Streaming+, enabled=true


### PR DESCRIPTION
ConnersHua was in global skip, so Loon never received those rules. Moving it to Clash-specific skip lets Loon sync ConnersHua entries (Advertising, Tracking, Malicious) from Surge Profile.conf.

https://claude.ai/code/session_012BQ6sdfyuSqVqJYdsLgJYL