### PR TITLE
fix: recognize [Proxy Group] INI format in _process_builtin_loon

### DIFF
--- a/.github/scripts/sync-config.py
+++ b/.github/scripts/sync-config.py
@@ -176,7 +176,7 @@ def _process_builtin_loon(lines: list[str]) -> tuple[str, dict | None, str, str,
 
     for line in lines:
         s = line.strip()
-        if s == "proxy-groups:":
+        if s in ("proxy-groups:", "[Proxy Group]"):
             mode = "pg"
             continue
         if s == "[Rule]":

--- a/.github/scripts/sync-config.txt
+++ b/.github/scripts/sync-config.txt
@@ -27,7 +27,6 @@ iCloud
 Apple News
 Apple TV
 Speedtest
-ConnersHua
 
 # > Builtin
 << .github/scripts/sync-config/clash.ini

--- a/Clash/Sample.yaml
+++ b/Clash/Sample.yaml
@@ -1,3 +1,222 @@
+# 通用设置
+
+# port: 7890 # HTTP(S) 代理服务器端口
+# socks-port: 7891 # SOCKS5 代理端口
+mixed-port: 7893 # HTTP(S) 和 SOCKS 代理混合端口
+# redir-port: 7892 # 透明代理端口，用于 Linux 和 MacOS
+# tproxy-port: 7893 # 透明代理端口，用于 Linux (TProxy TCP and TProxy UDP)
+
+allow-lan: true # 允许局域网连接
+bind-address: '*' # 绑定 IP 地址，仅作用于 allow-lan 为 true，'*' 表示所有地址
+
+mode: rule
+
+# 日志等级 silent/error/warning/info/debug
+log-level: info
+
+# 开启 IPv6 总开关，关闭阻断所有 IPv6 链接和屏蔽 DNS 请求 AAAA 记录
+ipv6: false
+
+# RESTful API 监听地址
+external-controller: 127.0.0.1:9090
+
+# 设置出口网卡
+# interface-name: eth0
+
+# 性能设置
+
+# 统一延迟
+# 去除握手等额外延迟，更准确反映节点延迟
+unified-delay: true
+
+# TCP 并发连接所有 IP，将使用最快握手的 TCP
+tcp-concurrent: true
+
+# 全局 TLS 指纹，优先级低于 proxy 内的 client-fingerprint
+# 可选：chrome/firefox/safari/ios/random/none
+global-client-fingerprint: chrome
+
+# 进程匹配模式
+# always - 开启，强制匹配所有进程
+# strict - 默认，由 mihomo 判断是否开启
+# off - 不匹配进程，推荐在路由器上使用此模式
+find-process-mode: strict
+
+# 连接设置
+
+# TCP Keep-Alive 间隔
+keep-alive-interval: 30
+
+# GeoData 设置
+
+# 是否自动更新 geodata
+geo-auto-update: true
+
+# 更新间隔，单位：小时
+geo-update-interval: 24
+
+# 自定义 geodata url
+geox-url:
+  geoip: "https://raw.githubusercontent.com/Loyalsoldier/v2ray-rules-dat/release/geoip.dat"
+  geosite: "https://raw.githubusercontent.com/Loyalsoldier/v2ray-rules-dat/release/geosite.dat"
+  mmdb: "https://raw.githubusercontent.com/Loyalsoldier/geoip/release/Country.mmdb"
+
+# Hosts 设置
+
+# 类似于 /etc/hosts，仅支持配置单个 IP
+hosts:
+  '*.clash.dev': 127.0.0.1
+  '.dev': 127.0.0.1
+  'localhost': 127.0.0.1
+
+# 配置持久化
+
+profile:
+  # 存储 select 选择记录
+  store-selected: true
+  # 持久化 fake-ip
+  store-fake-ip: true
+
+# 嗅探域名
+
+sniffer:
+  enable: true
+  # 是否使用嗅探结果作为实际访问，默认 true
+  # 全局配置，优先级低于 sniffer.sniff 实际配置
+  override-destination: false
+  sniff:
+    HTTP:
+      # 需要嗅探的端口
+      ports: [80, 8080-8880]
+      # 可覆盖 sniffer.override-destination
+      override-destination: true
+    TLS:
+      ports: [443, 8443]
+    QUIC:
+      ports: [443, 8443]
+
+# DNS 设置
+
+dns:
+  enable: true
+  # 开启 DNS 服务器监听
+  listen: 0.0.0.0:1053
+  # false 将返回 AAAA 的空结果
+  ipv6: false
+
+  # 用于解析 nameserver，fallback 以及其他 DNS 服务器配置的 DNS 服务域名
+  # 只能使用纯 IP 地址，可使用加密 DNS
+  default-nameserver:
+    - 223.5.5.5
+    - 119.29.29.29
+
+  enhanced-mode: fake-ip
+  # fake-ip 池设置
+  fake-ip-range: 198.18.0.1/16
+
+  # DNS 缓存算法
+  cache-algorithm: arc
+
+  # DNS 缓存大小
+  cache-size: 4096
+
+  # 是否开启 DoH 支持 HTTP/3，将并发尝试
+  prefer-h3: false
+
+  # 配置后面的 nameserver、fallback 和 nameserver-policy 向 DNS 服务器的连接过程是否遵守 rules 规则
+  # 如果为 false（默认值）则这三部分的 DNS 服务器在未特别指定的情况下会直连
+  # 如果为 true，将会按照 rules 的规则匹配链接方式（走代理或直连）
+  respect-rules: false
+
+  # 配置 fake-ip-filter 的匹配模式，默认为 blacklist，即如果匹配成功不返回 fake-ip
+  # 可设置为 whitelist，即只有匹配成功才返回 fake-ip
+  fake-ip-filter-mode: blacklist
+
+  # 配置不使用 fake-ip 的域名
+  fake-ip-filter:
+    # 局域网与本地服务
+    - '*.lan'
+    - '*.local'
+    - '*.localdomain'
+    - '*.home.arpa'
+    - '*.localhost'
+    - 'localhost.ptlogin2.qq.com'
+    - 'WORKGROUP'
+    # STUN 服务
+    - '+.stun.*'
+    - '*.srv.nintendo.net'
+    - 'xbox.*.microsoft.com'
+    - 'xbox.*.*.microsoft.com'
+    - '*.xboxlive.com'
+    # 网络检测
+    - '*.msftconnecttest.com'
+    - '*.msftncsi.com'
+    - 'connectivitycheck.gstatic.com'
+    - 'connectivitycheck.android.com'
+    - 'connectivitycheck.platform.hicloud.com'
+    - 'connect.rom.miui.com'
+    - 'captive.apple.com'
+    - 'network-test.debian.org'
+    - 'detectportal.firefox.com'
+    # 特殊服务
+    - 'lens.l.google.com'
+    - '*.mcdn.bilivideo.cn'
+    - '*.battlenet.com.cn'
+    - '*.battlenet.com'
+    - '*.blzstatic.cn'
+    - '*.battle.net'
+    # Steam
+    - '*.cm.steampowered.com'
+    - '*.steamcontent.com'
+    # Tailscale / ZeroTier
+    - '*.tailscale.com'
+    - '*.zerotier.com'
+    # Spotify
+    - '*.spotify.com'
+
+  # DNS 主要域名配置
+  # 支持 UDP、TCP、DoT、DoH、DoQ
+  # 这部分为主要 DNS 配置，影响所有直连，确保使用对大陆解析精准的 DNS
+  nameserver:
+    - https://dns.alidns.com/dns-query
+    - https://doh.pub/dns-query
+
+# TUN 设置
+
+tun:
+  enable: true
+
+  # 网络栈模式
+  # system - 性能最高，兼容性一般
+  # gvisor - 兼容性好，性能较低
+  # mixed - TCP 走系统栈，UDP 走 gvisor（推荐）
+  stack: mixed
+
+  # 需要劫持的 DNS
+  dns-hijack:
+    - any:53
+
+  # 配置路由表
+  auto-route: true
+
+  # 自动识别出口网卡
+  auto-detect-interface: true
+
+  # 将所有连接路由到 tun 来防止泄漏，但你的设备将无法被其他设备访问
+  # strict-route: false
+
+  # 启用 auto-route 时使用自定义路由而不是默认路由
+  # route-address:
+  #   - 0.0.0.0/1
+  #   - 128.0.0.0/1
+
+  # 排除路由，这些网段不经过 TUN
+  # route-exclude-address:
+  #   - 192.168.31.0/24
+
+# 本地节点配置（订阅为空）
+proxies: []
+
 # 服务器订阅配置
 proxy-providers:
   Server:
@@ -16,7 +235,7 @@ proxy-providers:
       interval: 600
 
 proxy-groups:
-  # 全局代理
+  # Global
   - name: "GLOBAL"
     type: select
     icon: https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Global.png
@@ -120,7 +339,7 @@ proxy-groups:
       - 🔰 Proxy
       - 🔘 DIRECT
 
-  # 去广告以及隐私追踪保护、反运营商劫持开关
+  # Adblock
   - name: "🚧 AdGuard"
     type: select
     icon: https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Clubhouse_2.png
@@ -128,7 +347,7 @@ proxy-groups:
       - ⛔️ REJECT
       - 🔘 DIRECT
 
-  # 阻止
+  # Reject
   - name: "⛔️ REJECT"
     type: select
     hidden: true
@@ -136,7 +355,7 @@ proxy-groups:
     proxies:
       - REJECT
 
-  # 直连
+  # Direct
   - name: "🔘 DIRECT"
     type: select
     hidden: true

--- a/Surge/Balloon.lcf
+++ b/Surge/Balloon.lcf
@@ -63,29 +63,79 @@ Sub-JP = NameRegex, FilterKey = "^(?=.*(?i)(🇯🇵|日本|\b(JP|Japan)\d*\b))(
 Sub-US = NameRegex, FilterKey = "^(?=.*(?i)(🇺🇸|美国|\b(US|United States)\d*\b))(?!.*(?i)\b(USE(D)?|TOTAL|EXPIRE|RESET|Panel|Premium)\b|\d{4}-\d{2}-\d{2}|\d+(\.\d+)?\s*G).*"
 Sub-UN = NameRegex, FilterKey = "^(?=.+)(?!.*(?i)\b(USE(D)?|TOTAL|EXPIRE|RESET|Panel|Premium)\b|\d{4}-\d{2}-\d{2}|\d+(\.\d+)?\s*G).*"
 
+[General]
+# IP 查询模式
+ip-mode = v4-only
+# TUN IPv6 配置
+ipv6-vif = off
+# DNS 服务器
+dns-server = system
+# Wi-Fi 共享开启时 HTTP 服务的端口
+wifi-access-http-port = 6154
+# Wi-Fi 共享开启时 SOCKS5 服务的端口
+wifi-access-socks5-port = 6153
+# 是否允许 Wi-Fi 下共享网络
+allow-wifi-access = false
+# 节点测速时的超时秒数
+test-timeout = 3
+# 网络接口
+interface-mode = auto
+# 域名拦截行为
+domain-reject-mode = DNS
+# DNS 拦截方式
+dns-reject-mode = LoopbackIP
+# SNI 辅助规则匹配
+sni-sniffing = true
+# 直连时丢弃STUN
+disable-stun = true
+# UDP 回落策略
+udp-fallback-mode = REJECT
+# 策略切换时关闭连接
+disconnect-on-policy-change = false
+# 直连延迟测试 URL
+internet-test-url = http://wifi.vivo.com.cn/generate_204
+# 代理延迟测试 URL
+proxy-test-url = http://www.gstatic.com/generate_204
+# 资源解析器
+resource-parser = https://raw.githubusercontent.com/sub-store-org/Sub-Store/release/sub-store-parser.loon.min.js
+# GeoIP 数据库
+geoip-url = https://raw.githubusercontent.com/Loyalsoldier/geoip/release/GeoLite2-Country.mmdb
+# ASN 数据库
+ipasn-url = https://raw.githubusercontent.com/Loyalsoldier/geoip/release/GeoLite2-ASN.mmdb
+# 绕过代理
+skip-proxy = 192.168.0.0/16,10.0.0.0/8,172.16.0.0/12,localhost,*.local,e.crashlynatics.com
+# 绕过路由
+bypass-tun = 10.0.0.0/8,100.64.0.0/10,127.0.0.0/8,169.254.0.0/16,172.16.0.0/12,192.0.0.0/24,192.0.2.0/24,192.88.99.0/24,192.168.0.0/16,198.51.100.0/24,203.0.113.0/24,224.0.0.0/4,255.255.255.255/32
+
+[Proxy]
+🔘 DIRECT = DIRECT
+🚫 REJECT = REJECT
+
 [Proxy Group]
-# 节点选项
+# Proxy
 🔰 Proxy = select,🇭🇰 Hong Kong,🇨🇳 Taiwan,🇸🇬 Singapore,🇯🇵 Japan,🇺🇸 America,🇺🇳 Server,🔘 DIRECT,img-url = https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Direct.png
-# 海外流媒体服务策略组（适用于 Netflix, Disney+, HBO Max, Prime Video 等海外流媒体服务）
+# Streaming Global
 🎬 Streaming = select,🇭🇰 Hong Kong,🇨🇳 Taiwan,🇸🇬 Singapore,🇯🇵 Japan,🇺🇸 America,🇺🇳 Server,🔰 Proxy,img-url = https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Streaming.png
-# 国内流媒体服务策略组（适用于 iQIYI Intl, WeTV, Bilibili 等大陆在港台东南亚地区提供服务的流媒体服务）
+# CNTV APAC
 📺 CNTV = select,🔘 DIRECT,🇨🇳 Taiwan,🇭🇰 Hong Kong,img-url = https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Images/StreamingCN.png
-# Apple 服务策略组
+# Apple
+# > Apple TV
 🍏 Apple TV = select,🔘 DIRECT,🔰 Proxy,🇺🇸 America,img-url = https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Apple_2.png
+# > Apple Services
 🍎 Apple = select,🔘 DIRECT,🔰 Proxy,🇺🇸 America,🇯🇵 Japan,img-url = https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Apple.png
-# Google 服务策略组
-🔍 Google = select,🔰 Proxy,🇺🇸 America,img-url = https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Images/Color/Google.png
-# AIGC 服务策略组
-🤖 AIGC = select,🇸🇬 Singapore,🇯🇵 Japan,🇺🇸 America,🔰 Proxy,img-url = https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/ChatGPT.png
-# Crypto 服务策略组
+# Google
+🔍 Google = select,🇺🇸 America,🔰 Proxy,img-url = https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Images/Color/Google.png
+# AIGC
+🤖 AIGC = select,🇺🇸 America,🇸🇬 Singapore,🔰 Proxy,img-url = https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/ChatGPT.png
+# Crypto
 🪙 Crypto = select,🇺🇸 America,🔰 Proxy,🔘 DIRECT,img-url = https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Cryptocurrency_3.png
-# Finance 服务策略组
-💳 Credit = select,🔘 DIRECT,🇺🇸 America,🔰 Proxy,img-url = https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/PayPal.png
-# Telegram 服务策略组
+# Finance
+💳 Credit = select,🇺🇸 America,🔰 Proxy,🔘 DIRECT,img-url = https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/PayPal.png
+# Telegram
 📬 Telegram = select,🔰 Proxy,🇸🇬 Singapore,🔘 DIRECT,img-url = https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Telegram.png
-# Mail 邮件服务策略组
+# Mail
 📧 Mail = select,🔰 Proxy,🔘 DIRECT,img-url = https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Mail.png
-# 去广告以及隐私追踪保护、反运营商劫持开关
+# Adblock
 🚧 AdGuard = select,🚫 REJECT,🔘 DIRECT,img-url = https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Clubhouse_2.png
 # Nodes
 🇺🇳 Server = select,Sub-UN,img-url = https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Clubhouse_1.png
@@ -96,9 +146,43 @@ Sub-UN = NameRegex, FilterKey = "^(?=.+)(?!.*(?i)\b(USE(D)?|TOTAL|EXPIRE|RESET|P
 🇺🇸 America = url-test,Sub-US,interval = 60,tolerance = 50,img-url = https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/United_States.png
 
 [Rule]
-# SSH 标准端口
-DEST-PORT,22,DIRECT
-FINAL,🔰 Proxy
+# Local Rule
+# Type:DOMAIN-SUFFIX,DOMAIN,DOMAIN-KEYWORD,USER-AGENT,URL-REGEX,IP-CIDR
+# Strategy:DIRECT,Proxy,REJECT
+# Options:no-resolve(no-resolve(only for cidr))
+# 请勿在此添加GEOIP,cn,DIRECT
+# 请勿修改CN REGION规则的排序甚至删除
+# 通过 ChatGPT 收集整理
+# 私有内网地址段（Class A）
+IP-CIDR,10.0.0.0/8,DIRECT
+# 私有内网地址段（Class B）
+IP-CIDR,172.16.0.0/12,DIRECT
+# 私有内网地址段（Class C）
+IP-CIDR,192.168.0.0/16,DIRECT
+# 本地回环地址（localhost）
+IP-CIDR,127.0.0.0/8,DIRECT
+# 链路本地地址（APIPA）
+IP-CIDR,169.254.0.0/16,DIRECT
+# 多播地址段
+IP-CIDR,224.0.0.0/4,DIRECT
+# 保留地址段
+IP-CIDR,240.0.0.0/4,DIRECT
+# 特殊地址：本网络段
+IP-CIDR,0.0.0.0/8,DIRECT
+# 运营商大内网（Carrier-Grade NAT）
+IP-CIDR,100.64.0.0/10,DIRECT
+# IPv6 回环地址
+IP-CIDR6,::1/128,DIRECT
+# IPv6 本地唯一地址（类似内网）
+IP-CIDR6,fc00::/7,DIRECT
+# IPv6 链路本地地址（Link-Local）
+IP-CIDR6,fe80::/10,DIRECT
+# IPv4 映射到 IPv6 的地址段
+IP-CIDR6,::ffff:0:0/96,DIRECT
+# IPv6 未指定地址（默认路由起始）
+IP-CIDR6,::/128,DIRECT
+# IPv6 多播地址段
+IP-CIDR6,ff00::/8,DIRECT
 
 [Remote Rule]
 # Unbreak 后续规则修正
@@ -113,7 +197,7 @@ https://raw.githubusercontent.com/ConnersHua/RuleGo/master/Surge/Ruleset/Extra/R
 https://raw.githubusercontent.com/ConnersHua/RuleGo/master/Surge/Ruleset/Extra/Reject/Tracking.list, policy=🚧 AdGuard, tag=Tracking, enabled=true
 # Hijacking 运营商劫持或恶意网站
 https://raw.githubusercontent.com/ConnersHua/RuleGo/master/Surge/Ruleset/Extra/Reject/Malicious.list, policy=🚧 AdGuard, tag=Malicious, enabled=true
-# 自定义多区域媒体应用
+# # Global Area Network
 # > 一些无需验证地区的分流 HOST
 https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Streaming+.list, policy=🔰 Proxy, tag=Streaming+, enabled=true
 # > Streaming by Region
@@ -128,10 +212,10 @@ https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Streaming.
 # > CNTV（适用于 iQIYI Intl,WeTV,Bilibili 等大陆在港台东南亚提供服务的流媒体服务）
 https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/CNTV.list, policy=📺 CNTV, tag=CNTV, enabled=true
 # Global 全球代理规则
-# > AIGC（ChatGPT、Claude、Gemini、Apple Intelligence 等）
+# > AIGC
 https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Gemini.list, policy=🔍 Google, tag=Gemini, enabled=true
 https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/GenAI.list, policy=🤖 AIGC, tag=GenAI, enabled=true
-# > Apple 部分服务代理（App Store、TV、Music、News 等）
+# > Apple
 # >> iCloud Private Relay
 https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Apple/iCloud.PrivateRelay.list, policy=🔰 Proxy, tag=iCloud.PrivateRelay, enabled=true
 # >> Apple News
@@ -157,8 +241,8 @@ https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Spark.list
 https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/proxy.txt, policy=🔰 Proxy, tag=proxy, enabled=true
 # China Area Network
 https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/direct.txt, policy=🔘 DIRECT, tag=direct, enabled=true
-https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/cncidr.txt, policy=🔘 DIRECT, tag=cncidr, enabled=true
 https://raw.githubusercontent.com/VirgilClyne/GetSomeFries/main/ruleset/ASN.China.list, policy=🔘 DIRECT, tag=ASN.China, enabled=true
+https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/cncidr.txt, policy=🔘 DIRECT, tag=cncidr, enabled=true
 
 [Plugin]
 https://raw.githubusercontent.com/chavyleung/scripts/master/box/rewrite/boxjs.rewrite.loon.plugin, tag=BoxJS, enabled=true
@@ -167,9 +251,3 @@ https://raw.githubusercontent.com/VirgilClyne/GetSomeFries/main/plugin/DNS.plugi
 https://raw.githubusercontent.com/VirgilClyne/GetSomeFries/main/plugin/HTTPDNS.Block.plugin, tag=HTTPDNS Block, enabled=true
 https://raw.githubusercontent.com/mw418/Loon/main/plugin/jd_price.plugin, tag=京东比价, enabled=true
 https://raw.githubusercontent.com/fmz200/wool_scripts/main/Loon/plugin/blockAds.plugin, tag=去广告合集, enabled=false
-
-[Mitm]
-skip-server-cert-verify = true
-h2 = true
-ca-passphrase = Dler
-ca-p12 = MIIDGgIBAzCCAuAGCSqGSIb3DQEHAaCCAtEEggLNMIICyTCCAb8GCSqGSIb3DQEHBqCCAbAwggGsAgEAMIIBpQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYwDgQI5e4W8st2yMMCAggAgIIBeBDhcB5oCpEtPyamF2QSSZMoKnIQ9idB7/spS4BgYMq/zDT8c7SDSKM746+4D98feqkJmAYFUWlXtXOHwSR8QlFad9dTYw4SulHDpDAVr/+da6iCX+LeQuducormCI6xVcmpfZ8qvHWzpfHy5mrKxkuyj5OHlehvYOedDZ9P9s9ME2qZFsffKC4kk398QPjoBMLCb73m7QcFdzdus7NuVAd/kYZRww7ODcXcb5a45Yv4NeRwRjnVT8eCgjGXjJXQgJPAtyAWPLW+o1uS132Qdkmg+8EjwuxL/lOu3rLKh0gWWUFHcxv2rg4OcezyoZuv70zs3A8Ju3wmQ6oZuakeRuRyKu6+9BtgOqxnoBwvTMCI4saY8E318DWZjBOzg9N2vPOhKDeoh8ES9TAbRlcp5Bnp5TWrPhae+XeHlHde5KCr3kjB15/DAhrlh7+ht18I/p1shnRKAd1tH6p62to51j9mSHNxOFFCbBPiFqBSnPmuV2SSOOYHcjUwggECBgkqhkiG9w0BBwGggfQEgfEwge4wgesGCyqGSIb3DQEMCgECoIG0MIGxMBwGCiqGSIb3DQEMAQMwDgQI/FfHqSBxFUoCAggABIGQIJa8eopsdqunR4ZwxWt/ThhdkRw2LFHTbgg5jWdAUQfK2b+I6+Wk9Dimdb2xGzAaYcAVt3ArbfuDTjDUTI4m3pzXBe/edyeXagr6i6DgM9TluB4OsG6hC/MFtF3rvqnCT3DGf5b48hSj0Y5OfJy+iFXmasxtwVIf4pFFylXOOJeJdQry1NgImb0nZwsS8NJAMSUwIwYJKoZIhvcNAQkVMRYEFHijHPCciGG5pbv+qBYZvjpHBIFnMDEwITAJBgUrDgMCGgUABBSxzZGBSpKB8R5FQ6wdiWxFka+xcgQIxB+kS2hfUpkCAggA


### PR DESCRIPTION
Loon INI uses [Proxy Group] section headers instead of YAML proxy-groups:, causing pg_inject_loon to be None and a duplicate [Proxy Group] in output.

Also removes duplicate ConnersHua skip entry from sync-config.txt.

https://claude.ai/code/session_012BQ6sdfyuSqVqJYdsLgJYL