### PR TITLE
feat: map Surge FINAL+[MITM] to Loon, fix loon.ini structure

### DIFF
--- a/.github/scripts/sync-config.py
+++ b/.github/scripts/sync-config.py
@@ -157,22 +157,28 @@ def _process_builtin(lines: list[str]) -> tuple[str, dict | None, dict | None]:
     return proxy_providers, pg_inject, rules_inject
 
 
-def _process_builtin_loon(lines: list[str]) -> tuple[str, dict | None, str, str, str]:
+def _process_builtin_loon(lines: list[str]) -> tuple[str, dict | None, str, str, str, str, str, str]:
     """从 Loon Builtin 内容解析头部和各段落块。
 
     返回：
-      loon_header     str        proxy-groups: 之前的所有内容（[General] 等静态段落）
+      loon_header     str        [Proxy Group] 之前的所有内容（[General] 等静态段落）
       pg_inject_loon  dict|None  {anchor, block, names, prepend_block}
       rule_block      str        [Rule] 内容（不含段落标题）
       plugin_block    str        [Plugin] 内容（不含段落标题）
-      mitm_block      str        [Mitm] 内容（不含段落标题）
+      mitm_block      str        [Mitm] 内容（不含段落标题，通常由 Surge 覆盖）
+      host_block      str        [Host] 内容（不含段落标题）
+      rewrite_block   str        [Rewrite] 内容（不含段落标题）
+      script_block    str        [Script] 内容（不含段落标题）
     """
     header_lines: list[str] = []
     pg_lines: list[str] = []
     rule_lines: list[str] = []
     plugin_lines: list[str] = []
     mitm_lines: list[str] = []
-    mode = "header"  # header | pg | Rule | Plugin | Mitm
+    host_lines: list[str] = []
+    rewrite_lines: list[str] = []
+    script_lines: list[str] = []
+    mode = "header"  # header | pg | Rule | RemoteRule | Host | Rewrite | Script | Plugin | Mitm
 
     for line in lines:
         s = line.strip()
@@ -181,6 +187,18 @@ def _process_builtin_loon(lines: list[str]) -> tuple[str, dict | None, str, str,
             continue
         if s == "[Rule]":
             mode = "Rule"
+            continue
+        if s == "[Remote Rule]":
+            mode = "RemoteRule"  # 内容由 Surge 生成，忽略 ini 中的占位内容
+            continue
+        if s == "[Host]":
+            mode = "Host"
+            continue
+        if s == "[Rewrite]":
+            mode = "Rewrite"
+            continue
+        if s == "[Script]":
+            mode = "Script"
             continue
         if s == "[Plugin]":
             mode = "Plugin"
@@ -194,10 +212,17 @@ def _process_builtin_loon(lines: list[str]) -> tuple[str, dict | None, str, str,
             pg_lines.append(line)
         elif mode == "Rule":
             rule_lines.append(line)
+        elif mode == "Host":
+            host_lines.append(line)
+        elif mode == "Rewrite":
+            rewrite_lines.append(line)
+        elif mode == "Script":
+            script_lines.append(line)
         elif mode == "Plugin":
             plugin_lines.append(line)
         elif mode == "Mitm":
             mitm_lines.append(line)
+        # RemoteRule: 忽略（由 Surge 生成）
 
     loon_header = "\n".join(l.rstrip() for l in header_lines).strip()
 
@@ -247,8 +272,11 @@ def _process_builtin_loon(lines: list[str]) -> tuple[str, dict | None, str, str,
     rule_block = "\n".join(l.rstrip() for l in rule_lines).strip()
     plugin_block = "\n".join(l.rstrip() for l in plugin_lines).strip()
     mitm_block = "\n".join(l.rstrip() for l in mitm_lines).strip()
+    host_block = "\n".join(l.rstrip() for l in host_lines).strip()
+    rewrite_block = "\n".join(l.rstrip() for l in rewrite_lines).strip()
+    script_block = "\n".join(l.rstrip() for l in script_lines).strip()
 
-    return loon_header, pg_inject_loon, rule_block, plugin_block, mitm_block
+    return loon_header, pg_inject_loon, rule_block, plugin_block, mitm_block, host_block, rewrite_block, script_block
 
 
 def _empty_plat() -> dict:
@@ -302,10 +330,13 @@ def parse_sync_txt() -> dict:
         if current_section == "Builtin" and current_platform and current_platform != "Surge":
             plat = result.setdefault(current_platform, _empty_plat())
             if current_platform == "Loon":
-                hdr, pg_inj, rule_blk, plugin_blk, mitm_blk = _process_builtin_loon(builtin_buf)
+                hdr, pg_inj, rule_blk, plugin_blk, mitm_blk, host_blk, rewrite_blk, script_blk = _process_builtin_loon(builtin_buf)
                 plat["loon_header"] = hdr
                 plat["pg_inject_loon"] = pg_inj
-                plat["loon_blocks"] = {"Rule": rule_blk, "Plugin": plugin_blk, "Mitm": mitm_blk}
+                plat["loon_blocks"] = {
+                    "Rule": rule_blk, "Plugin": plugin_blk, "Mitm": mitm_blk,
+                    "Host": host_blk, "Rewrite": rewrite_blk, "Script": script_blk,
+                }
             else:
                 pp, pg, ri = _process_builtin(builtin_buf)
                 plat["proxy_providers"] = pp
@@ -475,8 +506,8 @@ def map_surge_url(url: str, url_maps: list[tuple[str, str]]) -> str | None:
 # 解析 Surge Profile.conf
 # ---------------------------------------------------------------------------
 
-def parse_surge_profile(profile_path: Path) -> tuple[list[str], list[str], list[str]]:
-    """读取 Surge Profile.conf，返回 proxy_lines, group_lines, rule_lines。"""
+def parse_surge_profile(profile_path: Path) -> tuple[list[str], list[str], list[str], list[str]]:
+    """读取 Surge Profile.conf，返回 proxy_lines, group_lines, rule_lines, mitm_lines。"""
     text = profile_path.read_text(encoding="utf-8")
     sections: dict[str, list[str]] = {}
     current: str | None = None
@@ -504,6 +535,7 @@ def parse_surge_profile(profile_path: Path) -> tuple[list[str], list[str], list[
         clean(sections.get("Proxy", [])),
         clean(sections.get("Proxy Group", [])),
         clean(sections.get("Rule", [])),
+        clean(sections.get("MITM", [])),
     )
 
 # ---------------------------------------------------------------------------
@@ -1165,7 +1197,7 @@ def main() -> None:
     if not surge_src:
         raise ValueError("Surge 块缺少 >> 源文件路径指令")
 
-    _, group_lines, rule_lines = parse_surge_profile(REPO_ROOT / surge_src)
+    _, group_lines, rule_lines, surge_mitm_lines = parse_surge_profile(REPO_ROOT / surge_src)
     print(f"  Surge: {len(group_lines)} groups, {len(rule_lines)} rules")
 
     # ── Clash ──────────────────────────────────────────────────────────────
@@ -1216,7 +1248,9 @@ def main() -> None:
         loon_blocks = loon.get("loon_blocks", {})
         loon_rule_block = loon_blocks.get("Rule", "")
         loon_plugin_block = loon_blocks.get("Plugin", "")
-        loon_mitm_block = loon_blocks.get("Mitm", "")
+        loon_host_block = loon_blocks.get("Host", "")
+        loon_rewrite_block = loon_blocks.get("Rewrite", "")
+        loon_script_block = loon_blocks.get("Script", "")
         filter_map = loon.get("filter_map", {})
         loon_skips = config.get("global_skips", []) + loon.get("skips", [])
 
@@ -1225,17 +1259,40 @@ def main() -> None:
         if loon_pg_inject:
             print(f"  loon pg_inject: anchor={loon_pg_inject.get('anchor')} | names={loon_pg_inject.get('names')}")
 
+        # 从 Surge rule_lines 提取 FINAL 规则
+        surge_final = ""
+        for _rl in rule_lines:
+            _parts = [p.strip() for p in _rl.split(",")]
+            if _parts[0].upper() == "FINAL":
+                _policy = _parts[1] if len(_parts) > 1 else "🔰 Proxy"
+                surge_final = f"# Final\nFINAL,{_policy}"
+                break
+
         pg_loon = gen_loon_proxy_groups(group_lines, loon_skips, loon_pg_inject, filter_map)
         remote_rules = gen_loon_remote_rules(rule_lines, loon_skips)
 
-        loon_parts = [loon_header, pg_loon]
+        # [Rule]：静态规则 + FINAL（来自 Surge）
+        rule_section_parts = []
         if loon_rule_block:
-            loon_parts.append("[Rule]\n" + loon_rule_block)
+            rule_section_parts.append(loon_rule_block)
+        if surge_final:
+            rule_section_parts.append(surge_final)
+        rule_section = "[Rule]\n" + "\n".join(rule_section_parts) if rule_section_parts else ""
+
+        # [Mitm]：来自 Surge Profile [MITM] 段落
+        surge_mitm_block = "\n".join(surge_mitm_lines).strip()
+
+        loon_parts = [loon_header, pg_loon]
+        if rule_section:
+            loon_parts.append(rule_section)
         loon_parts.append(remote_rules)
+        loon_parts.append("[Host]\n" + loon_host_block if loon_host_block else "[Host]")
+        loon_parts.append("[Rewrite]\n" + loon_rewrite_block if loon_rewrite_block else "[Rewrite]")
+        loon_parts.append("[Script]\n" + loon_script_block if loon_script_block else "[Script]")
         if loon_plugin_block:
             loon_parts.append("[Plugin]\n" + loon_plugin_block)
-        if loon_mitm_block:
-            loon_parts.append("[Mitm]\n" + loon_mitm_block)
+        if surge_mitm_block:
+            loon_parts.append("[Mitm]\n" + surge_mitm_block)
 
         changed = write_if_changed(REPO_ROOT / loon_out_path, "\n\n".join(loon_parts) + "\n")
         print(f"  {'✓ ' + loon_out_path + ' 已更新' if changed else '✓ ' + loon_out_path + ' 无变化'}")

--- a/.github/scripts/sync-config/loon.ini
+++ b/.github/scripts/sync-config/loon.ini
@@ -62,54 +62,6 @@ Sub-JP = NameRegex, FilterKey = "^(?=.*(?i)(🇯🇵|日本|\b(JP|Japan)\d*\b))(
 Sub-US = NameRegex, FilterKey = "^(?=.*(?i)(🇺🇸|美国|\b(US|United States)\d*\b))(?!.*(?i)\b(USE(D)?|TOTAL|EXPIRE|RESET|Panel|Premium)\b|\d{4}-\d{2}-\d{2}|\d+(\.\d+)?\s*G).*"
 Sub-UN = NameRegex, FilterKey = "^(?=.+)(?!.*(?i)\b(USE(D)?|TOTAL|EXPIRE|RESET|Panel|Premium)\b|\d{4}-\d{2}-\d{2}|\d+(\.\d+)?\s*G).*"
 
-[General]
-# IP 查询模式
-ip-mode = v4-only
-# TUN IPv6 配置
-ipv6-vif = off
-# DNS 服务器
-dns-server = system
-# Wi-Fi 共享开启时 HTTP 服务的端口
-wifi-access-http-port = 6154
-# Wi-Fi 共享开启时 SOCKS5 服务的端口
-wifi-access-socks5-port = 6153
-# 是否允许 Wi-Fi 下共享网络
-allow-wifi-access = false
-# 节点测速时的超时秒数
-test-timeout = 3
-# 网络接口
-interface-mode = auto
-# 域名拦截行为
-domain-reject-mode = DNS
-# DNS 拦截方式
-dns-reject-mode = LoopbackIP
-# SNI 辅助规则匹配
-sni-sniffing = true
-# 直连时丢弃STUN
-disable-stun = true
-# UDP 回落策略
-udp-fallback-mode = REJECT
-# 策略切换时关闭连接
-disconnect-on-policy-change = false
-# 直连延迟测试 URL
-internet-test-url = http://wifi.vivo.com.cn/generate_204
-# 代理延迟测试 URL
-proxy-test-url = http://www.gstatic.com/generate_204
-# 资源解析器
-resource-parser = https://raw.githubusercontent.com/sub-store-org/Sub-Store/release/sub-store-parser.loon.min.js
-# GeoIP 数据库
-geoip-url = https://raw.githubusercontent.com/Loyalsoldier/geoip/release/GeoLite2-Country.mmdb
-# ASN 数据库
-ipasn-url = https://raw.githubusercontent.com/Loyalsoldier/geoip/release/GeoLite2-ASN.mmdb
-# 绕过代理
-skip-proxy = 192.168.0.0/16,10.0.0.0/8,172.16.0.0/12,localhost,*.local,e.crashlynatics.com
-# 绕过路由
-bypass-tun = 10.0.0.0/8,100.64.0.0/10,127.0.0.0/8,169.254.0.0/16,172.16.0.0/12,192.0.0.0/24,192.0.2.0/24,192.88.99.0/24,192.168.0.0/16,198.51.100.0/24,203.0.113.0/24,224.0.0.0/4,255.255.255.255/32
-
-[Proxy]
-🔘 DIRECT = DIRECT
-🚫 REJECT = REJECT
-
 [Proxy Group]
 # Adblock // 📧 Mail
 🚧 AdGuard = select,🚫 REJECT,🔘 DIRECT,img-url = https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Clubhouse_2.png
@@ -152,6 +104,14 @@ IP-CIDR6,::ffff:0:0/96,DIRECT
 IP-CIDR6,::/128,DIRECT
 # IPv6 多播地址段
 IP-CIDR6,ff00::/8,DIRECT
+
+[Remote Rule]
+
+[Host]
+
+[Rewrite]
+
+[Script]
 
 [Plugin]
 https://raw.githubusercontent.com/chavyleung/scripts/master/box/rewrite/boxjs.rewrite.loon.plugin, tag=BoxJS, enabled=true

--- a/Surge/Balloon.lcf
+++ b/Surge/Balloon.lcf
@@ -1,7 +1,6 @@
 # Loon
-# Date: 2025-11-20
+# Date: 2026-04-10
 # Author: @HotKids
-# Customized for Someone
 
 [General]
 # IP 查询模式
@@ -62,54 +61,6 @@ Sub-SG = NameRegex, FilterKey = "^(?=.*(?i)(🇸🇬|新加坡|狮城|\b(SG|Sing
 Sub-JP = NameRegex, FilterKey = "^(?=.*(?i)(🇯🇵|日本|\b(JP|Japan)\d*\b))(?!.*(?i)\b(USE(D)?|TOTAL|EXPIRE|RESET|Panel|Premium)\b|\d{4}-\d{2}-\d{2}|\d+(\.\d+)?\s*G).*"
 Sub-US = NameRegex, FilterKey = "^(?=.*(?i)(🇺🇸|美国|\b(US|United States)\d*\b))(?!.*(?i)\b(USE(D)?|TOTAL|EXPIRE|RESET|Panel|Premium)\b|\d{4}-\d{2}-\d{2}|\d+(\.\d+)?\s*G).*"
 Sub-UN = NameRegex, FilterKey = "^(?=.+)(?!.*(?i)\b(USE(D)?|TOTAL|EXPIRE|RESET|Panel|Premium)\b|\d{4}-\d{2}-\d{2}|\d+(\.\d+)?\s*G).*"
-
-[General]
-# IP 查询模式
-ip-mode = v4-only
-# TUN IPv6 配置
-ipv6-vif = off
-# DNS 服务器
-dns-server = system
-# Wi-Fi 共享开启时 HTTP 服务的端口
-wifi-access-http-port = 6154
-# Wi-Fi 共享开启时 SOCKS5 服务的端口
-wifi-access-socks5-port = 6153
-# 是否允许 Wi-Fi 下共享网络
-allow-wifi-access = false
-# 节点测速时的超时秒数
-test-timeout = 3
-# 网络接口
-interface-mode = auto
-# 域名拦截行为
-domain-reject-mode = DNS
-# DNS 拦截方式
-dns-reject-mode = LoopbackIP
-# SNI 辅助规则匹配
-sni-sniffing = true
-# 直连时丢弃STUN
-disable-stun = true
-# UDP 回落策略
-udp-fallback-mode = REJECT
-# 策略切换时关闭连接
-disconnect-on-policy-change = false
-# 直连延迟测试 URL
-internet-test-url = http://wifi.vivo.com.cn/generate_204
-# 代理延迟测试 URL
-proxy-test-url = http://www.gstatic.com/generate_204
-# 资源解析器
-resource-parser = https://raw.githubusercontent.com/sub-store-org/Sub-Store/release/sub-store-parser.loon.min.js
-# GeoIP 数据库
-geoip-url = https://raw.githubusercontent.com/Loyalsoldier/geoip/release/GeoLite2-Country.mmdb
-# ASN 数据库
-ipasn-url = https://raw.githubusercontent.com/Loyalsoldier/geoip/release/GeoLite2-ASN.mmdb
-# 绕过代理
-skip-proxy = 192.168.0.0/16,10.0.0.0/8,172.16.0.0/12,localhost,*.local,e.crashlynatics.com
-# 绕过路由
-bypass-tun = 10.0.0.0/8,100.64.0.0/10,127.0.0.0/8,169.254.0.0/16,172.16.0.0/12,192.0.0.0/24,192.0.2.0/24,192.88.99.0/24,192.168.0.0/16,198.51.100.0/24,203.0.113.0/24,224.0.0.0/4,255.255.255.255/32
-
-[Proxy]
-🔘 DIRECT = DIRECT
-🚫 REJECT = REJECT
 
 [Proxy Group]
 # Proxy
@@ -183,6 +134,8 @@ IP-CIDR6,::ffff:0:0/96,DIRECT
 IP-CIDR6,::/128,DIRECT
 # IPv6 多播地址段
 IP-CIDR6,ff00::/8,DIRECT
+# Final
+FINAL,🔰 Proxy
 
 [Remote Rule]
 # Unbreak 后续规则修正
@@ -244,6 +197,12 @@ https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/direct.txt, p
 https://raw.githubusercontent.com/VirgilClyne/GetSomeFries/main/ruleset/ASN.China.list, policy=🔘 DIRECT, tag=ASN.China, enabled=true
 https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/cncidr.txt, policy=🔘 DIRECT, tag=cncidr, enabled=true
 
+[Host]
+
+[Rewrite]
+
+[Script]
+
 [Plugin]
 https://raw.githubusercontent.com/chavyleung/scripts/master/box/rewrite/boxjs.rewrite.loon.plugin, tag=BoxJS, enabled=true
 https://raw.githubusercontent.com/Script-Hub-Org/Script-Hub/main/modules/script-hub.loon.plugin, tag=Script Hub, enabled=true
@@ -251,3 +210,9 @@ https://raw.githubusercontent.com/VirgilClyne/GetSomeFries/main/plugin/DNS.plugi
 https://raw.githubusercontent.com/VirgilClyne/GetSomeFries/main/plugin/HTTPDNS.Block.plugin, tag=HTTPDNS Block, enabled=true
 https://raw.githubusercontent.com/mw418/Loon/main/plugin/jd_price.plugin, tag=京东比价, enabled=true
 https://raw.githubusercontent.com/fmz200/wool_scripts/main/Loon/plugin/blockAds.plugin, tag=去广告合集, enabled=false
+
+[Mitm]
+skip-server-cert-verify = true
+h2 = true
+ca-passphrase = Dler
+ca-p12 = MIIDGgIBAzCCAuAGCSqGSIb3DQEHAaCCAtEEggLNMIICyTCCAb8GCSqGSIb3DQEHBqCCAbAwggGsAgEAMIIBpQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYwDgQI5e4W8st2yMMCAggAgIIBeBDhcB5oCpEtPyamF2QSSZMoKnIQ9idB7/spS4BgYMq/zDT8c7SDSKM746+4D98feqkJmAYFUWlXtXOHwSR8QlFad9dTYw4SulHDpDAVr/+da6iCX+LeQuducormCI6xVcmpfZ8qvHWzpfHy5mrKxkuyj5OHlehvYOedDZ9P9s9ME2qZFsffKC4kk398QPjoBMLCb73m7QcFdzdus7NuVAd/kYZRww7ODcXcb5a45Yv4NeRwRjnVT8eCgjGXjJXQgJPAtyAWPLW+o1uS132Qdkmg+8EjwuxL/lOu3rLKh0gWWUFHcxv2rg4OcezyoZuv70zs3A8Ju3wmQ6oZuakeRuRyKu6+9BtgOqxnoBwvTMCI4saY8E318DWZjBOzg9N2vPOhKDeoh8ES9TAbRlcp5Bnp5TWrPhae+XeHlHde5KCr3kjB15/DAhrlh7+ht18I/p1shnRKAd1tH6p62to51j9mSHNxOFFCbBPiFqBSnPmuV2SSOOYHcjUwggECBgkqhkiG9w0BBwGggfQEgfEwge4wgesGCyqGSIb3DQEMCgECoIG0MIGxMBwGCiqGSIb3DQEMAQMwDgQI/FfHqSBxFUoCAggABIGQIJa8eopsdqunR4ZwxWt/ThhdkRw2LFHTbgg5jWdAUQfK2b+I6+Wk9Dimdb2xGzAaYcAVt3ArbfuDTjDUTI4m3pzXBe/edyeXagr6i6DgM9TluB4OsG6hC/MFtF3rvqnCT3DGf5b48hSj0Y5OfJy+iFXmasxtwVIf4pFFylXOOJeJdQry1NgImb0nZwsS8NJAMSUwIwYJKoZIhvcNAQkVMRYEFHijHPCciGG5pbv+qBYZvjpHBIFnMDEwITAJBgUrDgMCGgUABBSxzZGBSpKB8R5FQ6wdiWxFka+xcgQIxB+kS2hfUpkCAggA


### PR DESCRIPTION
- Fix loon.ini: remove duplicate [General]/[Proxy] blocks, add proper [Remote Rule]/[Host]/[Rewrite]/[Script] section placeholders
- parse_surge_profile() now returns [MITM] section lines
- _process_builtin_loon() handles [Remote Rule]/[Host]/[Rewrite]/[Script] as recognized modes (ignores remote rule placeholder, captures rest)
- Map Surge FINAL rule → Loon [Rule] FINAL,🔰 Proxy
- Map Surge [MITM] → Loon [Mitm] (skip-server-cert-verify, h2, ca-p12)
- Add [Host]/[Rewrite]/[Script] empty sections to Balloon.lcf output

https://claude.ai/code/session_012BQ6sdfyuSqVqJYdsLgJYL