### PR TITLE
feat(qx): add emoji toggle + convert smart→static

### DIFF
--- a/.github/scripts/sync-config.py
+++ b/.github/scripts/sync-config.py
@@ -419,6 +419,7 @@ def _empty_plat() -> dict:
         "qx_header": "",
         "qx_blocks": {},
         "pg_inject_qx": None,
+        "emoji": False,
     }
 
 
@@ -569,6 +570,12 @@ def parse_sync_txt() -> dict:
             left, right = left.strip(), right.strip()
             if left:
                 result.setdefault(current_platform, _empty_plat())["filter_map"][left] = right
+        elif current_section == "Options" and current_platform and current_platform != "Surge":
+            if "=" in stripped:
+                key, _, val = stripped.partition("=")
+                key, val = key.strip(), val.strip().lower()
+                if key == "emoji":
+                    result.setdefault(current_platform, _empty_plat())["emoji"] = val in ("true", "1", "yes", "on")
 
     flush_builtin()
     return result
@@ -1282,24 +1289,57 @@ def gen_loon_remote_rules(
 _QX_PROXY_MAP = {"🚫 REJECT": "reject", "🔘 DIRECT": "direct"}
 
 
+def _qx_strip_emoji_text(text: str) -> str:
+    """Strip emoji from policy name references in QX config text blocks.
+
+    Handles:
+      static=🚧 AdGuard, reject, direct, img-url=...
+      force-policy=🚧 AdGuard  (within filter_remote lines)
+      final, 🔰 Proxy
+    """
+    result = []
+    for line in text.splitlines():
+        s = line.strip()
+        m = re.match(
+            r"^((?:static|url-latency-benchmark|available|round-robin|dest-hash)=)(.*)", s
+        )
+        if m:
+            kind, rest = m.group(1), m.group(2)
+            parts = [p.strip() for p in rest.split(",")]
+            # Strip emoji from all non-key=value tokens (policy name + proxy refs)
+            out_parts = [strip_emoji(p) if "=" not in p else p for p in parts]
+            result.append(kind + ", ".join(out_parts))
+        elif "force-policy=" in line:
+            new_line = re.sub(
+                r"(force-policy=)([^,]+)",
+                lambda m2: m2.group(1) + strip_emoji(m2.group(2).strip()),
+                line,
+            )
+            result.append(new_line)
+        elif s.startswith("final,"):
+            result.append("final, " + strip_emoji(s[6:].strip()))
+        else:
+            result.append(line)
+    return "\n".join(result)
+
+
 def _fmt_qx_policy(
     name: str,
     gtype: str,
     params: dict[str, str],
     proxies: list[str],
+    strip_names: bool = True,
 ) -> str | None:
     """格式化为 QX policy 单行。返回 None 表示跳过该组。"""
     icon_part = ""
     if icon_url := params.get("icon-url", ""):
         icon_part = f", img-url={icon_url}"
 
-    # smart + policy-regex-filter → url-latency-benchmark（必须先于 include-other-group 检查）
+    emit_name = strip_emoji(name) if strip_names else name
+
+    # smart + policy-regex-filter → static with server-tag-regex（必须先于 include-other-group 检查）
     if gtype == "smart" and (regex := params.get("policy-regex-filter", "")):
-        return (
-            f"url-latency-benchmark={name}, server-tag-regex={regex}, "
-            f"check-url=http://cp.cloudflare.com/generate_204, "
-            f"tolerance=100, alive-checking=false{icon_part}"
-        )
+        return f"static={emit_name}, server-tag-regex={regex}{icon_part}"
 
     # include-all-proxies / include-other-group / policy-path → 跳过
     if (
@@ -1312,7 +1352,9 @@ def _fmt_qx_policy(
     # select with explicit proxies → static
     if proxies:
         mapped = [_QX_PROXY_MAP.get(p, p) for p in proxies]
-        return f"static={name}, {', '.join(mapped)}{icon_part}"
+        if strip_names:
+            mapped = [strip_emoji(p) for p in mapped]
+        return f"static={emit_name}, {', '.join(mapped)}{icon_part}"
 
     return None
 
@@ -1321,6 +1363,7 @@ def gen_qx_policies(
     group_lines: list[str],
     skips: list[str],
     pg_inject: dict | None,
+    strip_names: bool = True,
 ) -> str:
     """生成 QX [policy] 段落。"""
     out: list[str] = ["[policy]"]
@@ -1329,7 +1372,8 @@ def gen_qx_policies(
     ph = PendingHeaders()
 
     if pg_inject and pg_inject.get("prepend_block"):
-        out.append(pg_inject["prepend_block"])
+        prepend = _qx_strip_emoji_text(pg_inject["prepend_block"]) if strip_names else pg_inject["prepend_block"]
+        out.append(prepend)
 
     for line in group_lines:
         if line.startswith("#"):
@@ -1350,7 +1394,7 @@ def gen_qx_policies(
             ph.skip()
             continue
 
-        qx_line = _fmt_qx_policy(name, g["type"], g["params"], g["proxies"])
+        qx_line = _fmt_qx_policy(name, g["type"], g["params"], g["proxies"], strip_names)
         if qx_line is None:
             ph.skip()
             continue
@@ -1358,12 +1402,15 @@ def gen_qx_policies(
         out.extend(ph.flush())
         out.append(qx_line)
 
+        # anchor 比较使用原始名称（inject_names 也用原始名称存储）
         if pg_inject and not injected and pg_inject.get("anchor") == name:
-            out.append(pg_inject["block"])
+            block = _qx_strip_emoji_text(pg_inject["block"]) if strip_names else pg_inject["block"]
+            out.append(block)
             injected = True
 
     if pg_inject and not injected and pg_inject.get("block"):
-        out.append(pg_inject["block"])
+        block = _qx_strip_emoji_text(pg_inject["block"]) if strip_names else pg_inject["block"]
+        out.append(block)
 
     return "\n".join(out)
 
@@ -1377,6 +1424,7 @@ def gen_qx_filter_remote(
     skips: list[str],
     rename_map: dict[str, str] | None = None,
     static_fr: str = "",
+    strip_names: bool = True,
 ) -> str:
     """生成 QX [filter_remote] 段落。
 
@@ -1384,7 +1432,8 @@ def gen_qx_filter_remote(
     """
     out: list[str] = ["[filter_remote]"]
     if static_fr:
-        for line in static_fr.splitlines():
+        fr_text = _qx_strip_emoji_text(static_fr) if strip_names else static_fr
+        for line in fr_text.splitlines():
             out.append(line)
         out.append("")
     ph = PendingHeaders()
@@ -1423,9 +1472,11 @@ def gen_qx_filter_remote(
 
         if rename_map:
             tag = rename_map.get(tag, tag)
+        # _QX_PROXY_MAP 优先（🔘 DIRECT→direct 等 QX 内建值），其余按 strip_names 处理
+        emit_policy = _QX_PROXY_MAP.get(policy, strip_emoji(policy) if strip_names else policy)
         out.extend(ph.flush())
         out.append(
-            f"{url}, tag={tag}, force-policy={policy}, "
+            f"{url}, tag={tag}, force-policy={emit_policy}, "
             f"update-interval=86400, opt-parser=true, enabled=true"
         )
 
@@ -1436,7 +1487,11 @@ def gen_qx_filter_remote(
 # 生成 QX [filter_local]
 # ---------------------------------------------------------------------------
 
-def gen_qx_filter_local(rule_lines: list[str], static_fl: str = "") -> str:
+def gen_qx_filter_local(
+    rule_lines: list[str],
+    static_fl: str = "",
+    strip_names: bool = True,
+) -> str:
     """生成 QX [filter_local] 段落。
 
     static_fl 为 qx.ini 中的静态 LAN 规则（含 geoip, cn, direct），
@@ -1464,7 +1519,8 @@ def gen_qx_filter_local(rule_lines: list[str], static_fl: str = "") -> str:
             out.append(f"geoip, {geoip_val}, {policy}")
         elif rule_type == "FINAL" and final_line is None:
             policy = parts[1] if len(parts) > 1 else "🔰 Proxy"
-            final_line = f"final, {policy}"
+            emit_policy = _QX_PROXY_MAP.get(policy, strip_emoji(policy) if strip_names else policy)
+            final_line = f"final, {emit_policy}"
 
     if final_line:
         out.append(final_line)
@@ -1618,16 +1674,19 @@ def main() -> None:
         qx_pg_inject = qx.get("pg_inject_qx")
         qx_skips = config.get("global_skips", []) + qx.get("skips", [])
         qx_rename_map = qx.get("rename_map", {})
+        qx_strip_names = not qx.get("emoji", False)  # emoji=False(default) → strip names
 
         print(f"  QX skip: {qx_skips}")
+        print(f"  QX emoji: {qx.get('emoji', False)} | strip_names: {qx_strip_names}")
         if qx_pg_inject:
             print(f"  QX pg_inject: anchor={qx_pg_inject.get('anchor')} | names={qx_pg_inject.get('names')}")
 
-        policies = gen_qx_policies(group_lines, qx_skips, qx_pg_inject)
+        policies = gen_qx_policies(group_lines, qx_skips, qx_pg_inject, strip_names=qx_strip_names)
         filter_remote = gen_qx_filter_remote(
-            rule_lines, qx_skips, qx_rename_map, qx_blocks.get("filter_remote", "")
+            rule_lines, qx_skips, qx_rename_map, qx_blocks.get("filter_remote", ""),
+            strip_names=qx_strip_names,
         )
-        filter_local = gen_qx_filter_local(rule_lines, qx_blocks.get("filter_local", ""))
+        filter_local = gen_qx_filter_local(rule_lines, qx_blocks.get("filter_local", ""), strip_names=qx_strip_names)
 
         def _qx_section(key: str, header: str) -> str:
             content = qx_blocks.get(key, "")

--- a/Quantumult/Sample.conf
+++ b/Quantumult/Sample.conf
@@ -568,123 +568,123 @@ doh-server = /*.he.net/https://ordns.he.net/dns-query
 
 [policy]
 # Proxy
-static=🔰 Proxy, 🇭🇰 Hong Kong, 🇨🇳 Taiwan, 🇸🇬 Singapore, 🇯🇵 Japan, 🇺🇸 America, 🇺🇳 Server, direct, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Direct.png
+static=Proxy, Hong Kong, Taiwan, Singapore, Japan, America, Server, direct, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Direct.png
 # Streaming Global
-static=🎬 Streaming, 🇭🇰 Hong Kong, 🇨🇳 Taiwan, 🇸🇬 Singapore, 🇯🇵 Japan, 🇺🇸 America, 🇺🇳 Server, 🔰 Proxy, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Streaming.png
+static=Streaming, Hong Kong, Taiwan, Singapore, Japan, America, Server, Proxy, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Streaming.png
 # CNTV APAC
-static=📺 CNTV, direct, 🇨🇳 Taiwan, 🇭🇰 Hong Kong, img-url=https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Images/StreamingCN.png
+static=CNTV, direct, Taiwan, Hong Kong, img-url=https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Images/StreamingCN.png
 # Apple
 # > Apple TV
-static=🍏 Apple TV, direct, 🔰 Proxy, 🇺🇸 America, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Apple_2.png
+static=Apple TV, direct, Proxy, America, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Apple_2.png
 # > Apple Services
-static=🍎 Apple, direct, 🔰 Proxy, 🇺🇸 America, 🇯🇵 Japan, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Apple.png
+static=Apple, direct, Proxy, America, Japan, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Apple.png
 # Google
-static=🔍 Google, 🇺🇸 America, 🔰 Proxy, img-url=https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Images/Color/Google.png
+static=Google, America, Proxy, img-url=https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Images/Color/Google.png
 # AIGC
-static=🤖 AIGC, 🇺🇸 America, 🇸🇬 Singapore, 🔰 Proxy, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/ChatGPT.png
+static=AIGC, America, Singapore, Proxy, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/ChatGPT.png
 # Crypto
-static=🪙 Crypto, 🇺🇸 America, 🔰 Proxy, direct, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Cryptocurrency_3.png
+static=Crypto, America, Proxy, direct, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Cryptocurrency_3.png
 # Finance
-static=💳 Credit, 🇺🇸 America, 🔰 Proxy, direct, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/PayPal.png
+static=Credit, America, Proxy, direct, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/PayPal.png
 # Telegram
-static=📬 Telegram, 🔰 Proxy, 🇸🇬 Singapore, direct, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Telegram.png
+static=Telegram, Proxy, Singapore, direct, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Telegram.png
 # Mail
-static=📧 Mail, 🔰 Proxy, direct, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Mail.png
+static=Mail, Proxy, direct, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Mail.png
 # AdGuard
-static=🚧 AdGuard, reject, direct, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Clubhouse_2.png
-url-latency-benchmark=🇭🇰 Hong Kong, server-tag-regex=🇭🇰|HK|Hong Kong|香港, check-url=http://cp.cloudflare.com/generate_204, tolerance=100, alive-checking=false, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Hong_Kong.png
-url-latency-benchmark=🇨🇳 Taiwan, server-tag-regex=🇨🇳|🇹🇼|TW|Taiwan|台湾, check-url=http://cp.cloudflare.com/generate_204, tolerance=100, alive-checking=false, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Taiwan.png
-url-latency-benchmark=🇸🇬 Singapore, server-tag-regex=🇸🇬|SG|Singapore|新加坡, check-url=http://cp.cloudflare.com/generate_204, tolerance=100, alive-checking=false, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Singapore.png
-url-latency-benchmark=🇯🇵 Japan, server-tag-regex=🇯🇵|JP|Japan|日本, check-url=http://cp.cloudflare.com/generate_204, tolerance=100, alive-checking=false, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Japan.png
-url-latency-benchmark=🇺🇸 America, server-tag-regex=🇺🇸|US|United States|美国, check-url=http://cp.cloudflare.com/generate_204, tolerance=100, alive-checking=false, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/United_States.png
+static=AdGuard, reject, direct, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Clubhouse_2.png
+static=Hong Kong, server-tag-regex=🇭🇰|HK|Hong Kong|香港, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Hong_Kong.png
+static=Taiwan, server-tag-regex=🇨🇳|🇹🇼|TW|Taiwan|台湾, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Taiwan.png
+static=Singapore, server-tag-regex=🇸🇬|SG|Singapore|新加坡, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Singapore.png
+static=Japan, server-tag-regex=🇯🇵|JP|Japan|日本, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Japan.png
+static=America, server-tag-regex=🇺🇸|US|United States|美国, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/United_States.png
 
 [server_remote]
 https://sub.hotkids.me#udp=1&tfo=1&emoji=2, tag=Sub, img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Airport.png, update-interval=86400, opt-parser=true, enabled=true
 
 [filter_remote]
 ;Advertising 广告
-https://raw.githubusercontent.com/blackmatrix7/ios_rule_script/refs/master/rule/QuantumultX/Advertising/Advertising.list, tag=Advertising+, force-policy=🚧 AdGuard, update-interval=86400, opt-parser=false, enabled=true
+https://raw.githubusercontent.com/blackmatrix7/ios_rule_script/refs/master/rule/QuantumultX/Advertising/Advertising.list, tag=Advertising+, force-policy=AdGuard, update-interval=86400, opt-parser=false, enabled=true
 
 ;Streaming CN 大陆流媒体（面向港台东南亚版本）
 ;Bilibili
-https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/Bilibili.list, tag=Bilibili, force-policy=📺 CNTV, update-interval=86400, opt-parser=false, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/Bilibili.list, tag=Bilibili, force-policy=CNTV, update-interval=86400, opt-parser=false, enabled=true
 ;iQIYI Intl
-https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/IQ.list, tag=iQIYI Intl, force-policy=📺 CNTV, update-interval=86400, opt-parser=false, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/IQ.list, tag=iQIYI Intl, force-policy=CNTV, update-interval=86400, opt-parser=false, enabled=true
 ;WeTV
-https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/WeTV.list, tag=WeTV, force-policy=📺 CNTV, update-interval=86400, opt-parser=false, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/WeTV.list, tag=WeTV, force-policy=CNTV, update-interval=86400, opt-parser=false, enabled=true
 
 ;Streaming Intl. 海外流媒体
 ;Disney+
-https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/Disney+.list, tag=Disney+, force-policy=🎬 Streaming, update-interval=86400, opt-parser=false, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/Disney+.list, tag=Disney+, force-policy=Streaming, update-interval=86400, opt-parser=false, enabled=true
 ;HBO Max
-https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/HBO%20Max.list, tag=HBO Max, force-policy=🎬 Streaming, update-interval=86400, opt-parser=false, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/HBO%20Max.list, tag=HBO Max, force-policy=Streaming, update-interval=86400, opt-parser=false, enabled=true
 ;Netflix
-https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/Netflix.list, tag=Netflix, force-policy=🎬 Streaming, update-interval=86400, opt-parser=false, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/Netflix.list, tag=Netflix, force-policy=Streaming, update-interval=86400, opt-parser=false, enabled=true
 ;Streaming
-https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/Streaming.list, tag=Streaming, force-policy=🎬 Streaming, update-interval=86400, opt-parser=false, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/Streaming.list, tag=Streaming, force-policy=Streaming, update-interval=86400, opt-parser=false, enabled=true
 
 ;Extra 特殊代理服务
 ;Apple TV
-https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/Apple%20TV.list, tag=Apple TV, force-policy=🍏 Apple TV, update-interval=86400, opt-parser=false, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/Apple%20TV.list, tag=Apple TV, force-policy=Apple TV, update-interval=86400, opt-parser=false, enabled=true
 ;Apple
-https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/Apple.list, tag=Apple, force-policy=🍎 Apple, update-interval=86400, opt-parser=false, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/Apple.list, tag=Apple, force-policy=Apple, update-interval=86400, opt-parser=false, enabled=true
 ;GenAI（补充规则）
-https://raw.githubusercontent.com/ConnersHua/RuleGo/master/Surge/Ruleset/Extra/AI.list, tag=GenAI+, force-policy=🤖 AIGC, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/ConnersHua/RuleGo/master/Surge/Ruleset/Extra/AI.list, tag=GenAI+, force-policy=AIGC, update-interval=86400, opt-parser=true, enabled=true
 
 # Unbreak 后续规则修正
-https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Unbreak.list, tag=Unbreak, force-policy=🔘 DIRECT, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Unbreak.list, tag=Unbreak, force-policy=direct, update-interval=86400, opt-parser=true, enabled=true
 # HTTPDNS 请求/流量阻止
-https://raw.githubusercontent.com/VirgilClyne/GetSomeFries/main/ruleset/HTTPDNS.Block.list, tag=HTTPDNS, force-policy=🚧 AdGuard, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/VirgilClyne/GetSomeFries/main/ruleset/HTTPDNS.Block.list, tag=HTTPDNS, force-policy=AdGuard, update-interval=86400, opt-parser=true, enabled=true
 # Advertising 广告
-https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/reject.txt, tag=Adblock, force-policy=🚧 AdGuard, update-interval=86400, opt-parser=true, enabled=true
-https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/AD.list, tag=Advertising, force-policy=🚧 AdGuard, update-interval=86400, opt-parser=true, enabled=true
-https://raw.githubusercontent.com/ConnersHua/RuleGo/master/Surge/Ruleset/Extra/Reject/Advertising.list, tag=Advertising, force-policy=🚧 AdGuard, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/reject.txt, tag=Adblock, force-policy=AdGuard, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/AD.list, tag=Advertising, force-policy=AdGuard, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/ConnersHua/RuleGo/master/Surge/Ruleset/Extra/Reject/Advertising.list, tag=Advertising, force-policy=AdGuard, update-interval=86400, opt-parser=true, enabled=true
 # Privacy 隐私
-https://raw.githubusercontent.com/ConnersHua/RuleGo/master/Surge/Ruleset/Extra/Reject/Tracking.list, tag=Tracking, force-policy=🚧 AdGuard, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/ConnersHua/RuleGo/master/Surge/Ruleset/Extra/Reject/Tracking.list, tag=Tracking, force-policy=AdGuard, update-interval=86400, opt-parser=true, enabled=true
 # Hijacking 运营商劫持或恶意网站
-https://raw.githubusercontent.com/ConnersHua/RuleGo/master/Surge/Ruleset/Extra/Reject/Malicious.list, tag=Malicious, force-policy=🚧 AdGuard, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/ConnersHua/RuleGo/master/Surge/Ruleset/Extra/Reject/Malicious.list, tag=Malicious, force-policy=AdGuard, update-interval=86400, opt-parser=true, enabled=true
 # # Global Area Network
 # > 一些无需验证地区的分流 HOST
-https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Streaming+.list, tag=Streaming+, force-policy=🔰 Proxy, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Streaming+.list, tag=Streaming+, force-policy=Proxy, update-interval=86400, opt-parser=true, enabled=true
 # > Streaming by Region
 # >> Streaming TW
-https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Streaming_TW.list, tag=Streaming_TW, force-policy=🇨🇳 Taiwan, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Streaming_TW.list, tag=Streaming_TW, force-policy=Taiwan, update-interval=86400, opt-parser=true, enabled=true
 # >> Streaming JP
-https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Streaming_JP.list, tag=Streaming_JP, force-policy=🇯🇵 Japan, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Streaming_JP.list, tag=Streaming_JP, force-policy=Japan, update-interval=86400, opt-parser=true, enabled=true
 # >> Streaming US
-https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Streaming_US.list, tag=Streaming_US, force-policy=🇺🇸 America, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Streaming_US.list, tag=Streaming_US, force-policy=America, update-interval=86400, opt-parser=true, enabled=true
 # > Streaming
-https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Streaming.list, tag=Streaming, force-policy=🎬 Streaming, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Streaming.list, tag=Streaming, force-policy=Streaming, update-interval=86400, opt-parser=true, enabled=true
 # > CNTV（适用于 iQIYI Intl,WeTV,Bilibili 等大陆在港台东南亚提供服务的流媒体服务）
-https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/CNTV.list, tag=CNTV, force-policy=📺 CNTV, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/CNTV.list, tag=CNTV, force-policy=CNTV, update-interval=86400, opt-parser=true, enabled=true
 # Global 全球代理规则
 # > AIGC
-https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Gemini.list, tag=Google, force-policy=🔍 Google, update-interval=86400, opt-parser=true, enabled=true
-https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/GenAI.list, tag=AIGC, force-policy=🤖 AIGC, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Gemini.list, tag=Google, force-policy=Google, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/GenAI.list, tag=AIGC, force-policy=AIGC, update-interval=86400, opt-parser=true, enabled=true
 # > Apple
 # >> Apple TV
-https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Apple/Apple%20TV.list, tag=Apple TV, force-policy=🍏 Apple TV, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Apple/Apple%20TV.list, tag=Apple TV, force-policy=Apple TV, update-interval=86400, opt-parser=true, enabled=true
 # >> Apple Services
-https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Apple/Apple%20CN.list, tag=Apple CN, force-policy=🔘 DIRECT, update-interval=86400, opt-parser=true, enabled=true
-https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Apple/Apple.list, tag=Apple, force-policy=🍎 Apple, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Apple/Apple%20CN.list, tag=Apple CN, force-policy=direct, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Apple/Apple.list, tag=Apple, force-policy=Apple, update-interval=86400, opt-parser=true, enabled=true
 # > Crypto
-https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Crypto.list, tag=Crypto, force-policy=🪙 Crypto, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Crypto.list, tag=Crypto, force-policy=Crypto, update-interval=86400, opt-parser=true, enabled=true
 # > Google
-https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Google.list, tag=Google, force-policy=🔍 Google, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Google.list, tag=Google, force-policy=Google, update-interval=86400, opt-parser=true, enabled=true
 # > Finance
-https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Credit.list, tag=Credit, force-policy=💳 Credit, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Credit.list, tag=Credit, force-policy=Credit, update-interval=86400, opt-parser=true, enabled=true
 # > PayPal
-https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/PayPal.list, tag=PayPal, force-policy=💳 Credit, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/PayPal.list, tag=PayPal, force-policy=Credit, update-interval=86400, opt-parser=true, enabled=true
 # > Telegram
-https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Telegram.list, tag=Telegram, force-policy=📬 Telegram, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Telegram.list, tag=Telegram, force-policy=Telegram, update-interval=86400, opt-parser=true, enabled=true
 # > Mail
-https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Spark.list, tag=Spark, force-policy=📧 Mail, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Spark.list, tag=Spark, force-policy=Mail, update-interval=86400, opt-parser=true, enabled=true
 # Global (DNS Cache Pollution) / (IP Blackhole) / (Region-Restricted Access Denied) / (Network Jitter)
-https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/proxy.txt, tag=Global, force-policy=🔰 Proxy, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/proxy.txt, tag=Global, force-policy=Proxy, update-interval=86400, opt-parser=true, enabled=true
 # China Area Network
-https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/direct.txt, tag=China, force-policy=🔘 DIRECT, update-interval=86400, opt-parser=true, enabled=true
-https://raw.githubusercontent.com/VirgilClyne/GetSomeFries/main/ruleset/ASN.China.list, tag=ASN China, force-policy=🔘 DIRECT, update-interval=86400, opt-parser=true, enabled=true
-https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/cncidr.txt, tag=CNCIDR, force-policy=🔘 DIRECT, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/direct.txt, tag=China, force-policy=direct, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/VirgilClyne/GetSomeFries/main/ruleset/ASN.China.list, tag=ASN China, force-policy=direct, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/cncidr.txt, tag=CNCIDR, force-policy=direct, update-interval=86400, opt-parser=true, enabled=true
 
 [rewrite_remote]
 ;引用自脚本作者
@@ -760,7 +760,7 @@ ip-cidr, 224.0.0.0/24, direct
 ;GeoIP China（Surge GEOIP,CN 已注释，此处保持静态）
 geoip, cn, direct
 
-final, 🔰 Proxy
+final, Proxy
 
 [rewrite_local]
 


### PR DESCRIPTION
- smart groups (area groups) now emit `static=Name, server-tag-regex=regex` instead of `url-latency-benchmark`, matching QX static policy format
- add emoji toggle (default off): strips emoji from all policy names in [policy], [filter_remote] force-policy, and [filter_local] final
- _QX_PROXY_MAP applied before strip in filter_remote/filter_local so 🔘 DIRECT → direct (lowercase QX builtin), not DIRECT
- add _qx_strip_emoji_text() helper for static qx.ini content blocks
- add # > Options section parser in parse_sync_txt() for emoji = true/false

https://claude.ai/code/session_012BQ6sdfyuSqVqJYdsLgJYL