### PR TITLE
fix: correct Loon section order and remove dead Options parser

### DIFF
--- a/.github/scripts/sync-config.py
+++ b/.github/scripts/sync-config.py
@@ -769,8 +769,6 @@ def parse_sync_txt() -> dict:
             left, right = left.strip(), right.strip()
             if left:
                 result.setdefault(current_platform, _empty_plat())["filter_map"][left] = right
-        elif current_section == "Options" and current_platform and current_platform != "Surge":
-            pass  # reserved for future options
 
     flush_builtin()
     return result
@@ -2170,9 +2168,10 @@ def main() -> None:
         surge_mitm_block = "\n".join(surge_mitm_lines).strip()
 
         loon_proxy_section = _gen_loon_proxy_section(proxy_lines)
-        loon_parts = [loon_header, pg_loon]
+        loon_parts = [loon_header]
         if loon_proxy_section:
             loon_parts.append(loon_proxy_section)
+        loon_parts.append(pg_loon)
         if rule_section:
             loon_parts.append(rule_section)
         loon_parts.append(remote_rules)

--- a/Surge/Balloon.lcf
+++ b/Surge/Balloon.lcf
@@ -58,6 +58,10 @@ Sub-JP = NameRegex, FilterKey = "^(?=.*(?i)(🇯🇵|日本|\b(JP|Japan)\d*\b))(
 Sub-US = NameRegex, FilterKey = "^(?=.*(?i)(🇺🇸|美国|\b(US|United States)\d*\b))(?!.*(?i)\b(USE(D)?|TOTAL|EXPIRE|RESET|Panel|Premium)\b|\d{4}-\d{2}-\d{2}|\d+(\.\d+)?\s*G).*"
 Sub-UN = NameRegex, FilterKey = "^(?=.+)(?!.*(?i)\b(USE(D)?|TOTAL|EXPIRE|RESET|Panel|Premium|DIRECT|REJECT)\b|\d{4}-\d{2}-\d{2}|\d+(\.\d+)?\s*G).*"
 
+[Proxy]
+⛔️ REJECT = REJECT
+🔘 DIRECT = DIRECT
+
 [Proxy Group]
 # Proxy
 🔰 Proxy = select,🇭🇰 Hong Kong,🇨🇳 Taiwan,🇸🇬 Singapore,🇯🇵 Japan,🇺🇸 America,🇺🇳 Server,🔘 DIRECT,img-url = https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Images/Color/Outbound.png
@@ -92,10 +96,6 @@ Sub-UN = NameRegex, FilterKey = "^(?=.+)(?!.*(?i)\b(USE(D)?|TOTAL|EXPIRE|RESET|P
 🇸🇬 Singapore = url-test,Sub-SG,img-url = https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Singapore.png
 🇯🇵 Japan = url-test,Sub-JP,img-url = https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Japan.png
 🇺🇸 America = url-test,Sub-US,img-url = https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/United_States.png
-
-[Proxy]
-⛔️ REJECT = REJECT
-🔘 DIRECT = DIRECT
 
 [Rule]
 # Local Rule


### PR DESCRIPTION
- Balloon.lcf: [Proxy] now appears before [Proxy Group] (standard Loon config order); action proxies (REJECT/DIRECT) are defined before the proxy groups that reference them
- sync-config.py: remove dead `Options` section parser block left over from emoji option removal

https://claude.ai/code/session_012BQ6sdfyuSqVqJYdsLgJYL