### PR TITLE
feat: add notify parameter & fix mask_ip toggle bug

### DIFF
--- a/Surge/Module/Pannel/ip-security-panel.sgmodule
+++ b/Surge/Module/Pannel/ip-security-panel.sgmodule
@@ -2,8 +2,8 @@
 #!desc=显示 IP 风险评分、类型、DNS 泄露检测、代理策略和本地/入口/出口 IP 地理信息，支持网络变化自动通知
 #!author=HotKids&ChatGPT&Claude
 #!system=ios
-#!arguments=ipqs_key:null,risk_api:null,local_geoapi:bilibili,remote_geoapi:ipinfo,mask_ip:0,tw_flag:cn,event_delay:2
-#!arguments-desc=ipqs_key:(可选) IPQualityScore API Key，仅 risk_api=ipqs 或回落模式需要\nrisk_api:(可选) 风险评分数据源，ipqs / proxycheck / ippure / scamalytics，不填则四级回落（IPQS → ProxyCheck → IPPure → Scamalytics）\nlocal_geoapi:(可选) 本地 IP 地理数据源，bilibili=bilibili(中文，默认)，ipsb=ip.sb(英文)\nremote_geoapi:(可选) 入口/出口地区数据源（仅影响地区，运营商始终用 ipinfo.io），ipinfo=ipinfo.io(默认)，ipapi=ip-api.com(英文)，ipapi-zh=ip-api.com(中文)\nmask_ip:(可选) IP 打码，1=开启（123.*.*.89），0=关闭，默认 0\ntw_flag:(可选) 台湾地区旗帜，cn=🇨🇳(默认)，tw=🇹🇼\nevent_delay:(可选) 网络变化后延迟检测时间（秒），默认 2 秒
+#!arguments=ipqs_key:null,risk_api:null,local_geoapi:bilibili,remote_geoapi:ipinfo,mask_ip:0,tw_flag:cn,event_delay:2,notify:true
+#!arguments-desc=ipqs_key:(可选) IPQualityScore API Key，仅 risk_api=ipqs 或回落模式需要\nrisk_api:(可选) 风险评分数据源，ipqs / proxycheck / ippure / scamalytics，不填则四级回落（IPQS → ProxyCheck → IPPure → Scamalytics）\nlocal_geoapi:(可选) 本地 IP 地理数据源，bilibili=bilibili(中文，默认)，ipsb=ip.sb(英文)\nremote_geoapi:(可选) 入口/出口地区数据源（仅影响地区，运营商始终用 ipinfo.io），ipinfo=ipinfo.io(默认)，ipapi=ip-api.com(英文)，ipapi-zh=ip-api.com(中文)\nmask_ip:(可选) IP 打码，1=开启（123.*.*.89），0=关闭，默认 0\ntw_flag:(可选) 台湾地区旗帜，cn=🇨🇳(默认)，tw=🇹🇼\nevent_delay:(可选) 网络变化后延迟检测时间（秒），默认 2 秒\nnotify:(可选) 网络变化时是否推送通知，true=推送(默认)，false=不推送
 
 [Panel]
 ip-security-panel = script-name=ip-security-panel,update-interval=600
@@ -13,4 +13,4 @@ ip-security-panel = script-name=ip-security-panel,update-interval=600
 ip-security-panel = type=generic,timeout=15,script-path=https://raw.githubusercontent.com/HotKids/Rules/master/Surge/Module/Scripts/ip-security.js,argument=ipqs_key={{{ipqs_key}}}&risk_api={{{risk_api}}}&local_geoapi={{{local_geoapi}}}&remote_geoapi={{{remote_geoapi}}}&mask_ip={{{mask_ip}}}&tw_flag={{{tw_flag}}}
 
 # 网络变化自动触发
-ip-security-event = type=event,event-name=network-changed,timeout=15,script-path=https://raw.githubusercontent.com/HotKids/Rules/master/Surge/Module/Scripts/ip-security.js,argument=TYPE=EVENT&ipqs_key={{{ipqs_key}}}&risk_api={{{risk_api}}}&local_geoapi={{{local_geoapi}}}&remote_geoapi={{{remote_geoapi}}}&mask_ip={{{mask_ip}}}&tw_flag={{{tw_flag}}}&event_delay={{{event_delay}}}
+ip-security-event = type=event,event-name=network-changed,timeout=15,script-path=https://raw.githubusercontent.com/HotKids/Rules/master/Surge/Module/Scripts/ip-security.js,argument=TYPE=EVENT&ipqs_key={{{ipqs_key}}}&risk_api={{{risk_api}}}&local_geoapi={{{local_geoapi}}}&remote_geoapi={{{remote_geoapi}}}&mask_ip={{{mask_ip}}}&tw_flag={{{tw_flag}}}&event_delay={{{event_delay}}}&notify={{{notify}}}

--- a/Surge/Module/Scripts/ip-security.js
+++ b/Surge/Module/Scripts/ip-security.js
@@ -29,6 +29,7 @@
  * - mask_ip: IP 打码，0=关闭，1=部分打码，2=全部隐藏 [IP 已隐藏]，默认 0
  * - tw_flag: 台湾地区旗帜，cn(默认)=🇨🇳，tw=🇹🇼
  * - event_delay: 网络变化后延迟检测（秒），默认 2 秒
+ * - notify: 网络变化时是否推送通知，true(默认)=推送，false=不推送
  *
  * 配置示例：
  * [Panel]
@@ -39,7 +40,7 @@
  * ip-security-panel = type=generic,timeout=10,script-path=ip-security.js,argument=ipqs_key=YOUR_API_KEY
  *
  * # 网络变化自动触发
- * ip-security-event = type=event,event-name=network-changed,timeout=10,script-path=ip-security.js,argument=TYPE=EVENT&ipqs_key=YOUR_API_KEY&event_delay=2
+ * ip-security-event = type=event,event-name=network-changed,timeout=10,script-path=ip-security.js,argument=TYPE=EVENT&ipqs_key=YOUR_API_KEY&event_delay=2&notify=true
  *
  * @author HotKids&Claude
  * @version 6.0.0
@@ -114,6 +115,10 @@ function parseArguments() {
 
   console.log("参数解析: risk_api=" + JSON.stringify(arg.risk_api) + " ipqs_key=" + (arg.ipqs_key ? "已设置" : "未设置"));
 
+  // notify 参数：默认 true，仅当明确设为 "false" 时关闭通知
+  const notifyVal = clean(arg.notify).toLowerCase();
+  const notify = notifyVal !== "false";
+
   return {
     isEvent: arg.TYPE === "EVENT",
     ipqsKey: clean(arg.ipqs_key),
@@ -122,12 +127,13 @@ function parseArguments() {
     remoteGeoApi: clean(arg.remote_geoapi) || "ipinfo",
     maskIP: arg.mask_ip === "2" ? 2 : (arg.mask_ip === "1" || arg.mask_ip === "true") ? 1 : 0,
     twFlag: clean(arg.tw_flag) || "cn",
-    eventDelay: parseFloat(arg.event_delay) || 2
+    eventDelay: parseFloat(arg.event_delay) || 2,
+    notify: notify
   };
 }
 
 const args = parseArguments();
-console.log("触发类型: " + (args.isEvent ? "EVENT" : "MANUAL") + ", risk_api: " + (args.riskApi || "fallback") + ", 本地: " + args.localGeoApi);
+console.log("触发类型: " + (args.isEvent ? "EVENT" : "MANUAL") + ", risk_api: " + (args.riskApi || "fallback") + ", 本地: " + args.localGeoApi + ", 通知: " + args.notify);
 
 // ==================== 全局状态控制 ====================
 let finished = false;
@@ -602,6 +608,11 @@ function buildPanelContent({ useBilibili, maskMode, riskInfo, riskResult, ipType
 
 // ==================== 通知内容构建 ====================
 function sendNetworkChangeNotification({ useBilibili, policy, localIP, outIP, entranceIP, localInfo, entranceInfo, outInfo, riskInfo, riskResult, ipType, ipSrc, maskMode, dnsLeak }) {
+  if (!args.notify) {
+    console.log("通知已禁用 (notify=false)，跳过推送");
+    return;
+  }
+
   const m = (ip) => maskIP(ip, maskMode);
   const title = "🔄 网络已切换 | " + policy;
   const subtitle = "Ⓓ " + m(localIP) + " 🅟 " + m(outIP);
@@ -740,7 +751,7 @@ function sendNetworkChangeNotification({ useBilibili, policy, localIP, outIP, en
     const remainder = elapsed % interval;
     const isAutoRefresh = lastRun > 0 && elapsed > tolerance
       && (remainder <= tolerance || remainder >= interval - tolerance);
-    if (!isAutoRefresh) {
+    if (lastRun > 0 && !isAutoRefresh) {
       maskMode = maskMode === 1 ? 0 : 1;
       $persistentStore.write(String(maskMode), CONFIG.storeKeys.maskToggle);
     }


### PR DESCRIPTION
## Summary
- Add `notify` parameter (default `true`) to allow users to disable push notifications on network changes
- Fix `mask_ip` toggling when kept at default

## Changes
### ip-security-panel.sgmodule
- Add `notify:true` to `#!arguments`
- Add notify parameter description to `#!arguments-desc`
- Pass `notify` parameter in event script argument

### ip-security.js
- Parse `notify` parameter in `parseArguments()`, default true, disable notifications when set to false
- Skip `$notification.post()` in `sendNetworkChangeNotification()` when `notify` is false
- Fix `mask_ip` toggle logic: add `lastRun > 0` check to prevent unintended toggling on first run