### PR TITLE
claude/review-error-handling-M5ZUw

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -48,7 +48,7 @@
 ### 各平台跳过 / 转换
 
 **Clash**
-- 规则类型重命名：`DEST-PORT` → `DST-PORT`，`PROTOCOL,TCP/UDP` → `NETWORK,tcp/udp`
+- 规则类型重命名：`DEST-PORT` → `DST-PORT`，`PROTOCOL,TCP/UDP` → `NETWORK,TCP/UDP`
 - 跳过：`URL-REGEX`、`USER-AGENT`、`PROTOCOL,QUIC`（无等价）
 
 **Loon**

--- a/.github/scripts/sync-config.py
+++ b/.github/scripts/sync-config.py
@@ -47,14 +47,14 @@ _CLASH_SUPPORTED_ACTIONS = frozenset({"direct", "reject"})
 # Surge → Clash 规则类型重命名（含 AND 子规则）
 _CLASH_TYPE_RENAMES = {"DEST-PORT": "DST-PORT", "PROTOCOL": "NETWORK"}
 # Surge PROTOCOL 值 → Clash NETWORK 值（不支持的值 → 跳过该规则）
-_SURGE_PROTOCOL_TO_NETWORK = {"TCP": "tcp", "UDP": "udp"}
+_SURGE_PROTOCOL_TO_NETWORK = {"TCP": "TCP", "UDP": "UDP"}
 
 
 def _convert_and_clash(s: str) -> str | None:
     """将 Surge AND rule 字符串转换为 Clash 格式，返回 None 表示无法转换（应跳过）。
 
     子规则类型按 _CLASH_TYPE_RENAMES 重命名；PROTOCOL 值按 _SURGE_PROTOCOL_TO_NETWORK
-    映射为小写（QUIC 等无对应值时返回 None）。
+    映射为大写（QUIC 等无对应值时返回 None）。
     """
     def convert_sub(m: re.Match) -> str:
         t, v = m.group(1).upper(), m.group(2)

--- a/Clash/RuleSet/AD.yaml
+++ b/Clash/RuleSet/AD.yaml
@@ -2,13 +2,11 @@ payload:
   # > 广告联盟
   - DOMAIN,i.snssdk.com
   - DOMAIN,is.snssdk.com
-  - DOMAIN,mi.gdt.qq.com
   - DOMAIN,open.e.kuaishou.com
   - DOMAIN-SUFFIX,miaozhen.com
   - DOMAIN-KEYWORD,adservice
   - DOMAIN-KEYWORD,pglstatp-toutiao
   - DOMAIN-KEYWORD,pangolin-sdk-toutiao
-  - DOMAIN-KEYWORD,pangolin.snssdk.com
   - DOMAIN-KEYWORD,pangolin.snssdk.com
   - DOMAIN-KEYWORD,video-cn.snssdk.com
 
@@ -51,7 +49,6 @@ payload:
   - DOMAIN,lc.map.baidu.com
   - DOMAIN,mobads-logs.baidu.com
   - DOMAIN,mobads.baidu.com
-  - DOMAIN,wn.pos.baidu.com
   - DOMAIN-SUFFIX,pos.baidu.com
   - DOMAIN-SUFFIX,union.baidu.cn
   - DOMAIN-SUFFIX,union.baidu.com
@@ -88,7 +85,6 @@ payload:
   - DOMAIN,pagead2.googlesyndication.com
   - DOMAIN,pubads.g.doubleclick.net
   - DOMAIN,www.googleadservices.com
-  - DOMAIN-KEYWORD,adservice.google.com.
 
   # > HeyTap(OPPO)
   - DOMAIN,event.dc.oppomobile.com
@@ -116,7 +112,6 @@ payload:
   - IP-CIDR6,2402:db40:5100:1011::5/128
 
   # > Keep
-  - DOMAIN,httpdns.n.netease.com
   - DOMAIN,httpdns.calorietech.com
   - DOMAIN,hc-ssp.sm.cn
 
@@ -181,14 +176,10 @@ payload:
   - DOMAIN,info4.video.qq.com
   - DOMAIN,info6.video.qq.com
   - DOMAIN,ios.video.mpush.qq.com
-  - DOMAIN,gdt.qq.com
   - DOMAIN,mtrace.qq.com
   - DOMAIN,monitor.music.qq.com
-  - DOMAIN,otheve.beacon.qq.com
   - DOMAIN,p.l.qq.com
   - DOMAIN,pgdt.gtimg.cn
-  - DOMAIN,rpt.gdt.qq.com
-  - DOMAIN,tytx.m.cn.miaozhen.com
   - DOMAIN,wxsmsdy.video.qq.com
   - DOMAIN,wxsnsdy.wxs.qq.com
   - DOMAIN,wxsnsdythumb.wxs.qq.com
@@ -217,17 +208,10 @@ payload:
   - DOMAIN,r2---sn-j5o76n7e.gvt1.com
 
   # > WeChat
-  - DOMAIN,wxsnsdy.wxs.qq.com
-  - DOMAIN,wxsnsdythumb.wxs.qq.com
   - DOMAIN,badjs.weixinbridge.com
 
   # > Weibo
   - DOMAIN,huodong.weibo.cn
-  - DOMAIN,adstrategy.biz.weibo.com
-  - DOMAIN,kadmimage.biz.weibo.com
-  - DOMAIN,sdkaction.biz.weibo.com
-  - DOMAIN,sdkclick.biz.weibo.com
-  - DOMAIN,sdkmonitor.biz.weibo.com
   - DOMAIN-SUFFIX,biz.weibo.com
   - IP-CIDR,39.97.130.51/32
   - IP-CIDR,39.97.128.148/32

--- a/Clash/RuleSet/BBC.yaml
+++ b/Clash/RuleSet/BBC.yaml
@@ -1,12 +1,9 @@
 payload:
   # > BBC iPlayer
   - DOMAIN-KEYWORD,bbcfmt
-  - DOMAIN-KEYWORD,co.uk
   - DOMAIN-KEYWORD,uk-live
   - DOMAIN-SUFFIX,bbc.com
-  - DOMAIN-SUFFIX,bbc.co
   - DOMAIN-SUFFIX,bbc.co.uk
-  - DOMAIN-SUFFIX,bbci.co
   - DOMAIN-SUFFIX,bbci.co.uk
   - DOMAIN,ssl-bbcsmarttv.2cnt.net
   - DOMAIN,vod-dash-uk-live.akamaized.net

--- a/Clash/RuleSet/Google Play.yaml
+++ b/Clash/RuleSet/Google Play.yaml
@@ -14,6 +14,5 @@ payload:
   - DOMAIN,play-lh.googleusercontent.com
   - DOMAIN-KEYWORD,play.google
   - DOMAIN-WILDCARD,*play*.google.com
-  - DOMAIN-WILDCARD,*play*.google.com
   - DOMAIN-WILDCARD,*play*.googleapis.com
   - DOMAIN-WILDCARD,*play*.googleusercontent.com

--- a/Clash/RuleSet/Streaming.yaml
+++ b/Clash/RuleSet/Streaming.yaml
@@ -37,12 +37,9 @@ payload:
 
   # > BBC iPlayer
   - DOMAIN-KEYWORD,bbcfmt
-  - DOMAIN-KEYWORD,co.uk
   - DOMAIN-KEYWORD,uk-live
   - DOMAIN-SUFFIX,bbc.com
-  - DOMAIN-SUFFIX,bbc.co
   - DOMAIN-SUFFIX,bbc.co.uk
-  - DOMAIN-SUFFIX,bbci.co
   - DOMAIN-SUFFIX,bbci.co.uk
   - DOMAIN,ssl-bbcsmarttv.2cnt.net
   - DOMAIN,vod-dash-uk-live.akamaized.net

--- a/Clash/Sample.yaml
+++ b/Clash/Sample.yaml
@@ -597,7 +597,7 @@ rule-providers:
 # 规则
 rules:
   # 标准 SSH 端口
-  - AND,((DST-PORT,22),(NETWORK,tcp)),🔘 DIRECT
+  - AND,((DST-PORT,22),(NETWORK,TCP)),🔘 DIRECT
 
   # Unbreak 后续规则修正
   - RULE-SET,Unbreak,🔘 DIRECT

--- a/Quantumult/X/Filter/AD.list
+++ b/Quantumult/X/Filter/AD.list
@@ -1,13 +1,11 @@
 # > 广告联盟
 DOMAIN,i.snssdk.com,AD
 DOMAIN,is.snssdk.com,AD
-DOMAIN,mi.gdt.qq.com,AD
 DOMAIN,open.e.kuaishou.com,AD
 DOMAIN-SUFFIX,miaozhen.com,AD
 DOMAIN-KEYWORD,adservice,AD
 DOMAIN-KEYWORD,pglstatp-toutiao,AD
 DOMAIN-KEYWORD,pangolin-sdk-toutiao,AD
-DOMAIN-KEYWORD,pangolin.snssdk.com,AD
 DOMAIN-KEYWORD,pangolin.snssdk.com,AD
 DOMAIN-KEYWORD,video-cn.snssdk.com,AD
 
@@ -50,7 +48,6 @@ DOMAIN,httpdns.baidubce.com,AD
 DOMAIN,lc.map.baidu.com,AD
 DOMAIN,mobads-logs.baidu.com,AD
 DOMAIN,mobads.baidu.com,AD
-DOMAIN,wn.pos.baidu.com,AD
 DOMAIN-SUFFIX,pos.baidu.com,AD
 DOMAIN-SUFFIX,union.baidu.cn,AD
 DOMAIN-SUFFIX,union.baidu.com,AD
@@ -87,7 +84,6 @@ DOMAIN,googleads.g.doubleclick.net,AD
 DOMAIN,pagead2.googlesyndication.com,AD
 DOMAIN,pubads.g.doubleclick.net,AD
 DOMAIN,www.googleadservices.com,AD
-DOMAIN-KEYWORD,adservice.google.com.,AD
 
 # > HeyTap(OPPO)
 DOMAIN,event.dc.oppomobile.com,AD
@@ -115,7 +111,6 @@ IP-CIDR,101.124.19.122/32,AD
 IP-CIDR6,2402:db40:5100:1011::5/128,AD
 
 # > Keep
-DOMAIN,httpdns.n.netease.com,AD
 DOMAIN,httpdns.calorietech.com,AD
 DOMAIN,hc-ssp.sm.cn,AD
 
@@ -180,14 +175,10 @@ DOMAIN,btrace.video.qq.com,AD
 DOMAIN,info4.video.qq.com,AD
 DOMAIN,info6.video.qq.com,AD
 DOMAIN,ios.video.mpush.qq.com,AD
-DOMAIN,gdt.qq.com,AD
 DOMAIN,mtrace.qq.com,AD
 DOMAIN,monitor.music.qq.com,AD
-DOMAIN,otheve.beacon.qq.com,AD
 DOMAIN,p.l.qq.com,AD
 DOMAIN,pgdt.gtimg.cn,AD
-DOMAIN,rpt.gdt.qq.com,AD
-DOMAIN,tytx.m.cn.miaozhen.com,AD
 DOMAIN,wxsmsdy.video.qq.com,AD
 DOMAIN,wxsnsdy.wxs.qq.com,AD
 DOMAIN,wxsnsdythumb.wxs.qq.com,AD
@@ -216,17 +207,10 @@ DOMAIN-SUFFIX,adcolony.com,AD
 DOMAIN,r2---sn-j5o76n7e.gvt1.com,AD
 
 # > WeChat
-DOMAIN,wxsnsdy.wxs.qq.com,AD
-DOMAIN,wxsnsdythumb.wxs.qq.com,AD
 DOMAIN,badjs.weixinbridge.com,AD
 
 # > Weibo
 DOMAIN,huodong.weibo.cn,AD
-DOMAIN,adstrategy.biz.weibo.com,AD
-DOMAIN,kadmimage.biz.weibo.com,AD
-DOMAIN,sdkaction.biz.weibo.com,AD
-DOMAIN,sdkclick.biz.weibo.com,AD
-DOMAIN,sdkmonitor.biz.weibo.com,AD
 DOMAIN-SUFFIX,biz.weibo.com,AD
 IP-CIDR,39.97.130.51/32,AD
 IP-CIDR,39.97.128.148/32,AD

--- a/Quantumult/X/Filter/BBC.list
+++ b/Quantumult/X/Filter/BBC.list
@@ -1,12 +1,9 @@
 # > BBC iPlayer
 USER-AGENT,BBCiPlayer*,BBC
 DOMAIN-KEYWORD,bbcfmt,BBC
-DOMAIN-KEYWORD,co.uk,BBC
 DOMAIN-KEYWORD,uk-live,BBC
 DOMAIN-SUFFIX,bbc.com,BBC
-DOMAIN-SUFFIX,bbc.co,BBC
 DOMAIN-SUFFIX,bbc.co.uk,BBC
-DOMAIN-SUFFIX,bbci.co,BBC
 DOMAIN-SUFFIX,bbci.co.uk,BBC
 DOMAIN,ssl-bbcsmarttv.2cnt.net,BBC
 DOMAIN,vod-dash-uk-live.akamaized.net,BBC

--- a/Quantumult/X/Filter/Google Play.list
+++ b/Quantumult/X/Filter/Google Play.list
@@ -13,6 +13,5 @@ DOMAIN,playgateway-pa.googleapis.com,Google Play
 DOMAIN,play-lh.googleusercontent.com,Google Play
 DOMAIN-KEYWORD,play.google,Google Play
 DOMAIN-WILDCARD,*play*.google.com,Google Play
-DOMAIN-WILDCARD,*play*.google.com,Google Play
 DOMAIN-WILDCARD,*play*.googleapis.com,Google Play
 DOMAIN-WILDCARD,*play*.googleusercontent.com,Google Play

--- a/Quantumult/X/Filter/Streaming.list
+++ b/Quantumult/X/Filter/Streaming.list
@@ -38,12 +38,9 @@ DOMAIN-KEYWORD,avoddashs,Streaming
 # > BBC iPlayer
 USER-AGENT,BBCiPlayer*,Streaming
 DOMAIN-KEYWORD,bbcfmt,Streaming
-DOMAIN-KEYWORD,co.uk,Streaming
 DOMAIN-KEYWORD,uk-live,Streaming
 DOMAIN-SUFFIX,bbc.com,Streaming
-DOMAIN-SUFFIX,bbc.co,Streaming
 DOMAIN-SUFFIX,bbc.co.uk,Streaming
-DOMAIN-SUFFIX,bbci.co,Streaming
 DOMAIN-SUFFIX,bbci.co.uk,Streaming
 DOMAIN,ssl-bbcsmarttv.2cnt.net,Streaming
 DOMAIN,vod-dash-uk-live.akamaized.net,Streaming

--- a/Surge/RULE-SET/AD.list
+++ b/Surge/RULE-SET/AD.list
@@ -1,13 +1,11 @@
 # > 广告联盟
 DOMAIN,i.snssdk.com
 DOMAIN,is.snssdk.com
-DOMAIN,mi.gdt.qq.com
 DOMAIN,open.e.kuaishou.com
 DOMAIN-SUFFIX,miaozhen.com
 DOMAIN-KEYWORD,adservice
 DOMAIN-KEYWORD,pglstatp-toutiao
 DOMAIN-KEYWORD,pangolin-sdk-toutiao
-DOMAIN-KEYWORD,pangolin.snssdk.com
 DOMAIN-KEYWORD,pangolin.snssdk.com
 DOMAIN-KEYWORD,video-cn.snssdk.com
 
@@ -50,7 +48,6 @@ DOMAIN,httpdns.baidubce.com
 DOMAIN,lc.map.baidu.com
 DOMAIN,mobads-logs.baidu.com
 DOMAIN,mobads.baidu.com
-DOMAIN,wn.pos.baidu.com
 DOMAIN-SUFFIX,pos.baidu.com
 DOMAIN-SUFFIX,union.baidu.cn
 DOMAIN-SUFFIX,union.baidu.com
@@ -87,7 +84,6 @@ DOMAIN,googleads.g.doubleclick.net
 DOMAIN,pagead2.googlesyndication.com
 DOMAIN,pubads.g.doubleclick.net
 DOMAIN,www.googleadservices.com
-DOMAIN-KEYWORD,adservice.google.com.
 
 # > HeyTap(OPPO)
 DOMAIN,event.dc.oppomobile.com
@@ -115,7 +111,6 @@ IP-CIDR,101.124.19.122/32
 IP-CIDR6,2402:db40:5100:1011::5/128
 
 # > Keep
-DOMAIN,httpdns.n.netease.com
 DOMAIN,httpdns.calorietech.com
 DOMAIN,hc-ssp.sm.cn
 
@@ -180,14 +175,10 @@ DOMAIN,btrace.video.qq.com
 DOMAIN,info4.video.qq.com
 DOMAIN,info6.video.qq.com
 DOMAIN,ios.video.mpush.qq.com
-DOMAIN,gdt.qq.com
 DOMAIN,mtrace.qq.com
 DOMAIN,monitor.music.qq.com
-DOMAIN,otheve.beacon.qq.com
 DOMAIN,p.l.qq.com
 DOMAIN,pgdt.gtimg.cn
-DOMAIN,rpt.gdt.qq.com
-DOMAIN,tytx.m.cn.miaozhen.com
 DOMAIN,wxsmsdy.video.qq.com
 DOMAIN,wxsnsdy.wxs.qq.com
 DOMAIN,wxsnsdythumb.wxs.qq.com
@@ -216,17 +207,10 @@ DOMAIN-SUFFIX,adcolony.com
 DOMAIN,r2---sn-j5o76n7e.gvt1.com
 
 # > WeChat
-DOMAIN,wxsnsdy.wxs.qq.com
-DOMAIN,wxsnsdythumb.wxs.qq.com
 DOMAIN,badjs.weixinbridge.com
 
 # > Weibo
 DOMAIN,huodong.weibo.cn
-DOMAIN,adstrategy.biz.weibo.com
-DOMAIN,kadmimage.biz.weibo.com
-DOMAIN,sdkaction.biz.weibo.com
-DOMAIN,sdkclick.biz.weibo.com
-DOMAIN,sdkmonitor.biz.weibo.com
 DOMAIN-SUFFIX,biz.weibo.com
 IP-CIDR,39.97.130.51/32
 IP-CIDR,39.97.128.148/32

--- a/Surge/RULE-SET/BBC.list
+++ b/Surge/RULE-SET/BBC.list
@@ -1,12 +1,9 @@
 # > BBC iPlayer
 USER-AGENT,BBCiPlayer*
 DOMAIN-KEYWORD,bbcfmt
-DOMAIN-KEYWORD,co.uk
 DOMAIN-KEYWORD,uk-live
 DOMAIN-SUFFIX,bbc.com
-DOMAIN-SUFFIX,bbc.co
 DOMAIN-SUFFIX,bbc.co.uk
-DOMAIN-SUFFIX,bbci.co
 DOMAIN-SUFFIX,bbci.co.uk
 DOMAIN,ssl-bbcsmarttv.2cnt.net
 DOMAIN,vod-dash-uk-live.akamaized.net

--- a/Surge/RULE-SET/Google Play.list
+++ b/Surge/RULE-SET/Google Play.list
@@ -13,6 +13,5 @@ DOMAIN,playgateway-pa.googleapis.com
 DOMAIN,play-lh.googleusercontent.com
 DOMAIN-KEYWORD,play.google
 DOMAIN-WILDCARD,*play*.google.com
-DOMAIN-WILDCARD,*play*.google.com
 DOMAIN-WILDCARD,*play*.googleapis.com
 DOMAIN-WILDCARD,*play*.googleusercontent.com

--- a/Surge/RULE-SET/Streaming.list
+++ b/Surge/RULE-SET/Streaming.list
@@ -39,12 +39,9 @@ URL-REGEX,^https?:\/\/www\.amazon\.com\/(Amazon-Video|gp\/video)\/
 # > BBC iPlayer
 USER-AGENT,BBCiPlayer*
 DOMAIN-KEYWORD,bbcfmt
-DOMAIN-KEYWORD,co.uk
 DOMAIN-KEYWORD,uk-live
 DOMAIN-SUFFIX,bbc.com
-DOMAIN-SUFFIX,bbc.co
 DOMAIN-SUFFIX,bbc.co.uk
-DOMAIN-SUFFIX,bbci.co
 DOMAIN-SUFFIX,bbci.co.uk
 DOMAIN,ssl-bbcsmarttv.2cnt.net
 DOMAIN,vod-dash-uk-live.akamaized.net


### PR DESCRIPTION
- AD: remove duplicate DOMAIN-KEYWORD,pangolin.snssdk.com (×2)
- AD: remove duplicate DOMAIN,httpdns.n.netease.com (Keep section, kept in NetEase)
- AD: remove duplicate DOMAIN,wxsnsdy/wxsnsdythumb.wxs.qq.com (WeChat section, kept in Tencent)
- AD: remove DOMAIN-KEYWORD,adservice.google.com. (trailing dot = invalid syntax; redundant to DOMAIN-KEYWORD,adservice)
- AD: remove DOMAIN,mi.gdt.qq.com / gdt.qq.com / otheve.beacon.qq.com / rpt.gdt.qq.com / tytx.m.cn.miaozhen.com covered by DOMAIN-SUFFIX
- AD: remove DOMAIN,wn.pos.baidu.com covered by DOMAIN-SUFFIX,pos.baidu.com
- AD: remove 5× DOMAIN,*.biz.weibo.com covered by DOMAIN-SUFFIX,biz.weibo.com
- Google Play: remove duplicate DOMAIN-WILDCARD,*play*.google.com
- BBC/Streaming: remove DOMAIN-KEYWORD,co.uk (matches any .co.uk; bbc.co.uk covered by SUFFIX rules)
- BBC/Streaming: remove DOMAIN-SUFFIX,bbc.co and DOMAIN-SUFFIX,bbci.co (.co is Colombian TLD, not BBC)

Synced across Clash/Surge/Quantumult X.

https://claude.ai/code/session_014LgUCPtnesXoDAEXo1BVK5