### PR TITLE
feat(clash): add Sample1.yaml — mihomo best-practice review

### DIFF
--- a/Clash/Sample1.yaml
+++ b/Clash/Sample1.yaml
@@ -1,0 +1,738 @@
+# Clash
+# Date: 2026-04-18 01:44:56
+# Author: @HotKids
+
+# 通用设置
+
+# port: 7890 # HTTP(S) 代理服务器端口
+# socks-port: 7891 # SOCKS5 代理端口
+mixed-port: 7893 # HTTP(S) 和 SOCKS 代理混合端口
+# redir-port: 7892 # 透明代理端口，用于 Linux 和 MacOS
+# tproxy-port: 7894 # 透明代理端口，用于 Linux (TProxy TCP and TProxy UDP)
+
+allow-lan: true # 允许局域网连接
+bind-address: '*' # 绑定 IP 地址，仅作用于 allow-lan 为 true，'*' 表示所有地址
+
+mode: rule
+
+# 日志等级 silent/error/warning/info/debug
+log-level: info
+
+# 开启 IPv6 总开关，关闭阻断所有 IPv6 链接和屏蔽 DNS 请求 AAAA 记录
+ipv6: false
+
+# RESTful API 监听地址
+external-controller: 127.0.0.1:9090
+
+# 设置出口网卡
+# interface-name: eth0
+
+# 性能设置
+
+# 统一延迟
+# 去除握手等额外延迟，更准确反映节点延迟
+unified-delay: true
+
+# TCP 并发连接所有 IP，将使用最快握手的 TCP
+tcp-concurrent: true
+
+# 全局 TLS 指纹，优先级低于 proxy 内的 client-fingerprint
+# 可选：chrome/firefox/safari/ios/random/none
+global-client-fingerprint: chrome
+
+# 进程匹配模式
+# always - 开启，强制匹配所有进程
+# strict - 默认，由 mihomo 判断是否开启
+# off - 不匹配进程，推荐在路由器上使用此模式
+find-process-mode: strict
+
+# GeoData 加载模式，memconservative 低内存，适合路由器/嵌入式设备
+geodata-loader: memconservative
+
+# 显式声明 HTTP 请求 UA，避免默认值随版本漂移
+global-ua: clash.meta
+
+# 连接设置
+
+# TCP Keep-Alive 间隔
+keep-alive-interval: 30
+
+# GeoData 设置
+
+# 是否自动更新 geodata
+geo-auto-update: true
+
+# 更新间隔，单位：小时
+geo-update-interval: 24
+
+# 自定义 geodata url
+geox-url:
+  geoip: "https://testingcf.jsdelivr.net/gh/Loyalsoldier/v2ray-rules-dat@release/geoip.dat"
+  geosite: "https://testingcf.jsdelivr.net/gh/Loyalsoldier/v2ray-rules-dat@release/geosite.dat"
+  mmdb: "https://testingcf.jsdelivr.net/gh/Loyalsoldier/geoip@release/Country.mmdb"
+
+# Hosts 设置
+
+# 类似于 /etc/hosts，仅支持配置单个 IP
+hosts:
+  '*.clash.dev': 127.0.0.1
+  '.dev': 127.0.0.1
+  'localhost': 127.0.0.1
+
+# 配置持久化
+
+profile:
+  # 存储 select 选择记录
+  store-selected: true
+  # 持久化 fake-ip
+  store-fake-ip: true
+
+# 嗅探域名
+
+sniffer:
+  enable: true
+  # 是否使用嗅探结果作为实际访问，默认 true
+  # 全局配置，优先级低于 sniffer.sniff 实际配置
+  override-destination: false
+  # fake-ip 下改善 QUIC/HTTPS 直连 IP 场景的规则命中
+  force-dns-mapping: true
+  parse-pure-ip: true
+  sniff:
+    HTTP:
+      # 需要嗅探的端口
+      ports: [80, 8080-8880]
+      # 可覆盖 sniffer.override-destination
+      override-destination: true
+    TLS:
+      ports: [443, 8443]
+    QUIC:
+      ports: [443, 8443]
+  # Apple Push 及小米云等服务嗅探会导致连接失败，予以豁免
+  skip-domain:
+    - '+.push.apple.com'
+    - 'Mijia Cloud'
+    - '+.apple.com'
+
+# DNS 设置
+
+dns:
+  enable: true
+  # 开启 DNS 服务器监听
+  listen: 0.0.0.0:1053
+  # false 将返回 AAAA 的空结果
+  ipv6: false
+
+  # 让系统 hosts 及自定义 hosts 生效（如局域网 NAS、Pi-hole）
+  use-system-hosts: true
+
+  # 用于解析 nameserver，fallback 以及其他 DNS 服务器配置的 DNS 服务域名
+  # 只能使用纯 IP 地址，可使用加密 DNS
+  default-nameserver:
+    - 223.5.5.5
+    - 119.29.29.29
+
+  enhanced-mode: fake-ip
+  # fake-ip 池设置
+  fake-ip-range: 198.18.0.1/16
+
+  # DNS 缓存算法
+  cache-algorithm: arc
+
+  # 是否开启 DoH 支持 HTTP/3，将并发尝试
+  prefer-h3: false
+
+  # 配置后面的 nameserver、fallback 和 nameserver-policy 向 DNS 服务器的连接过程是否遵守 rules 规则
+  # 如果为 false（默认值）则这三部分的 DNS 服务器在未特别指定的情况下会直连
+  # 如果为 true，将会按照 rules 的规则匹配链接方式（走代理或直连）
+  # 启用 true 时必须同时配置 proxy-server-nameserver
+  respect-rules: true
+
+  # 配置 fake-ip-filter 的匹配模式，默认为 blacklist，即如果匹配成功不返回 fake-ip
+  # 可设置为 whitelist，即只有匹配成功才返回 fake-ip
+  fake-ip-filter-mode: blacklist
+
+  # 配置不使用 fake-ip 的域名
+  fake-ip-filter:
+    # 局域网与本地服务
+    - '*.lan'
+    - '+.lan'
+    - '*.local'
+    - '*.localdomain'
+    - '*.home.arpa'
+    - '*.localhost'
+    - 'localhost.ptlogin2.qq.com'
+    - 'WORKGROUP'
+    # STUN 服务
+    - '+.stun.*'
+    - '*.srv.nintendo.net'
+    - 'xbox.*.microsoft.com'
+    - 'xbox.*.*.microsoft.com'
+    - '*.xboxlive.com'
+    # 网络检测
+    - '*.msftconnecttest.com'
+    - '*.msftncsi.com'
+    - 'connectivitycheck.gstatic.com'
+    - 'connectivitycheck.android.com'
+    - 'connectivitycheck.platform.hicloud.com'
+    - 'connect.rom.miui.com'
+    - 'captive.apple.com'
+    - 'network-test.debian.org'
+    - 'detectportal.firefox.com'
+    # 特殊服务
+    - 'lens.l.google.com'
+    - '*.mcdn.bilivideo.cn'
+    - '*.battlenet.com.cn'
+    - '*.battlenet.com'
+    - '*.blzstatic.cn'
+    - '*.battle.net'
+    # Steam
+    - '*.cm.steampowered.com'
+    - '*.steamcontent.com'
+    # Tailscale / ZeroTier
+    - '*.tailscale.com'
+    - '*.zerotier.com'
+    # Spotify
+    - '*.spotify.com'
+    # 推送服务
+    - '+.push.apple.com'
+    - '+.market.xiaomi.com'
+    # NTP 时间服务
+    - 'time.*.com'
+    - 'ntp.*.com'
+    - '+.pool.ntp.org'
+    # 音乐服务
+    - '+.music.126.net'
+
+  # DNS 主要域名配置
+  # 支持 UDP、TCP、DoT、DoH、DoQ
+  # 这部分为主要 DNS 配置，影响所有直连，确保使用对大陆解析精准的 DNS
+  nameserver:
+    - https://dns.alidns.com/dns-query
+    - https://doh.pub/dns-query
+
+  # 用于解析机场/代理服务器域名（respect-rules: true 时必须配置）
+  # 走加密通道，避免 DNS 污染导致节点连接失败
+  proxy-server-nameserver:
+    - https://dns.cloudflare.com/dns-query
+    - https://dns.google/dns-query
+
+# TUN 设置
+
+tun:
+  enable: true
+
+  # 网络栈模式
+  # system - 性能最高，兼容性一般
+  # gvisor - 兼容性好，性能较低
+  # mixed - TCP 走系统栈，UDP 走 gvisor（推荐）
+  stack: mixed
+
+  # 需要劫持的 DNS
+  dns-hijack:
+    - any:53
+
+  # 配置路由表
+  auto-route: true
+
+  # 自动识别出口网卡
+  auto-detect-interface: true
+
+  # Linux 下自动透明代理 TCP，替代手工 iptables/nftables（非 Linux 平台自动忽略）
+  auto-redirect: true
+
+  # 启用 GSO（Generic Segmentation Offload）提升 TUN 吞吐
+  gso: true
+  gso-max-size: 65536
+
+  # 将所有连接路由到 tun 来防止泄漏，但你的设备将无法被其他设备访问
+  strict-route: true
+
+  # 启用 auto-route 时使用自定义路由而不是默认路由
+  # route-address:
+  #   - 0.0.0.0/1
+  #   - 128.0.0.0/1
+
+  # 排除路由，这些网段不经过 TUN
+  # route-exclude-address:
+  #   - 192.168.31.0/24
+
+# 本地节点配置（订阅为空）
+proxies: []
+
+# 服务器订阅配置
+proxy-providers:
+  Server:
+    type: http
+    path: ./Provider/Proxy/Server.yaml
+    url: https://sub.hotkids.me
+    interval: 3600
+    size-limit: 10485760
+    proxy: DIRECT
+    header:
+      User-Agent:
+      - "Clash/v1.18.0"
+      - "mihomo/1.18.3"
+    health-check:
+      enable: true
+      url: https://cp.cloudflare.com/generate_204
+      interval: 600
+      expected-status: 204
+      lazy: true
+
+proxy-groups:
+  # Global
+  - name: "GLOBAL"
+    type: select
+    icon: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Color/Inbound.png
+    include-all: true
+
+  # Proxy
+  - name: "🔰 Proxy"
+    type: select
+    icon: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Color/Outbound.png
+    proxies:
+      - 🇭🇰 Hong Kong
+      - 🇨🇳 Taiwan
+      - 🇸🇬 Singapore
+      - 🇯🇵 Japan
+      - 🇺🇸 America
+      - 🇺🇳 Server
+      - 🔘 DIRECT
+
+  # Streaming Global
+  - name: "🎬 Streaming"
+    type: select
+    icon: https://testingcf.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Streaming.png
+    proxies:
+      - 🔰 Proxy
+      - 🇭🇰 Hong Kong
+      - 🇨🇳 Taiwan
+      - 🇸🇬 Singapore
+      - 🇯🇵 Japan
+      - 🇺🇸 America
+      - 🇺🇳 Server
+
+  # CNTV APAC
+  - name: "📺 CNTV"
+    type: select
+    icon: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/StreamingCN.png
+    proxies:
+      - 🔘 DIRECT
+      - 🇨🇳 Taiwan
+      - 🇭🇰 Hong Kong
+
+  # Apple
+  # > Apple Services
+  - name: "🍎 Apple"
+    type: select
+    icon: https://testingcf.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Apple.png
+    proxies:
+      - 🔘 DIRECT
+      - 🔰 Proxy
+      - 🇺🇸 America
+      - 🇯🇵 Japan
+
+  # Google
+  - name: "🔍 Google"
+    type: select
+    icon: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Color/Google.png
+    proxies:
+      - 🇺🇸 America
+      - 🔰 Proxy
+
+  # AIGC
+  - name: "🤖 AIGC"
+    type: select
+    icon: https://testingcf.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/ChatGPT.png
+    proxies:
+      - 🇺🇸 America
+      - 🇸🇬 Singapore
+      - 🔰 Proxy
+
+  # Crypto
+  - name: "🪙 Crypto"
+    type: select
+    icon: https://testingcf.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Cryptocurrency_3.png
+    proxies:
+      - 🇺🇸 America
+      - 🔰 Proxy
+      - 🔘 DIRECT
+
+  # Finance
+  - name: "💳 Credit"
+    type: select
+    icon: https://testingcf.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/PayPal.png
+    proxies:
+      - 🇺🇸 America
+      - 🔰 Proxy
+      - 🔘 DIRECT
+
+  # Telegram
+  - name: "📬 Telegram"
+    type: select
+    icon: https://testingcf.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Telegram.png
+    proxies:
+      - 🔰 Proxy
+      - 🇸🇬 Singapore
+      - 🔘 DIRECT
+
+  # Mail
+  - name: "📧 Mail"
+    type: select
+    icon: https://testingcf.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Mail.png
+    proxies:
+      - 🔰 Proxy
+      - 🔘 DIRECT
+
+  # Adblock
+  - name: "🚧 AdGuard"
+    type: select
+    icon: https://testingcf.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Clubhouse_2.png
+    proxies:
+      - 🔘 DIRECT
+      - ⛔️ REJECT
+      - 📛 REJECT-DROP
+
+  # DIRECT
+  - name: "🔘 DIRECT"
+    type: select
+    hidden: true
+    proxies:
+      - DIRECT
+
+  # REJECT
+  - name: "⛔️ REJECT"
+    type: select
+    hidden: true
+    proxies:
+      - REJECT
+
+  # REJECT-DROP
+  - name: "📛 REJECT-DROP"
+    type: select
+    hidden: true
+    proxies:
+      - REJECT-DROP
+
+  # Nodes
+  - name: "🇺🇳 Server"
+    type: select
+    icon: https://testingcf.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Clubhouse_1.png
+    use:
+      - Server
+
+  # Area
+  - name: "🇭🇰 Hong Kong"
+    type: select
+    icon: https://testingcf.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Hong_Kong.png
+    use:
+      - Server
+    filter: '🇭🇰|HK|Hong Kong|香港'
+
+  - name: "🇨🇳 Taiwan"
+    type: select
+    icon: https://testingcf.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Taiwan.png
+    use:
+      - Server
+    filter: '🇨🇳|🇹🇼|TW|Taiwan|台湾'
+
+  - name: "🇸🇬 Singapore"
+    type: select
+    icon: https://testingcf.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Singapore.png
+    use:
+      - Server
+    filter: '🇸🇬|SG|Singapore|新加坡'
+
+  - name: "🇯🇵 Japan"
+    type: select
+    icon: https://testingcf.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Japan.png
+    use:
+      - Server
+    filter: '🇯🇵|JP|Japan|日本'
+
+  - name: "🇺🇸 America"
+    type: select
+    icon: https://testingcf.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/United_States.png
+    use:
+      - Server
+    filter: '🇺🇸|US|United States|美国'
+
+
+# 关于 Rule Provider 请查阅：https://wiki.metacubex.one/en/config/rule-providers/
+
+rule-providers:
+# name: # Provider 名称
+#   type: http # http 或 file
+#   behavior: classical # 或 ipcidr、domain
+#   path: # 文件路径
+#   url: # 只有当类型为 HTTP 时才可用，您不需要在本地空间中创建新文件。
+#   interval: # 自动更新间隔，仅在类型为 HTTP 时可用
+  Unbreak:
+    type: http
+    behavior: classical
+    path: ./Provider/RuleSet/Unbreak.yaml
+    url: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Unbreak.yaml
+    interval: 86400
+
+  Private:
+    type: http
+    behavior: domain
+    format: mrs
+    path: ./Provider/RuleSet/Private.mrs
+    url: https://testingcf.jsdelivr.net/gh/Loyalsoldier/mihomo-rule-set@release/private.mrs
+    interval: 86400
+
+  HTTPDNS:
+    type: http
+    behavior: classical
+    path: ./Provider/RuleSet/HTTPDNS.yaml
+    url: https://testingcf.jsdelivr.net/gh/VirgilClyne/GetSomeFries@main/ruleset/HTTPDNS.Block.yaml
+    interval: 86400
+
+  Reject:
+    type: http
+    behavior: domain
+    format: mrs
+    path: ./Provider/RuleSet/Reject.mrs
+    url: https://testingcf.jsdelivr.net/gh/Loyalsoldier/mihomo-rule-set@release/reject.mrs
+    interval: 86400
+
+  Advertising:
+    type: http
+    behavior: classical
+    path: ./Provider/RuleSet/Advertising.yaml
+    url: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/AD.yaml
+    interval: 86400
+
+  Streaming+:
+    type: http
+    behavior: classical
+    path: ./Provider/RuleSet/Streaming+.yaml
+    url: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Streaming+.yaml
+    interval: 86400
+
+  Streaming_TW:
+    type: http
+    behavior: classical
+    path: ./Provider/RuleSet/Streaming_TW.yaml
+    url: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Streaming_TW.yaml
+    interval: 86400
+
+  Streaming_JP:
+    type: http
+    behavior: classical
+    path: ./Provider/RuleSet/Streaming_JP.yaml
+    url: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Streaming_JP.yaml
+    interval: 86400
+
+  Streaming_US:
+    type: http
+    behavior: classical
+    path: ./Provider/RuleSet/Streaming_US.yaml
+    url: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Streaming_US.yaml
+    interval: 86400
+
+  Streaming:
+    type: http
+    behavior: classical
+    path: ./Provider/RuleSet/Streaming.yaml
+    url: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Streaming.yaml
+    interval: 86400
+
+  CNTV:
+    type: http
+    behavior: classical
+    path: ./Provider/RuleSet/CNTV.yaml
+    url: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/CNTV.yaml
+    interval: 86400
+
+  Google AI Studio:
+    type: http
+    behavior: classical
+    path: ./Provider/RuleSet/Google_AI_Studio.yaml
+    url: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Gemini.yaml
+    interval: 86400
+
+  AIGC:
+    type: http
+    behavior: classical
+    path: ./Provider/RuleSet/AIGC.yaml
+    url: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/GenAI.yaml
+    interval: 86400
+
+  Apple CN:
+    type: http
+    behavior: classical
+    path: ./Provider/RuleSet/Apple_CN.yaml
+    url: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Apple%20CN.yaml
+    interval: 86400
+
+  Apple:
+    type: http
+    behavior: classical
+    path: ./Provider/RuleSet/Apple.yaml
+    url: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Apple.yaml
+    interval: 86400
+
+  Crypto:
+    type: http
+    behavior: classical
+    path: ./Provider/RuleSet/Crypto.yaml
+    url: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Crypto.yaml
+    interval: 86400
+
+  Google:
+    type: http
+    behavior: classical
+    path: ./Provider/RuleSet/Google.yaml
+    url: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Google.yaml
+    interval: 86400
+
+  Credit:
+    type: http
+    behavior: classical
+    path: ./Provider/RuleSet/Credit.yaml
+    url: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Credit.yaml
+    interval: 86400
+
+  PayPal:
+    type: http
+    behavior: classical
+    path: ./Provider/RuleSet/PayPal.yaml
+    url: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/PayPal.yaml
+    interval: 86400
+
+  Telegram:
+    type: http
+    behavior: classical
+    path: ./Provider/RuleSet/Telegram.yaml
+    url: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Telegram.yaml
+    interval: 86400
+
+  Spark:
+    type: http
+    behavior: classical
+    path: ./Provider/RuleSet/Spark.yaml
+    url: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Spark.yaml
+    interval: 86400
+
+  Global:
+    type: http
+    behavior: domain
+    format: mrs
+    path: ./Provider/RuleSet/Global.mrs
+    url: https://testingcf.jsdelivr.net/gh/Loyalsoldier/mihomo-rule-set@release/proxy.mrs
+    interval: 86400
+
+  China:
+    type: http
+    behavior: domain
+    format: mrs
+    path: ./Provider/RuleSet/China.mrs
+    url: https://testingcf.jsdelivr.net/gh/Loyalsoldier/mihomo-rule-set@release/direct.mrs
+    interval: 86400
+
+  CNASN:
+    type: http
+    behavior: classical
+    path: ./Provider/RuleSet/CNASN.yaml
+    url: https://testingcf.jsdelivr.net/gh/VirgilClyne/GetSomeFries@main/ruleset/ASN.China.yaml
+    interval: 86400
+
+  CNCIDR:
+    type: http
+    behavior: ipcidr
+    format: mrs
+    path: ./Provider/RuleSet/CNCIDR.mrs
+    url: https://testingcf.jsdelivr.net/gh/Loyalsoldier/mihomo-rule-set@release/cncidr.mrs
+    interval: 86400
+
+  LAN:
+    type: http
+    behavior: ipcidr
+    path: ./Provider/RuleSet/LANCIDR.yaml
+    url: https://testingcf.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/lancidr.txt
+    interval: 86400
+
+# 规则
+rules:
+  # 标准 SSH 端口
+  - AND,((DST-PORT,22),(NETWORK,TCP)),🔘 DIRECT
+
+  # Unbreak 后续规则修正
+  - RULE-SET,Unbreak,🔘 DIRECT
+
+  # Private 私有网络
+  - RULE-SET,Private,🔘 DIRECT
+
+  # HTTPDNS 请求/流量阻止
+  - RULE-SET,HTTPDNS,🚧 AdGuard
+
+  # Advertising 广告
+  - RULE-SET,Reject,🚧 AdGuard
+  - RULE-SET,Advertising,🚧 AdGuard
+
+  # Global Area Network
+  # > 一些无需验证地区的分流 HOST
+  - RULE-SET,Streaming+,🔰 Proxy
+
+  # > Streaming by Region
+  # >> Streaming TW
+  - RULE-SET,Streaming_TW,🇨🇳 Taiwan
+  # >> Streaming JP
+  - RULE-SET,Streaming_JP,🇯🇵 Japan
+  # >> Streaming US
+  - RULE-SET,Streaming_US,🇺🇸 America
+
+  # > Streaming
+  - RULE-SET,Streaming,🎬 Streaming
+
+  # > CNTV（适用于 iQIYI Intl,WeTV,Bilibili 等大陆在港台东南亚提供服务的流媒体服务）
+  - RULE-SET,CNTV,📺 CNTV
+
+  # Global 全球代理规则
+  # > AIGC
+  - RULE-SET,Google AI Studio,🔍 Google
+  - RULE-SET,AIGC,🤖 AIGC
+
+  # > Apple
+  # >> Apple Services
+  - RULE-SET,Apple CN,🔘 DIRECT
+  - RULE-SET,Apple,🍎 Apple
+
+  # > Crypto
+  - RULE-SET,Crypto,🪙 Crypto
+
+  # > Google
+  - RULE-SET,Google,🔍 Google
+
+  # > Finance
+  - RULE-SET,Credit,💳 Credit
+
+  # > PayPal
+  - RULE-SET,PayPal,💳 Credit
+
+  # > Telegram
+  - RULE-SET,Telegram,📬 Telegram
+
+  # > Mail
+  - RULE-SET,Spark,📧 Mail
+
+  # Global (DNS Cache Pollution) / (IP Blackhole) / (Region-Restricted Access Denied) / (Network Jitter)
+  - RULE-SET,Global,🔰 Proxy
+
+  # China Area Network
+  - RULE-SET,China,🔘 DIRECT
+  - RULE-SET,CNASN,🔘 DIRECT
+  - RULE-SET,CNCIDR,🔘 DIRECT,no-resolve
+
+  # Local Area Network
+  - RULE-SET,LAN,🔘 DIRECT,no-resolve
+
+  # GeoIP
+  - GEOSITE,cn,🔘 DIRECT
+  - GEOIP,CN,🔘 DIRECT,no-resolve
+  - GEOSITE,geolocation-!cn,🔰 Proxy
+
+  # Final
+  - MATCH,🔰 Proxy


### PR DESCRIPTION
## Summary

Review `Clash/Sample.yaml` against wiki.metacubex.one (2026-04) and produce `Clash/Sample1.yaml` as a diffable improved copy. The original `Sample.yaml` is **not modified**.

### A. 修正（无效 / 误导项）

- **A1** `tproxy-port` 注释端口由 `7893` 改为 `7894`，避免与 `mixed-port: 7893` 冲突误导
- **A2** 删除 `dns.cache-size: 4096`（文档无此字段，缓存由 `cache-algorithm` 内部控制）
- **A3** 新增 `proxy-server-nameserver`（Cloudflare / Google DoH），配合 `respect-rules: true` 让机场域名走加密解析，避免污染
- **A4** `fake-ip-filter` 补充推送服务（`+.push.apple.com`、`+.market.xiaomi.com`）、NTP（`time.*.com`、`ntp.*.com`、`+.pool.ntp.org`）、局域网（`+.lan`）、音乐（`+.music.126.net`）等常见条目

### B. 新特性跟进（强烈推荐）

| # | 改动 | 理由 |
|---|---|---|
| B1 | `geodata-loader: memconservative` | 官方推荐，低内存，适合路由器/嵌入式 |
| B2 | `global-ua: clash.meta` | 显式 UA，避免默认值随版本漂移 |
| B4 | `sniffer.force-dns-mapping: true` / `parse-pure-ip: true` | fake-ip 下改善直连 IP 场景规则命中 |
| B5 | `sniffer.skip-domain`：Apple Push / Mijia Cloud | 官方文档推荐豁免，防止 hijack 失败 |
| B6 | `tun.auto-redirect: true` | Linux 自动透明代理 TCP，替代手工 iptables（非 Linux 自动忽略） |
| B7 | `tun.strict-route: true` | 防止流量泄漏（原已注释，现启用） |
| B8 | `respect-rules: true` + `proxy-server-nameserver` | 机场域名走代理解析，彻底隔离 DNS 污染 |
| B9 | `use-system-hosts: true` | 让系统 hosts / Pi-hole 生效 |
| B10 | `proxy-providers.Server`: `size-limit: 10485760` + `health-check.lazy: true` | 防御恶意订阅；空闲减少探测流量 |
| B11 | `Private`/`Reject`/`Global`/`China`/`CNCIDR` 切换 `format: mrs` | 二进制规则集体积小、加载快（Loyalsoldier mihomo-rule-set） |
| B12 | `CNCIDR`/`LAN`/`GEOIP,CN` 规则追加 `,no-resolve` | 防止规则阶段反查 DNS 造成泄漏或卡顿 |

## Test plan

- [ ] `mihomo -t -f Clash/Sample1.yaml` → `configuration file testing is successful`
- [ ] 启动后无 `unknown field` warning（重点：`dns`、`sniffer`、`tun` 段）
- [ ] `dig @127.0.0.1 -p 1053 google.com` 返回 `198.18.x.x`（fake-ip）
- [ ] `dig @127.0.0.1 -p 1053 weibo.com` 返回真实国内 IP
- [ ] 机场域名（`sub.hotkids.me`）通过 `proxy-server-nameserver` 解析成功
- [ ] 日志里 `provider [Private/Reject/Global/China/CNCIDR]` 加载成功
- [ ] Linux：`iptables -t mangle -nvL` 确认 auto-redirect 写入规则；卸载后清理干净
- [ ] Sniffer：访问纯 IP HTTPS 站点，日志打印 `sniffed SNI`，命中域名规则集

https://claude.ai/code/session_012vQgxc7X3A48LPaxTaK5aQ