### PR TITLE
fix(surge): set ipv6-vif=auto to intercept gateway IPv6 traffic

### DIFF
--- a/Surge/Profile.conf
+++ b/Surge/Profile.conf
@@ -22,7 +22,7 @@ geoip-maxmind-url = https://raw.githubusercontent.com/Loyalsoldier/geoip/release
 # > IPv6 支持
 ipv6 = false
 # 允许 IPv6 通过 Surge VIF（可选：off，auto，always）
-ipv6-vif = off
+ipv6-vif = auto
 
 # > 阻止 QUIC / HTTP3
 # 禁用基于 UDP 443 的 QUIC 协议，强制回退 HTTP/2 / HTTP/1.1


### PR DESCRIPTION
With ipv6-vif=off, IPv6 packets from bypass router clients passed through Mac without Surge VIF interception, leaking via Chinese ISP IPv6 instead of going through the proxy.