### PR TITLE
fix(surge): comment out include-local-networks per official recommend…

### DIFF
--- a/Surge/Profile.conf
+++ b/Surge/Profile.conf
@@ -109,7 +109,7 @@ force-http-engine-hosts = *.ott.cibntv.net, *.tc.qq.com, *.douyinvod.com, *.douy
 # > 路由防火墙
 # include-all-networks = false
 # 允许 Surge VIF 接管局域网转发流量，使旁路由设备的 DNS 查询可被 hijack-dns 捕获
-include-local-networks = true #!MACOS-ONLY
+# include-local-networks = true #!MACOS-ONLY
 
 # > UDP 优先级
 udp-priority = true


### PR DESCRIPTION
…ation

Official docs warn this causes AirDrop, Xcode Debugger, and Surge Dashboard USB connection failures. Gateway mode works correctly without it when downstream devices set DNS to 198.18.0.2 and hijack-dns = *:53 handles hardcoded DNS.


Claude-Session: https://claude.ai/code/session_01Mn2cKMp58kuuvoxBSnaByo