### PR TITLE
fix(clash): 修复 Sniffer "may not have any sent data" 警告刷屏

### DIFF
--- a/Clash/General.yaml
+++ b/Clash/General.yaml
@@ -94,8 +94,8 @@ sniffer:
   override-destination: false
   # redir-host 模式下也强制嗅探，改善直连 IP 的规则命中
   force-dns-mapping: true
-  # 对无域名信息的纯 IP 连接也尝试嗅探
-  parse-pure-ip: true
+  # fake-ip 模式下域名已由映射得知，无需对纯 IP 连接嗅探（开启会导致大量 "may not have any sent data" 警告）
+  parse-pure-ip: false
   sniff:
     HTTP:
       ports: [80, 8080-8880]

--- a/Clash/General.yaml
+++ b/Clash/General.yaml
@@ -109,13 +109,6 @@ sniffer:
   skip-domain:
     - "+.push.apple.com"
     - "Mijia Cloud"
-  # 跳过嗅探的目标 IP 段（避免对纯 IP 直连产生无效嗅探警告）
-  skip-dst-address:
-    - "198.18.0.0/16"    # fake-ip 段（域名已由 fake-ip 映射得知，无需嗅探）
-    - "2001:4860::/32"   # Google IPv6
-    - "2404:6800::/32"   # Google IPv6 APAC
-    - "2a00:1450::/32"   # Google IPv6 EU
-    - "240.0.0.0/4"      # 保留地址
 
 # ── DNS ──
 

--- a/Clash/Sample.yaml
+++ b/Clash/Sample.yaml
@@ -98,8 +98,8 @@ sniffer:
   override-destination: false
   # redir-host 模式下也强制嗅探，改善直连 IP 的规则命中
   force-dns-mapping: true
-  # 对无域名信息的纯 IP 连接也尝试嗅探
-  parse-pure-ip: true
+  # fake-ip 模式下域名已由映射得知，无需对纯 IP 连接嗅探（开启会导致大量 "may not have any sent data" 警告）
+  parse-pure-ip: false
   sniff:
     HTTP:
       ports: [80, 8080-8880]

--- a/Clash/Sample.yaml
+++ b/Clash/Sample.yaml
@@ -113,13 +113,6 @@ sniffer:
   skip-domain:
     - "+.push.apple.com"
     - "Mijia Cloud"
-  # 跳过嗅探的目标 IP 段（避免对纯 IP 直连产生无效嗅探警告）
-  skip-dst-address:
-    - "198.18.0.0/16"    # fake-ip 段（域名已由 fake-ip 映射得知，无需嗅探）
-    - "2001:4860::/32"   # Google IPv6
-    - "2404:6800::/32"   # Google IPv6 APAC
-    - "2a00:1450::/32"   # Google IPv6 EU
-    - "240.0.0.0/4"      # 保留地址
 
 # ── DNS ──
 


### PR DESCRIPTION
## 问题

Clash (mihomo) 持续刷 `[Sniffer] [x.x.x.x] [tls] may not have any sent data, Consider adding skip` 警告，且每次都是不同 IP（真实 IP 如 `74.125.20.139`、fake-ip 如 `198.18.0.113`），靠 `skip-dst-address` 逐个堵是 whack-a-mole，永远加不完。

## 根因

`parse-pure-ip: true` 会对**所有未获取到域名的流量**强制嗅探。在 fake-ip 模式下（`fake-ip-ttl: 1`）映射快速失效，过期的 `198.18.x.x` 连接也退化为"无域名流量"，与真实纯 IP 直连一样被嗅探，遇到不立即发数据的 TLS/QUIC 连接就报此警告。

依据 [mihomo 官方文档](https://wiki.metacubex.one/en/config/sniff/)：
- `parse-pure-ip`：对所有未获取到域名的流量进行强制嗅探
- `force-dns-mapping`：仅对 `redir-host` 类型流量强制嗅探（fake-ip 模式下不生效）

## 改动

- `parse-pure-ip: true` → `false`（根治方案）—— fake-ip 模式下域名已由映射得知，无需对纯 IP 连接嗅探
- 删除整个 `skip-dst-address` 列表 —— 其唯一目的就是规避 `parse-pure-ip` 的副作用，根因解决后全部冗余
- 保留 `skip-domain`（跳过特定域名嗅探，与本问题无关）

`General.yaml` 与 `Sample.yaml` 同步修改，YAML 已校验通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mn2cKMp58kuuvoxBSnaByo)_