### PR TITLE
chore(module): migrate all {{{var}}} → %var% in sgmodule arguments

### DIFF
--- a/Surge/Module/APNs.sgmodule
+++ b/Surge/Module/APNs.sgmodule
@@ -6,12 +6,12 @@
 
 [General]
 # > 包含所有网络,默认情况下，某些请求可能不会被 Surge 接管。例如，应用程序可以绑定到物理网络接口以绕过浪涌 VIF。启用“包括所有网络”选项，以确保所有请求都由 Surge 处理而不会泄漏。当您使用 Surge 作为防火墙时，此选项很有用。（需要 iOS 14.0 或以上版本）,启用此选项可能会导致 AirDrop 和 Xcode 调试问题、通过 USB 的 Surge Dashboard 无法正常工作以及其他意外的副作用。请谨慎使用。
-include-all-networks={{{Tunnel}}}
+include-all-networks=%Tunnel%
 # > 包含本地网络,启用此选项可使 Surge VIF 处理发送到 LAN 的请求。（需要 iOS 14.2 或更高版本）启用此选项可能会导致 AirDrop 和 Xcode 调试问题、通过 USB 的 Surge Dashboard 无法正常工作以及其他意外的副作用。请谨慎使用。必须与 include-all-networks=true 结合使用。
 # include-local-networks = false
 # > 启用此选项可使 Surge VIF 处理 Apple 推送通知服务 （APNs） 的网络流量。必须与 include-all-networks=true 结合使用。
-include-apns={{{Tunnel}}}
+include-apns=%Tunnel%
 
 [Rule]
 # APNs
-RULE-SET,https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Apple/APNS.list,{{{APNs}}},extended-matching
+RULE-SET,https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Apple/APNS.list,%APNs%,extended-matching

--- a/Surge/Module/BlockAds.sgmodule
+++ b/Surge/Module/BlockAds.sgmodule
@@ -559,7 +559,7 @@ IP-CIDR6,2402:4e00:1200:ed00:0:9089:6dac:96b6/128,REJECT,no-resolve,pre-matching
 # > IT之家去广告 · 2025-12-01
 # desc = 过滤IT之家信息流广告和文末广告，自定义移除置顶和轮播图，自定义移除项需在插件配置。
 # hostname = napi.ithome.com, api.zuihuimai.com, dat.ruanmei.com
-IT之家去广告 = type=http-response, pattern=^https:\/\/napi\.ithome\.com\/api\/(news\/indexv2\/iphone\/\d+|topmenu\/getfeeds\?), script-path=https://kelee.one/Resource/JavaScript/IThome/IThome_remove_ads.js, requires-body=true, argument="[{{{removeAllBanners}}},{{{removePinnedArticles}}}]"
+IT之家去广告 = type=http-response, pattern=^https:\/\/napi\.ithome\.com\/api\/(news\/indexv2\/iphone\/\d+|topmenu\/getfeeds\?), script-path=https://kelee.one/Resource/JavaScript/IThome/IThome_remove_ads.js, requires-body=true, argument="[%removeAllBanners%,%removePinnedArticles%]"
 
 # > 阿里云盘去广告 · 2025-05-13
 # desc = 移除首页广告横幅、弹窗和顶部奖励。

--- a/Surge/Module/CloudMusic.sgmodule
+++ b/Surge/Module/CloudMusic.sgmodule
@@ -16,13 +16,13 @@
 网易云音乐 = type=http-response,pattern=^https?:\/\/(ipv4|interface\d?)\.music\.163\.com\/e?api\/(batch|v\d\/resource\/comment\/floor\/get),requires-body=1,max-size=0,timeout=20,binary-body-mode=1,script-path=https://raw.githubusercontent.com/Keywos/rule/main/script/wy/js/wyres.js
 
 # 伪vip
-{{{脚本伪vip}}} = type=http-response,pattern=^https?:\/\/(ipv4|interface\d?)\.music\.163\.com\/e?api\/(music-vip-membership\/client\/vip\/info|vipnewcenter\/app\/resource\/newaccountpage),requires-body=1,max-size=0,timeout=20,binary-body-mode=1,script-path=https://raw.githubusercontent.com/Keywos/rule/main/script/wy/js/wyres.js
+%脚本伪vip% = type=http-response,pattern=^https?:\/\/(ipv4|interface\d?)\.music\.163\.com\/e?api\/(music-vip-membership\/client\/vip\/info|vipnewcenter\/app\/resource\/newaccountpage),requires-body=1,max-size=0,timeout=20,binary-body-mode=1,script-path=https://raw.githubusercontent.com/Keywos/rule/main/script/wy/js/wyres.js
 
 # tab
-网易云音乐 = type=http-response,pattern=^https?:\/\/(ipv4|interface\d?)\.music\.163\.com\/e?api\/link\/home\/framework\/tab,requires-body=1,max-size=0,timeout=20,binary-body-mode=1,script-path=https://raw.githubusercontent.com/Keywos/rule/main/script/wy/js/wyres.js, argument="{"MY":"{{{漫游}}}","DT":"{{{笔记}}}","FX":"{{{发现}}}"}"
+网易云音乐 = type=http-response,pattern=^https?:\/\/(ipv4|interface\d?)\.music\.163\.com\/e?api\/link\/home\/framework\/tab,requires-body=1,max-size=0,timeout=20,binary-body-mode=1,script-path=https://raw.githubusercontent.com/Keywos/rule/main/script/wy/js/wyres.js, argument="{"MY":"%漫游%","DT":"%笔记%","FX":"%发现%"}"
 
 # 推荐 | home | 主页
-网易云音乐 = type=http-response,pattern=^https?:\/\/(ipv4|interface\d?)\.music\.163\.com\/e?api\/(homepage\/block\/page|link\/page\/rcmd\/(resource\/show|block\/resource\/multi\/refresh)),requires-body=1,max-size=0,timeout=20,binary-body-mode=1,script-path=https://raw.githubusercontent.com/Keywos/rule/main/script/wy/js/wyres.js, argument="{"PRGG":"{{{问候语}}}","PRDRD":"{{{每日推荐}}}","PRSCVPT":"{{{推荐歌单}}}","PRST":"{{{最近常听}}}","HMPR":"{{{音乐合伙人}}}","PRRR":"{{{雷达歌单}}}","PRRK":"{{{排行榜}}}","PRMST":"{{{推荐专属歌单}}}","PRCN":"{{{你的专属歌单}}}"}"
+网易云音乐 = type=http-response,pattern=^https?:\/\/(ipv4|interface\d?)\.music\.163\.com\/e?api\/(homepage\/block\/page|link\/page\/rcmd\/(resource\/show|block\/resource\/multi\/refresh)),requires-body=1,max-size=0,timeout=20,binary-body-mode=1,script-path=https://raw.githubusercontent.com/Keywos/rule/main/script/wy/js/wyres.js, argument="{"PRGG":"%问候语%","PRDRD":"%每日推荐%","PRSCVPT":"%推荐歌单%","PRST":"%最近常听%","HMPR":"%音乐合伙人%","PRRR":"%雷达歌单%","PRRK":"%排行榜%","PRMST":"%推荐专属歌单%","PRCN":"%你的专属歌单%"}"
 
 # 发现
 网易云音乐 = type=http-response,pattern=^https?:\/\/(ipv4|interface\d?)\.music\.163\.com\/e?api\/link\/page\/discovery\/resource\/show,requires-body=1,max-size=0,timeout=20,binary-body-mode=1,script-path=https://raw.githubusercontent.com/Keywos/rule/main/script/wy/js/wyres.js

--- a/Surge/Module/GeoLoc.sgmodule
+++ b/Surge/Module/GeoLoc.sgmodule
@@ -6,37 +6,37 @@
 
 [Rule]
 # bilibili
-URL-REGEX,https:\/\/api\.bilibili\.com\/x\/v\d\/reply\/add,{{{SNS}}}
+URL-REGEX,https:\/\/api\.bilibili\.com\/x\/v\d\/reply\/add,%SNS%
 
 # ByteDance
 # (Amemv)
 AND,((DOMAIN-KEYWORD,amemv.com,extended-matching),(PROTOCOL,UDP)),REJECT
-DOMAIN-KEYWORD,-core-hl.amemv.com,{{{SNS}}},extended-matching
-DOMAIN-KEYWORD,-core-lf.amemv.com,{{{SNS}}},extended-matching
+DOMAIN-KEYWORD,-core-hl.amemv.com,%SNS%,extended-matching
+DOMAIN-KEYWORD,-core-lf.amemv.com,%SNS%,extended-matching
 
 # (TouTiao)
-DOMAIN,ib.snssdk.com,{{{SNS}}}
+DOMAIN,ib.snssdk.com,%SNS%
 
 # Kuwo
-DOMAIN,ip.i.kuwo.cn,{{{SNS}}}
+DOMAIN,ip.i.kuwo.cn,%SNS%
 
 # Xiaohongshu
-DOMAIN,edith.xiaohongshu.com,{{{SNS}}},extended-matching
+DOMAIN,edith.xiaohongshu.com,%SNS%,extended-matching
 
 # Weibo
-URL-REGEX,https:\/\/api\.weibo\.cn\/\d\/comments\/(create|reply),{{{SNS}}}
-URL-REGEX,https:\/\/weibo\.com\/ajax\/comments\/create,{{{SNS}}}
-URL-REGEX,https:\/\/api\.weibo\.cn\/\d\/statuses\/send,{{{SNS}}}
+URL-REGEX,https:\/\/api\.weibo\.cn\/\d\/comments\/(create|reply),%SNS%
+URL-REGEX,https:\/\/weibo\.com\/ajax\/comments\/create,%SNS%
+URL-REGEX,https:\/\/api\.weibo\.cn\/\d\/statuses\/send,%SNS%
 # (Web)
-DOMAIN,www.weibo.com,{{{SNS}}}
-DOMAIN,s.weibo.com,{{{SNS}}}
+DOMAIN,www.weibo.com,%SNS%
+DOMAIN,s.weibo.com,%SNS%
 
 # Zhihu
-URL-REGEX,https:\/\/api\.zhihu\.com\/answers,{{{SNS}}}
-URL-REGEX,https:\/\/api\.zhihu\.com\/comment_v\d\/answers\/\d+\/comment,{{{SNS}}}
+URL-REGEX,https:\/\/api\.zhihu\.com\/answers,%SNS%
+URL-REGEX,https:\/\/api\.zhihu\.com\/comment_v\d\/answers\/\d+\/comment,%SNS%
 
 # Twitter/X
-{{{可选 Twitter}}},https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Twitter.list,{{{Twitter}}},extended-matching
+%可选 Twitter%,https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Twitter.list,%Twitter%,extended-matching
 
 [MITM]
 hostname = %APPEND% api.bilibili.com, api.weibo.cn, weibo.com, api.zhihu.com

--- a/Surge/Module/Pannel/airport-traffic-panel.sgmodule
+++ b/Surge/Module/Pannel/airport-traffic-panel.sgmodule
@@ -6,7 +6,7 @@
 #!arguments-desc=【必填参数】\nsub: 机场订阅链接（必须先 URL encode）\n  - 单机场：直接填入 encode 后的链接\n  - 多机场：1️⃣链接1 2️⃣链接2 3️⃣链接3\n  - 在线 encode: https://www.urlencoder.org/\n\n【可选参数】\nname: 机场名称\n  - 单机场：我的机场\n  - 多机场：1️⃣机场A 2️⃣机场B 3️⃣机场C\n\nexpire: 到期日期（优先使用此值，否则从订阅读取）\n  - 格式：YYYYMMDD / YYYY-MM-DD / Unix时间戳\n\nreset: 每月流量重置日（1-31）\n\ntitle: 面板标题（默认：机场流量信息）\n\nicon: 面板图标（默认：airplane.departure）\n\ncolor: 图标颜色（默认：#007AFF）
 
 [Panel]
-airport-traffic-panel = type=generic,script-name=airport-traffic,update-interval=600,icon={{{icon}}}
+airport-traffic-panel = type=generic,script-name=airport-traffic,update-interval=600,icon=%icon%
 
 [Script]
-airport-traffic = type=generic,timeout=30,script-path=https://raw.githubusercontent.com/HotKids/Rules/master/Surge/Module/Scripts/airport-traffic.js,argument=name={{{name}}}&sub={{{sub}}}&expire={{{expire}}}&reset={{{reset}}}&title={{{title}}}&icon={{{icon}}}&color={{{color}}}
+airport-traffic = type=generic,timeout=30,script-path=https://raw.githubusercontent.com/HotKids/Rules/master/Surge/Module/Scripts/airport-traffic.js,argument=name=%name%&sub=%sub%&expire=%expire%&reset=%reset%&title=%title%&icon=%icon%&color=%color%

--- a/Surge/Module/Pannel/ip-security-panel.sgmodule
+++ b/Surge/Module/Pannel/ip-security-panel.sgmodule
@@ -10,7 +10,7 @@ ip-security-panel = script-name=ip-security-panel,update-interval=600
 
 [Script]
 # 面板手动触发
-ip-security-panel = type=generic,timeout=15,script-path=https://raw.githubusercontent.com/HotKids/Rules/master/Surge/Module/Scripts/ip-security.js,argument=ipqs_key={{{ipqs_key}}}&risk_api={{{risk_api}}}&local_geoapi={{{local_geoapi}}}&remote_geoapi={{{remote_geoapi}}}&mask_ip={{{mask_ip}}}&tw_flag={{{tw_flag}}}
+ip-security-panel = type=generic,timeout=15,script-path=https://raw.githubusercontent.com/HotKids/Rules/master/Surge/Module/Scripts/ip-security.js,argument=ipqs_key=%ipqs_key%&risk_api=%risk_api%&local_geoapi=%local_geoapi%&remote_geoapi=%remote_geoapi%&mask_ip=%mask_ip%&tw_flag=%tw_flag%
 
 # 网络变化自动触发
-ip-security-event = type=event,event-name=network-changed,timeout=15,script-path=https://raw.githubusercontent.com/HotKids/Rules/master/Surge/Module/Scripts/ip-security.js,argument=TYPE=EVENT&ipqs_key={{{ipqs_key}}}&risk_api={{{risk_api}}}&local_geoapi={{{local_geoapi}}}&remote_geoapi={{{remote_geoapi}}}&mask_ip={{{mask_ip}}}&tw_flag={{{tw_flag}}}&event_delay={{{event_delay}}}&notify={{{notify}}}
+ip-security-event = type=event,event-name=network-changed,timeout=15,script-path=https://raw.githubusercontent.com/HotKids/Rules/master/Surge/Module/Scripts/ip-security.js,argument=TYPE=EVENT&ipqs_key=%ipqs_key%&risk_api=%risk_api%&local_geoapi=%local_geoapi%&remote_geoapi=%remote_geoapi%&mask_ip=%mask_ip%&tw_flag=%tw_flag%&event_delay=%event_delay%&notify=%notify%

--- a/Surge/Module/Pannel/media-check-panel.sgmodule
+++ b/Surge/Module/Pannel/media-check-panel.sgmodule
@@ -9,4 +9,4 @@
 media-check-panel = type=generic,script-name=media-check,update-interval=600,icon=play.circle.fill
 
 [Script]
-media-check = type=generic,timeout=30,script-path=https://raw.githubusercontent.com/HotKids/Rules/master/Surge/Module/Scripts/media-check.js,argument=geminiapikey={{{geminiapikey}}}&nfprice={{{nfprice}}}
+media-check = type=generic,timeout=30,script-path=https://raw.githubusercontent.com/HotKids/Rules/master/Surge/Module/Scripts/media-check.js,argument=geminiapikey=%geminiapikey%&nfprice=%nfprice%

--- a/Surge/Module/Pannel/vps-traffic-panel.sgmodule
+++ b/Surge/Module/Pannel/vps-traffic-panel.sgmodule
@@ -9,4 +9,4 @@
 vps-traffic-panel = type=generic,script-name=vps-traffic,update-interval=300,icon=server.rack
 
 [Script]
-vps-traffic = type=generic,timeout=30,script-path=https://raw.githubusercontent.com/HotKids/Rules/master/Surge/Module/Scripts/vps-traffic.js,argument="title={{{title}}}&ip={{{ip}}}&quota={{{quota}}}&resetday={{{resetday}}}&mode={{{mode}}}&expire={{{expire}}}"
+vps-traffic = type=generic,timeout=30,script-path=https://raw.githubusercontent.com/HotKids/Rules/master/Surge/Module/Scripts/vps-traffic.js,argument="title=%title%&ip=%ip%&quota=%quota%&resetday=%resetday%&mode=%mode%&expire=%expire%"

--- a/Surge/Module/Service+.sgmodule
+++ b/Surge/Module/Service+.sgmodule
@@ -4,20 +4,20 @@
 
 [Rule]
 # > ChatGPT
-{{{ChatGPT 禁用}}},https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/OpenAI.list,{{{ChatGPT 分流}}},extended-matching
+%ChatGPT 禁用%,https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/OpenAI.list,%ChatGPT 分流%,extended-matching
 # > Claude
-{{{Claude 禁用}}},https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Anthropic.list,{{{Claude 分流}}},extended-matching
+%Claude 禁用%,https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Anthropic.list,%Claude 分流%,extended-matching
 # > Discovery+
-{{{Discovery+ 禁用}}},https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Discovery+.list,{{{Discovery+ 分流}}},extended-matching
+%Discovery+ 禁用%,https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Discovery+.list,%Discovery+ 分流%,extended-matching
 # > Disney+
-{{{Disney+ 禁用}}},https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Disney+.list,{{{Disney+ 分流}}},extended-matching
+%Disney+ 禁用%,https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Disney+.list,%Disney+ 分流%,extended-matching
 # > HBO Max
-{{{HBO Max 禁用}}},https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/HBO_Max.list,{{{HBO Max 分流}}},extended-matching
+%HBO Max 禁用%,https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/HBO_Max.list,%HBO Max 分流%,extended-matching
 # > Netflix
-{{{Netflix 禁用}}},https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Netflix.list,{{{Netflix 分流}}},extended-matching
+%Netflix 禁用%,https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Netflix.list,%Netflix 分流%,extended-matching
 # > Spotify
-{{{Spotify 禁用}}},https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Spotify.list,{{{Spotify 分流}}},extended-matching
+%Spotify 禁用%,https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Spotify.list,%Spotify 分流%,extended-matching
 # > Viu｜HK IN SEA
-{{{Viu 禁用}}},https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Viu.list,{{{Viu 分流}}},extended-matching
+%Viu 禁用%,https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Viu.list,%Viu 分流%,extended-matching
 # > YouTube
-{{{YouTube 禁用}}},https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/YouTube.list,{{{YouTube 分流}}},extended-matching
+%YouTube 禁用%,https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/YouTube.list,%YouTube 分流%,extended-matching

--- a/Surge/Module/WBD.sgmodule
+++ b/Surge/Module/WBD.sgmodule
@@ -13,8 +13,8 @@ hostname = %APPEND% default.any-any.prd.api.discomax.com
 #   Discovery+ UA 识别：*DPlus*
 #   HBO Max   UA 识别：*Max*
 # 以下注释示例按需启用：
-# AND,((DOMAIN,default.any-any.prd.api.discomax.com),(USER-AGENT,*DPlus*)),{{{DPlus}}}
-# AND,((DOMAIN,default.any-any.prd.api.discomax.com),(USER-AGENT,*Max*)),{{{Max}}}
+# AND,((DOMAIN,default.any-any.prd.api.discomax.com),(USER-AGENT,*DPlus*)),%DPlus%
+# AND,((DOMAIN,default.any-any.prd.api.discomax.com),(USER-AGENT,*Max*)),%Max%
 
 # Discovery+ 服务域名分流
-RULE-SET,https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Discovery+.list,{{{DPlus}}},force-remote-dns,extended-matching
+RULE-SET,https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Discovery+.list,%DPlus%,force-remote-dns,extended-matching


### PR DESCRIPTION
Replace the deprecated {{{variable}}} placeholder syntax with the current Surge %variable% syntax across all manually-maintained modules. Bilibili.sgmodule (auto-synced upstream) excluded.


Claude-Session: https://claude.ai/code/session_01Mn2cKMp58kuuvoxBSnaByo