### PR TITLE
feat(sync-modules): argumentize domain labels per module like GeoLoc

### DIFF
--- a/.github/scripts/sync-modules.py
+++ b/.github/scripts/sync-modules.py
@@ -82,14 +82,30 @@ def parse_sgmodule(text: str) -> dict:
     return {"meta": meta, "sections": sections}
 
 
-def _merge_mitm(entries: list[tuple[str, list[str]]]) -> list[str]:
-    """合并多个来源的 [MITM] 块：hostname 去重合并，布尔键取 true 优先。"""
-    hostnames: list[str] = []
-    seen_hosts: set[str] = set()
+def _sub_alias(text: str, alias: str) -> str:
+    """将 text 中作为域名标签出现的 alias 替换为 {{{alias}}}。
+
+    仅在紧邻点号（`.` 或转义的 `\\.`）时替换，从而命中域名部分
+    （如 ad.12306.cn → ad.{{{12306}}}.cn），而不会误伤脚本名
+    （移除12306开屏广告）或 script-path 路径（.../12306/12306_remove.js）。
+    """
+    esc = re.escape(alias)
+    return re.compile(rf"(?<=\.){esc}|{esc}(?=\\?\.)").sub(
+        f"{{{{{{{alias}}}}}}}", text
+    )
+
+
+def _merge_mitm(entries: list[tuple[str, list[str]]], name_to_alias: dict[str, str]) -> list[str]:
+    """合并多个来源的 [MITM] 块：hostname 去重合并，布尔键取 true 优先。
+
+    每条 hostname 按其所属模块的 alias 做域名替换。
+    """
+    host_map: dict[str, str] = {}  # 原始 hostname -> 替换后 hostname（按原始去重/排序）
     bool_flags: dict[str, str] = {}
     other: list[str] = []
 
-    for _name, lines in entries:
+    for name, lines in entries:
+        alias = name_to_alias.get(name)
         for line in lines:
             if not line.strip():
                 continue
@@ -104,9 +120,8 @@ def _merge_mitm(entries: list[tuple[str, list[str]]]) -> list[str]:
                 val = re.sub(r"^%APPEND%\s*", "", val)
                 for h in val.split(","):
                     h = h.strip()
-                    if h and h not in seen_hosts:
-                        seen_hosts.add(h)
-                        hostnames.append(h)
+                    if h and h not in host_map:
+                        host_map[h] = _sub_alias(h, alias) if alias else h
             elif key in _MITM_BOOL_KEYS:
                 if bool_flags.get(key) != "true":
                     bool_flags[key] = val
@@ -116,8 +131,9 @@ def _merge_mitm(entries: list[tuple[str, list[str]]]) -> list[str]:
     result = list(other)
     for k, v in bool_flags.items():
         result.append(f"{k} = {v}")
-    if hostnames:
-        result.append(f"hostname = %APPEND% {', '.join(sorted(hostnames))}")
+    if host_map:
+        merged = ", ".join(host_map[k] for k in sorted(host_map))
+        result.append(f"hostname = %APPEND% {merged}")
     return result
 
 
@@ -186,9 +202,9 @@ def aggregate():
     merged_args: dict[str, str] = {}
     # 合并后的 upstream arguments-desc：key -> desc（保序去重）
     merged_args_desc: dict[str, str] = {}
-    # alias -> 模块名（默认值），用于生成 #!arguments，保留 url_alias_list 顺序
-    alias_args: dict[str, str] = {}
-    # 模块名 -> alias，用于 Script section 替换 key
+    # alias 有序集合（默认值即 alias 本身），用于生成 #!arguments，保留 url_alias_list 顺序
+    alias_args: dict[str, None] = {}
+    # 模块名 -> alias，用于在各 section 内做域名替换
     name_to_alias: dict[str, str] = {}
 
     for url, alias in url_alias_list:
@@ -198,7 +214,7 @@ def aggregate():
         parsed = parse_sgmodule(text)
         name = parsed["meta"].get("name", url)
         if alias:
-            alias_args[alias] = name
+            alias_args[alias] = None
             name_to_alias[name] = alias
         # 提取上游 date（只保留年月日）
         raw_date = parsed["meta"].get("date", "")
@@ -254,18 +270,15 @@ def aggregate():
     out.append(f"#!category={existing_meta.get('category', 'HotKids')}")
     if "remark" in existing_meta:
         out.append(f"#!remark={existing_meta['remark']}")
-    # 写入合并后的 arguments
-    # 优先级：existing_meta 手动值 > alias_args（模块开关）> upstream merged_args
-    if "arguments" in existing_meta:
-        out.append(f"#!arguments={existing_meta['arguments']}")
-        if "arguments-desc" in existing_meta:
-            out.append(f"#!arguments-desc={existing_meta['arguments-desc']}")
-    else:
-        all_args = {**{k: f"{k}:{v}" for k, v in alias_args.items()}, **merged_args}
-        if all_args:
-            out.append(f"#!arguments={','.join(all_args.values())}")
-        if merged_args_desc:
-            out.append(f"#!arguments-desc={chr(10).join(merged_args_desc.values())}")
+    # 写入合并后的 arguments：模块域名开关（alias:alias，默认值即 alias 本身=启用）
+    # 在前，上游自带 arguments 在后。
+    all_args: dict[str, str] = {alias: f"{alias}:{alias}" for alias in alias_args}
+    for k, v in merged_args.items():
+        all_args.setdefault(k, v)
+    if all_args:
+        out.append(f"#!arguments={','.join(all_args.values())}")
+    if merged_args_desc:
+        out.append(f"#!arguments-desc={chr(10).join(merged_args_desc.values())}")
     out.append(f"#!date={now}")
     out.append("")
 
@@ -277,28 +290,23 @@ def aggregate():
             return
         out.append(f"[{sec}]")
         if sec == "MITM":
-            out.extend(_merge_mitm(entries))
+            out.extend(_merge_mitm(entries, name_to_alias))
         else:
             first = True
             for name, lines in entries:
                 if not first:
                     out.append("")
+                alias = name_to_alias.get(name)
                 date_suffix = f" · {module_dates[name]}" if name in module_dates else ""
                 out.append(f"# > {name}{date_suffix}")
                 if name in module_descs:
                     out.append(f"# desc = {module_descs[name]}")
                 if sec == "Script" and name in module_hostnames:
-                    out.append(f"# hostname = {module_hostnames[name]}")
-                if sec == "Script" and name in name_to_alias:
-                    alias = name_to_alias[name]
-                    out.extend(
-                        re.sub(r'^([^=]+?)(\s*=)', f'{{{{{{{alias}}}}}}}\\2', line, count=1)
-                        if "=" in line and not line.startswith("#")
-                        else line
-                        for line in lines
-                    )
-                else:
-                    out.extend(lines)
+                    hint = module_hostnames[name]
+                    if alias:
+                        hint = _sub_alias(hint, alias)
+                    out.append(f"# hostname = {hint}")
+                out.extend(_sub_alias(line, alias) if alias else line for line in lines)
                 first = False
         out.append("")
         written_sections.add(sec)

--- a/Surge/Module/BlockAds.sgmodule
+++ b/Surge/Module/BlockAds.sgmodule
@@ -2,53 +2,53 @@
 #!desc=（个人向）按需收录自 QingRex/LoonKissSurge，自动同步上游，不另行维护，部分 App 需清除缓存或重新安装后才会生效。
 #!category=去广告
 #!remark=广告平台拦截器是去广告基础，优先级需置于本模块之前: https://raw.githubusercontent.com/HotKids/Rules/master/Surge/Module/BlockAdsBase.sgmodule
-#!arguments=removePinnedArticles:false,removeAllBanners:false
-#!date=2026-06-23 01:04:07
+#!arguments=12306:12306,123pan:123pan,eco:eco,ithome:ithome,gotokeep:gotokeep,line:line,tencentmusic:tencentmusic,reddit:reddit,alipan:alipan,iqiyi:iqiyi,baidu:baidu,bilibili:bilibili,kuwo:kuwo,cainiao:cainiao,caixin:caixin,taobao:taobao,dewu:dewu,ddxq:ddxq,flyert:flyert,amap:amap,umetrip:umetrip,jd:jd,coolapk:coolapk,kuaidi100:kuaidi100,tv:tv,moji:moji,pinduoduo:pinduoduo,smzdm:smzdm,sf-express:sf-express,youdao:youdao,163:163,weibo:weibo,qq:qq,ximalaya:ximalaya,xiachufang:xiachufang,goofish:goofish,me:me,xiaoheihe:xiaoheihe,xiaohongshu:xiaohongshu,meituan:meituan,youku:youku,zhihu:zhihu,10010:10010,removePinnedArticles:false,removeAllBanners:false
+#!date=2026-06-23 01:17:19
 
 [MITM]
-hostname = %APPEND% *.amap.com, *.iqiyi.com, *.weibo.cn, *.weibo.com, *.zhihu.com, -i.vip.iqiyi.com, 114.115.217.129, 119.29.29.*, a.line.me, acs.m.goofish.com, acs.m.taobao.com, ad.12306.cn, ad.line-scdn.net, afd.baidu.com, api-app.dc-cn.cn.ecouser.net, api.alipan.com, api.coolapk.com, api.gotokeep.com, api.m.jd.com, api.pinduoduo.com, api.xiachufang.com, api.xiaoheihe.cn, api.zuihuimai.com, api5-normal-m.amemv.com, app-api.smzdm.com, app.dewu.com, appconf.mail.163.com, article-api.smzdm.com, aweme.snssdk.com, bd-api.kuwo.cn, bizapi.alipan.com, businessapi.ksedt.com, buy.line.me, ccsp-egmas.sf-express.com, ci.xiaohongshu.com, cix.line-apps.com, cn-acs.m.cainiao.com, color.jddj.com, crs-event.line.me, d.line-scdn.net, damang.api.mgtv.com, dashi.163.com, dat.ruanmei.com, dc?.bz.mgtv.com, dict.youdao.com, e*.caixin.com, e2e-mtop.cainiao.com, ec-bot-obs.line-scdn.net, ecom.map.baidu.com, edith.xiaohongshu.com, fcard.api.moji.com, g*.caixin.com, g-acs.m.goofish.com, gl-cn-api.ecovacs.cn, gorgon.youdao.com, gql-fed.reddit.com, gql.reddit.com, gslbali.ximalaya.com, gw.line.naver.jp, h5.smzdm.com, haojia-api.smzdm.com, haojia-cdn.smzdm.com, haojia.m.smzdm.com, hb-boom.api.mgtv.com, home.umetrip.com, homepage-api.smzdm.com, lan.line.me, legy.line-apps.com, longquan-mtop.cainiao.com, m*.caixin.com, m.baidu.com, m.client.10010.com, m.ximalaya.com, maicai.api.ddxq.mobi, mall.meituan.com, manga.bilibili.com, me.bz.mgtv.com, member.alipan.com, mme.api.moji.com, mobile-thor.api.mgtv.com, mobile.12306.cn, mobile.api.hunantv.com, mobile.api.mgtv.com, mobile.ximalaya.com, mobilehera.ximalaya.com, mobileso.bz.mgtv.com, mobwsa.ximalaya.com, mp.weixin.qq.com, mwsa.ximalaya.com, napi.ithome.com, nbcps-mtop.cainiao.com, nelo2-col.linecorp.com, netflow-mtop.cainiao.com, newclient.map.baidu.com, obs.line-scdn.net, p.kuaidi100.com, pan.baidu.com, portal-portm.meituan.com, post.m.smzdm.com, psnlz.api.moji.com, ptf.flyertrip.com, push.m.youku.com, rec.xiaohongshu.com, s-api.smzdm.com, scdn.line-apps.com, sch.line.me, search.ximalaya.com, searchwsa.ximalaya.com, sns.api.moji.com, so.xiaohongshu.com, static.line-scdn.net, ucmp-static.sf-express.com, ucmp.sf-express.com, un-acs.youku.com, user-api.smzdm.com, user.api.ddxq.mobi, uts-front.line-apps.com, vdo.api.moji.com, w.line.me, weibo.com, www.123pan.com, www.baidu.com, www.flyert.com.cn, www.xiaohongshu.com, yongche.baidu.com
+hostname = %APPEND% *.{{{amap}}}.com, *.{{{iqiyi}}}.com, *.{{{weibo}}}.cn, *.{{{weibo}}}.com, *.{{{zhihu}}}.com, -i.vip.{{{iqiyi}}}.com, 114.115.217.129, 119.29.29.*, a.{{{line}}}.me, acs.m.{{{goofish}}}.com, acs.m.{{{taobao}}}.com, ad.{{{12306}}}.cn, ad.{{{line}}}-scdn.net, afd.{{{baidu}}}.com, api-app.dc-cn.cn.{{{eco}}}user.net, api.{{{alipan}}}.com, api.{{{coolapk}}}.com, api.{{{gotokeep}}}.com, api.m.{{{jd}}}.com, api.{{{pinduoduo}}}.com, api.{{{xiachufang}}}.com, api.{{{xiaoheihe}}}.cn, api.zuihuimai.com, api5-normal-m.amemv.com, app-api.{{{smzdm}}}.com, app.{{{dewu}}}.com, appconf.mail.{{{163}}}.com, article-api.{{{smzdm}}}.com, awe{{{me}}}.snssdk.com, bd-api.{{{kuwo}}}.cn, bizapi.{{{alipan}}}.com, businessapi.ksedt.com, buy.{{{line}}}.me, ccsp-egmas.{{{sf-express}}}.com, ci.{{{xiaohongshu}}}.com, cix.{{{line}}}-apps.com, cn-acs.m.{{{cainiao}}}.com, color.{{{jd}}}dj.com, crs-event.{{{line}}}.me, d.{{{line}}}-scdn.net, damang.api.mg{{{tv}}}.com, dashi.{{{163}}}.com, dat.ruanmei.com, dc?.bz.mg{{{tv}}}.com, dict.{{{youdao}}}.com, e*.{{{caixin}}}.com, e2e-mtop.{{{cainiao}}}.com, ec-bot-obs.{{{line}}}-scdn.net, ecom.map.{{{baidu}}}.com, edith.{{{xiaohongshu}}}.com, fcard.api.{{{moji}}}.com, g*.{{{caixin}}}.com, g-acs.m.{{{goofish}}}.com, gl-cn-api.{{{eco}}}vacs.cn, gorgon.{{{youdao}}}.com, gql-fed.{{{reddit}}}.com, gql.{{{reddit}}}.com, gslbali.{{{ximalaya}}}.com, gw.{{{line}}}.naver.jp, h5.{{{smzdm}}}.com, haojia-api.{{{smzdm}}}.com, haojia-cdn.{{{smzdm}}}.com, haojia.m.{{{smzdm}}}.com, hb-boom.api.mg{{{tv}}}.com, home.{{{umetrip}}}.com, homepage-api.{{{smzdm}}}.com, lan.{{{line}}}.me, legy.{{{line}}}-apps.com, longquan-mtop.{{{cainiao}}}.com, m*.{{{caixin}}}.com, m.{{{baidu}}}.com, m.client.{{{10010}}}.com, m.{{{ximalaya}}}.com, maicai.api.{{{ddxq}}}.mobi, mall.{{{meituan}}}.com, manga.{{{bilibili}}}.com, me.bz.mg{{{tv}}}.com, member.{{{alipan}}}.com, mme.api.{{{moji}}}.com, mobile-thor.api.mg{{{tv}}}.com, mobile.{{{12306}}}.cn, mobile.api.hunan{{{tv}}}.com, mobile.api.mg{{{tv}}}.com, mobile.{{{ximalaya}}}.com, mobilehera.{{{ximalaya}}}.com, mobileso.bz.mg{{{tv}}}.com, mobwsa.{{{ximalaya}}}.com, mp.weixin.{{{qq}}}.com, mwsa.{{{ximalaya}}}.com, napi.{{{ithome}}}.com, nbcps-mtop.{{{cainiao}}}.com, nelo2-col.{{{line}}}corp.com, netflow-mtop.{{{cainiao}}}.com, newclient.map.{{{baidu}}}.com, obs.{{{line}}}-scdn.net, p.{{{kuaidi100}}}.com, pan.{{{baidu}}}.com, portal-portm.{{{meituan}}}.com, post.m.{{{smzdm}}}.com, psnlz.api.{{{moji}}}.com, ptf.{{{flyert}}}rip.com, push.m.{{{youku}}}.com, rec.{{{xiaohongshu}}}.com, s-api.{{{smzdm}}}.com, scdn.{{{line}}}-apps.com, sch.{{{line}}}.me, search.{{{ximalaya}}}.com, searchwsa.{{{ximalaya}}}.com, sns.api.{{{moji}}}.com, so.{{{xiaohongshu}}}.com, static.{{{line}}}-scdn.net, ucmp-static.{{{sf-express}}}.com, ucmp.{{{sf-express}}}.com, un-acs.{{{youku}}}.com, user-api.{{{smzdm}}}.com, user.api.{{{ddxq}}}.mobi, uts-front.{{{line}}}-apps.com, vdo.api.{{{moji}}}.com, w.{{{line}}}.me, {{{weibo}}}.com, www.{{{123pan}}}.com, www.{{{baidu}}}.com, www.{{{flyert}}}.com.cn, www.{{{xiaohongshu}}}.com, yongche.{{{baidu}}}.com
 
 [Rule]
 # > 12306去广告 · 2025-05-13
 # desc = 过滤12306应用内广告及开屏广告
-DOMAIN,ad.12306.cn,DIRECT,extended-matching
+DOMAIN,ad.{{{12306}}}.cn,DIRECT,extended-matching
 
 # > Keep去广告 · 2025-09-18
 # desc = 移除开屏广告、搜索推荐和弹窗广告，精简底栏和首页标签。移除关注推荐、文章相关推荐和信息流中的课程推广。
-DOMAIN,kad.gotokeep.com,REJECT,extended-matching,pre-matching
+DOMAIN,kad.{{{gotokeep}}}.com,REJECT,extended-matching,pre-matching
 
 # > Line去广告 · 2026-02-12
 # desc = 移除Line各类广告
-URL-REGEX,"^https:\/\/a\.line\.me\/er\/lads\/v\d\/ei\?",REJECT-TINYGIF,extended-matching
-URL-REGEX,"^https:\/\/a\.line\.me\/er\/l.*\/v\d\/event\/image",REJECT-TINYGIF,extended-matching
-URL-REGEX,"^https:\/\/a\.line\.me\/lass\/api\/v\d\/ads$",REJECT-DROP,extended-matching
-URL-REGEX,"^https:\/\/a\.line\.me\/oa\/v\d\/e$",REJECT-DROP,extended-matching
-URL-REGEX,"^https:\/\/a\.line\.me\/cs\/v\d\/oa$",REJECT-DROP,extended-matching
-URL-REGEX,"^https:\/\/w\.line\.me\/adp\/api\/ad\/v\d\/",REJECT-DROP,extended-matching
-URL-REGEX,"^https:\/\/crs-event\.line\.me\/v\d\/imp",REJECT-DROP,extended-matching
-URL-REGEX,"^https:\/\/sch\.line\.me\/api\/v\d\/ads$",REJECT-DROP,extended-matching
-URL-REGEX,"^https:\/\/uts-front\.line-apps\.com\/event$",REJECT-DROP,extended-matching
-URL-REGEX,"^https:\/\/uts-front\.line-apps\.com\/settings$",REJECT-DROP,extended-matching
-URL-REGEX,"^https:\/\/obs\.line-scdn\.net\/0h[a-zA-Z0-9_-]{50}[a-zA-Z0-9_-]*",REJECT-DROP,extended-matching
-URL-REGEX,"^https:\/\/obs\.line-scdn\.net\/0h.+\/(o|m)\d+x\d+$",REJECT-DROP,extended-matching
-URL-REGEX,"^https:\/\/obs\.line-scdn\.net\/0hGH\d",REJECT-DROP,extended-matching
-URL-REGEX,"^https:\/\/obs\.line-scdn\.net\/0h.+\/\d+p\.mp4$",REJECT-DROP,extended-matching
-URL-REGEX,"^https:\/\/obs\.line-scdn\.net\/r\/linecrs\/.+\/m180x180$",REJECT-TINYGIF,extended-matching
-URL-REGEX,"^https:\/\/ec-bot-obs\.line-scdn\.net\/0h[0-9a-zA-Z_-]{50}[0-9a-zA-Z_-]*",REJECT-TINYGIF,extended-matching
-URL-REGEX,"^https:\/\/d\.line-scdn\.net\/lcp-prod-photo\/20.+\.(jpg|jpeg|png)",REJECT-TINYGIF,extended-matching
-URL-REGEX,"^https:\/\/web-mmap-pay\.line-apps\.com\/tw\/liff\/campaign\/v\d\/aggregate\/ad\/banner\/",REJECT-TINYGIF,extended-matching
-URL-REGEX,"^https:\/\/scdn\.line-apps\.com\/lan\/image\/line\/bannerImageEvent\/",REJECT-DROP,extended-matching
-URL-REGEX,"^https:\/\/scdn\.line-apps\.com\/lan\/document\/pageEvent\/line\/ios\/",REJECT-DROP,extended-matching
+URL-REGEX,"^https:\/\/a\.{{{line}}}\.me\/er\/lads\/v\d\/ei\?",REJECT-TINYGIF,extended-matching
+URL-REGEX,"^https:\/\/a\.{{{line}}}\.me\/er\/l.*\/v\d\/event\/image",REJECT-TINYGIF,extended-matching
+URL-REGEX,"^https:\/\/a\.{{{line}}}\.me\/lass\/api\/v\d\/ads$",REJECT-DROP,extended-matching
+URL-REGEX,"^https:\/\/a\.{{{line}}}\.me\/oa\/v\d\/e$",REJECT-DROP,extended-matching
+URL-REGEX,"^https:\/\/a\.{{{line}}}\.me\/cs\/v\d\/oa$",REJECT-DROP,extended-matching
+URL-REGEX,"^https:\/\/w\.{{{line}}}\.me\/adp\/api\/ad\/v\d\/",REJECT-DROP,extended-matching
+URL-REGEX,"^https:\/\/crs-event\.{{{line}}}\.me\/v\d\/imp",REJECT-DROP,extended-matching
+URL-REGEX,"^https:\/\/sch\.{{{line}}}\.me\/api\/v\d\/ads$",REJECT-DROP,extended-matching
+URL-REGEX,"^https:\/\/uts-front\.{{{line}}}-apps\.com\/event$",REJECT-DROP,extended-matching
+URL-REGEX,"^https:\/\/uts-front\.{{{line}}}-apps\.com\/settings$",REJECT-DROP,extended-matching
+URL-REGEX,"^https:\/\/obs\.{{{line}}}-scdn\.net\/0h[a-zA-Z0-9_-]{50}[a-zA-Z0-9_-]*",REJECT-DROP,extended-matching
+URL-REGEX,"^https:\/\/obs\.{{{line}}}-scdn\.net\/0h.+\/(o|m)\d+x\d+$",REJECT-DROP,extended-matching
+URL-REGEX,"^https:\/\/obs\.{{{line}}}-scdn\.net\/0hGH\d",REJECT-DROP,extended-matching
+URL-REGEX,"^https:\/\/obs\.{{{line}}}-scdn\.net\/0h.+\/\d+p\.mp4$",REJECT-DROP,extended-matching
+URL-REGEX,"^https:\/\/obs\.{{{line}}}-scdn\.net\/r\/linecrs\/.+\/m180x180$",REJECT-TINYGIF,extended-matching
+URL-REGEX,"^https:\/\/ec-bot-obs\.{{{line}}}-scdn\.net\/0h[0-9a-zA-Z_-]{50}[0-9a-zA-Z_-]*",REJECT-TINYGIF,extended-matching
+URL-REGEX,"^https:\/\/d\.{{{line}}}-scdn\.net\/lcp-prod-photo\/20.+\.(jpg|jpeg|png)",REJECT-TINYGIF,extended-matching
+URL-REGEX,"^https:\/\/web-mmap-pay\.{{{line}}}-apps\.com\/tw\/liff\/campaign\/v\d\/aggregate\/ad\/banner\/",REJECT-TINYGIF,extended-matching
+URL-REGEX,"^https:\/\/scdn\.{{{line}}}-apps\.com\/lan\/image\/line\/bannerImageEvent\/",REJECT-DROP,extended-matching
+URL-REGEX,"^https:\/\/scdn\.{{{line}}}-apps\.com\/lan\/document\/pageEvent\/line\/ios\/",REJECT-DROP,extended-matching
 
 # > QQ音乐去广告 · 2025-11-10
 # desc = 过滤QQ音乐广告
-DOMAIN,adstats.tencentmusic.com,REJECT,extended-matching,pre-matching
-DOMAIN,ad.tencentmusic.com,REJECT,extended-matching,pre-matching
-DOMAIN,adcdn.tencentmusic.com,REJECT,extended-matching,pre-matching
-DOMAIN,adcdn6.tencentmusic.com,REJECT,extended-matching,pre-matching
-DOMAIN,adexpo.tencentmusic.com,REJECT,extended-matching,pre-matching
-DOMAIN,adclick.tencentmusic.com,REJECT,extended-matching,pre-matching
-DOMAIN,mc.tencentmusic.com,REJECT,extended-matching,pre-matching
+DOMAIN,adstats.{{{tencentmusic}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,ad.{{{tencentmusic}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,adcdn.{{{tencentmusic}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,adcdn6.{{{tencentmusic}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,adexpo.{{{tencentmusic}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,adclick.{{{tencentmusic}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,mc.{{{tencentmusic}}}.com,REJECT,extended-matching,pre-matching
 DOMAIN,monitor.music.qq.com,REJECT,extended-matching,pre-matching
 DOMAIN,tmead.y.qq.com,REJECT,extended-matching,pre-matching
 DOMAIN,tmeadbak.y.qq.com,REJECT,extended-matching,pre-matching
@@ -63,65 +63,65 @@ IP-CIDR,203.107.1.1/24,REJECT,no-resolve,pre-matching
 IP-CIDR,103.44.59.54/32,REJECT,no-resolve,pre-matching
 IP-CIDR,111.63.147.158/32,REJECT,no-resolve,pre-matching
 IP-CIDR,116.211.198.237/32,REJECT,no-resolve,pre-matching
-DOMAIN-SUFFIX,cupid.iqiyi.com,DIRECT,extended-matching
-DOMAIN,api.iqiyi.com,REJECT,extended-matching,pre-matching
-DOMAIN,access.if.iqiyi.com,REJECT,extended-matching,pre-matching
+DOMAIN-SUFFIX,cupid.{{{iqiyi}}}.com,DIRECT,extended-matching
+DOMAIN,api.{{{iqiyi}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,access.if.{{{iqiyi}}}.com,REJECT,extended-matching,pre-matching
 
 # > 叮咚买菜去广告 · 2025-05-13
 # desc = 移除开屏广告、弹窗推广、搜索推荐、信息流广告、悬浮广告、各页面购物推荐、精简我的页面，移除底栏和各页面AI入口。
-DOMAIN,trackercollect.ddxq.mobi,REJECT,extended-matching,pre-matching
+DOMAIN,trackercollect.{{{ddxq}}}.mobi,REJECT,extended-matching,pre-matching
 DOMAIN,ddfs-public.ddimg.mobi,REJECT,extended-matching,pre-matching
-DOMAIN,rttrack.ddxq.mobi,REJECT,extended-matching,pre-matching
+DOMAIN,rttrack.{{{ddxq}}}.mobi,REJECT,extended-matching,pre-matching
 
 # > 高德地图去广告 · 2026-02-22
 # desc = 过滤高德地图开屏广告、各页面推广，精简我的页面。
-DOMAIN,amap-aos-info-nogw.amap.com,REJECT,extended-matching,pre-matching
-DOMAIN,free-aos-cdn-image.amap.com,REJECT,extended-matching,pre-matching
+DOMAIN,amap-aos-info-nogw.{{{amap}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,free-aos-cdn-image.{{{amap}}}.com,REJECT,extended-matching,pre-matching
 DOMAIN-SUFFIX,v.smtcdns.com,REJECT,extended-matching,pre-matching
 
 # > 航旅纵横去广告 · 2025-05-13
 # desc = 过滤航旅纵横广告
-URL-REGEX,"^http?:\/\/(discardrp|startup)\.umetrip\.com\/gateway\/api\/umetrip\/native",REJECT,extended-matching
+URL-REGEX,"^http?:\/\/(discardrp|startup)\.{{{umetrip}}}\.com\/gateway\/api\/umetrip\/native",REJECT,extended-matching
 
 # > 京东去广告 · 2025-05-13
 # desc = 移除京东开屏广告，精简我的页面产品推广。
-URL-REGEX,"^http:\/\/\w{32}\.jddebug\.com\/diagnose\?",REJECT,extended-matching
+URL-REGEX,"^http:\/\/\w{32}\.{{{jd}}}debug\.com\/diagnose\?",REJECT,extended-matching
 
 # > 芒果TV去广告 · 2025-11-09
 # desc = 移除开屏广告、信息流广告、播放页广告，精简我的页面。
-DOMAIN,credits.bz.mgtv.com,REJECT,extended-matching,pre-matching
-DOMAIN,credits2.bz.mgtv.com,REJECT,extended-matching,pre-matching
-DOMAIN,credits3.bz.mgtv.com,REJECT,extended-matching,pre-matching
-DOMAIN,dflow.bz.mgtv.com,REJECT,extended-matching,pre-matching
-DOMAIN,encounter.bz.mgtv.com,REJECT,extended-matching,pre-matching
-DOMAIN,floor.bz.mgtv.com,REJECT,extended-matching,pre-matching
-DOMAIN,layer.bz.mgtv.com,REJECT,extended-matching,pre-matching
-DOMAIN,mob.bz.mgtv.com,REJECT,extended-matching,pre-matching
-DOMAIN,rc-topic-api.bz.mgtv.com,REJECT,extended-matching,pre-matching
-DOMAIN,rprain.bz.mgtv.com,REJECT,extended-matching,pre-matching
-DOMAIN,rprain.log.mgtv.com,REJECT,extended-matching,pre-matching
-DOMAIN,vip.bz.mgtv.com,REJECT,extended-matching,pre-matching
-DOMAIN-SUFFIX,da.mgtv.com,REJECT,extended-matching,pre-matching
+DOMAIN,credits.bz.mg{{{tv}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,credits2.bz.mg{{{tv}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,credits3.bz.mg{{{tv}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,dflow.bz.mg{{{tv}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,encounter.bz.mg{{{tv}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,floor.bz.mg{{{tv}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,layer.bz.mg{{{tv}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,mob.bz.mg{{{tv}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,rc-topic-api.bz.mg{{{tv}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,rprain.bz.mg{{{tv}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,rprain.log.mg{{{tv}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,vip.bz.mg{{{tv}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN-SUFFIX,da.mg{{{tv}}}.com,REJECT,extended-matching,pre-matching
 
 # > 拼多多去广告 · 2026-02-28
 # desc = 移除开屏广告、底栏多多视频、会场入口、聊天页面精选推荐及推广，精简首页和个人中心。
-AND,((URL-REGEX,"^http:\/\/((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/d(\d)?",extended-matching),(USER-AGENT,"*com.xunmeng.pinduoduo*")),REJECT
-AND,((URL-REGEX,"^http:\/\/\[[0-9a-fA-F:]+\]\/d(\d)?\?",extended-matching),(USER-AGENT,"*com.xunmeng.pinduoduo*")),REJECT
-AND,((DOMAIN,api.pinduoduo.com,extended-matching),(PROTOCOL,QUIC)),REJECT
-DOMAIN,titan.pinduoduo.com,REJECT-NO-DROP,extended-matching,pre-matching
-DOMAIN,xg.pinduoduo.com,REJECT,extended-matching,pre-matching
+AND,((URL-REGEX,"^http:\/\/((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/d(\d)?",extended-matching),(USER-AGENT,"*com.xunmeng.{{{pinduoduo}}}*")),REJECT
+AND,((URL-REGEX,"^http:\/\/\[[0-9a-fA-F:]+\]\/d(\d)?\?",extended-matching),(USER-AGENT,"*com.xunmeng.{{{pinduoduo}}}*")),REJECT
+AND,((DOMAIN,api.{{{pinduoduo}}}.com,extended-matching),(PROTOCOL,QUIC)),REJECT
+DOMAIN,titan.{{{pinduoduo}}}.com,REJECT-NO-DROP,extended-matching,pre-matching
+DOMAIN,xg.{{{pinduoduo}}}.com,REJECT,extended-matching,pre-matching
 DOMAIN,cdl-1.pddpic.com,REJECT,extended-matching,pre-matching
-DOMAIN,titan.pinduoduo.com,REJECT,extended-matching,pre-matching
+DOMAIN,titan.{{{pinduoduo}}}.com,REJECT,extended-matching,pre-matching
 DOMAIN,cdl-p2.pddpic.com,REJECT,extended-matching,pre-matching
 DOMAIN,cd-1.pddpic.com,REJECT,extended-matching,pre-matching
-DOMAIN,apm.pinduoduo.com,REJECT,extended-matching,pre-matching
-DOMAIN,th-b.pinduoduo.com,REJECT,extended-matching,pre-matching
-DOMAIN,ta.pinduoduo.com,REJECT,extended-matching,pre-matching
-DOMAIN,th.pinduoduo.com,REJECT,extended-matching,pre-matching
-DOMAIN,th-a.pinduoduo.com,REJECT,extended-matching,pre-matching
-DOMAIN,ta-a.pinduoduo.com,REJECT,extended-matching,pre-matching
-DOMAIN,meta.pinduoduo.com,REJECT,extended-matching,pre-matching
-DOMAIN,apm-a.pinduoduo.com,REJECT,extended-matching,pre-matching
+DOMAIN,apm.{{{pinduoduo}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,th-b.{{{pinduoduo}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,ta.{{{pinduoduo}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,th.{{{pinduoduo}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,th-a.{{{pinduoduo}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,ta-a.{{{pinduoduo}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,meta.{{{pinduoduo}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,apm-a.{{{pinduoduo}}}.com,REJECT,extended-matching,pre-matching
 
 # > 什么值得买去广告 · 2025-11-27
 # desc = 移除开屏广告、信息流广告、各类横幅广告、搜索页广告、文章内广告，移除活动皮肤、精简我的页面。
@@ -129,21 +129,21 @@ DOMAIN,adx-api.zdmimg.com,REJECT,extended-matching,pre-matching
 
 # > 微博去广告 · 2026-02-22
 # desc = 过滤微博广告及去除各部分推广模块
-DOMAIN-SUFFIX,uve.weibo.com,DIRECT,extended-matching
-DOMAIN,huodong.weibo.cn,REJECT,extended-matching,pre-matching
-DOMAIN-SUFFIX,biz.weibo.com,REJECT,extended-matching,pre-matching
+DOMAIN-SUFFIX,uve.{{{weibo}}}.com,DIRECT,extended-matching
+DOMAIN,huodong.{{{weibo}}}.cn,REJECT,extended-matching,pre-matching
+DOMAIN-SUFFIX,biz.{{{weibo}}}.com,REJECT,extended-matching,pre-matching
 
 # > 微信公众号去广告 · 2025-05-13
 # desc = 过滤微信公众号广告
-DOMAIN-SUFFIX,wxs.qq.com,REJECT,extended-matching,pre-matching
+DOMAIN-SUFFIX,wxs.{{{qq}}}.com,REJECT,extended-matching,pre-matching
 
 # > 喜马拉雅去广告 · 2025-07-11
 # desc = 移除开屏广告、播放器广告、各类推荐内容，精简频道和我的页面。
-DOMAIN,adse.ximalaya.com,REJECT,extended-matching,pre-matching
-DOMAIN,adsehera.ximalaya.com,REJECT,extended-matching,pre-matching
-DOMAIN,adse.wsa.ximalaya.com,REJECT,extended-matching,pre-matching
-DOMAIN,adbehavior.ximalaya.com,REJECT,extended-matching,pre-matching
-DOMAIN,adbehavior.wsa.ximalaya.com,REJECT,extended-matching,pre-matching
+DOMAIN,adse.{{{ximalaya}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,adsehera.{{{ximalaya}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,adse.wsa.{{{ximalaya}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,adbehavior.{{{ximalaya}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,adbehavior.wsa.{{{ximalaya}}}.com,REJECT,extended-matching,pre-matching
 
 # > 香港抖音去广告 · 2025-05-13
 # desc = 精简左右侧边栏、移除底栏切换，其余内容后续再完善。
@@ -156,42 +156,42 @@ AND,((OR,((DOMAIN-SUFFIX,bytegecko.com,extended-matching),(DOMAIN-SUFFIX,byteeff
 
 # > 小红书去广告 · 2026-02-22
 # desc = 过滤信息流推广，移除图片及视频水印，如有异常，请先清除缓存再尝试。
-AND,((PROTOCOL,QUIC),(DOMAIN-SUFFIX,xiaohongshu.com,extended-matching)),REJECT
+AND,((PROTOCOL,QUIC),(DOMAIN-SUFFIX,{{{xiaohongshu}}}.com,extended-matching)),REJECT
 
 # > 优酷视频去广告 · 2025-11-14
 # desc = 移除开屏广告、视频广告、信息流广告。其余广告由于请求已加密，故无法移除。
-DOMAIN,push.m.youku.com,DIRECT,extended-matching
-DOMAIN,un-acs.youku.com,DIRECT,extended-matching
+DOMAIN,push.m.{{{youku}}}.com,DIRECT,extended-matching
+DOMAIN,un-acs.{{{youku}}}.com,DIRECT,extended-matching
 DOMAIN,dorangesource.alicdn.com,DIRECT,extended-matching
 DOMAIN,h-adashx.ut.taobao.com,REJECT,extended-matching,pre-matching
-DOMAIN,adx-core.youku.com,REJECT,extended-matching,pre-matching
-DOMAIN,adx-open-service.youku.com,REJECT,extended-matching,pre-matching
-DOMAIN,yk-ssp.ad.youku.com,REJECT,extended-matching,pre-matching
-DOMAIN,cad.youku.com,REJECT,extended-matching,pre-matching
-DOMAIN,ykad-data.youku.com,REJECT,extended-matching,pre-matching
-DOMAIN,yk-ssp.ad.youku.com,REJECT,extended-matching,pre-matching
-DOMAIN,amdc.m.youku.com,REJECT,extended-matching,pre-matching
-DOMAIN,cad.youku.com,REJECT,extended-matching,pre-matching
+DOMAIN,adx-core.{{{youku}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,adx-open-service.{{{youku}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,yk-ssp.ad.{{{youku}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,cad.{{{youku}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,ykad-data.{{{youku}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,yk-ssp.ad.{{{youku}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,amdc.m.{{{youku}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,cad.{{{youku}}}.com,REJECT,extended-matching,pre-matching
 DOMAIN,nbsdk-baichuan.alicdn.com,REJECT,extended-matching,pre-matching
-DOMAIN,youku-crm-product.youku.com,REJECT,extended-matching,pre-matching
-DOMAIN,dr-danmu.youku.com,REJECT,extended-matching,pre-matching
-DOMAIN,group-ssl-danmu-ori.youku.com,REJECT,extended-matching,pre-matching
-DOMAIN,m.atm.youku.com,REJECT,extended-matching,pre-matching
-DOMAIN,mc.atm.youku.com,REJECT,extended-matching,pre-matching
+DOMAIN,youku-crm-product.{{{youku}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,dr-danmu.{{{youku}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,group-ssl-danmu-ori.{{{youku}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,m.atm.{{{youku}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,mc.atm.{{{youku}}}.com,REJECT,extended-matching,pre-matching
 DOMAIN,vali-g1.cp31.ott.cibntv.net,REJECT,extended-matching,pre-matching
 DOMAIN,vali-ugc.cp31.ott.cibntv.net,REJECT,extended-matching,pre-matching
-DOMAIN-SUFFIX,iyes.youku.com,REJECT,extended-matching,pre-matching
+DOMAIN-SUFFIX,iyes.{{{youku}}}.com,REJECT,extended-matching,pre-matching
 DOMAIN,adsmind.ugdtimg.com,REJECT,extended-matching,pre-matching
-DOMAIN,pre-acs.youku.com,REJECT,extended-matching,pre-matching
+DOMAIN,pre-acs.{{{youku}}}.com,REJECT,extended-matching,pre-matching
 DOMAIN,youku-acs.m.taobao.com,REJECT,extended-matching,pre-matching
 
 # > 知乎去广告 · 2026-02-22
 # desc = 移除各部分广告，移除知乎安全中心跳转，建议卸载知乎重新安装。如遇安全中心页面移除失败的，请积极反馈。
-DOMAIN,appcloud.zhihu.com,REJECT,extended-matching,pre-matching
-DOMAIN,appcloud2.in.zhihu.com,REJECT,extended-matching,pre-matching
-DOMAIN,crash2.zhihu.com,REJECT,extended-matching,pre-matching
-DOMAIN,mqtt.zhihu.com,REJECT,extended-matching,pre-matching
-DOMAIN,sugar.zhihu.com,REJECT,extended-matching,pre-matching
+DOMAIN,appcloud.{{{zhihu}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,appcloud2.in.{{{zhihu}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,crash2.{{{zhihu}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,mqtt.{{{zhihu}}}.com,REJECT,extended-matching,pre-matching
+DOMAIN,sugar.{{{zhihu}}}.com,REJECT,extended-matching,pre-matching
 DOMAIN,zxid-m.mobileservice.cn,REJECT,extended-matching,pre-matching
 IP-CIDR,103.41.167.237/32,REJECT,no-resolve,pre-matching
 IP-CIDR,118.89.204.198/32,REJECT,no-resolve,pre-matching
@@ -201,485 +201,485 @@ IP-CIDR6,2402:4e00:1200:ed00:0:9089:6dac:96b6/128,REJECT,no-resolve,pre-matching
 [Map Local]
 # > 123云盘去广告 · 2025-05-13
 # desc = 移除开屏广告、应用内横幅广告。
-^https:\/\/www\.123pan\.com\/api\/config\/get data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/www\.{{{123pan}}}\.com\/api\/config\/get data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > ECOVACS HOME去广告 · 2026-02-27
 # desc = 移除横幅推广，精简底栏。
-^https:\/\/api-app\.dc-cn\.cn\.ecouser\.net\/api\/ecms\/app\/ad\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/gl-cn-api\.ecovacs\.cn\/v1\/private\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api-app\.dc-cn\.cn\.{{{eco}}}user\.net\/api\/ecms\/app\/ad\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/gl-cn-api\.{{{eco}}}vacs\.cn\/v1\/private\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > Keep去广告 · 2025-09-18
 # desc = 移除开屏广告、搜索推荐和弹窗广告，精简底栏和首页标签。移除关注推荐、文章相关推荐和信息流中的课程推广。
-^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/ad\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.gotokeep\.com\/search\/v6\/default\/keyword\/list\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.gotokeep\.com\/twins\/v4\/feed\/followPage\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.gotokeep\.com\/twins\/union\/feed\/function\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.gotokeep\.com\/guide-webapp\/v1\/popup\/getPopUp\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.gotokeep\.com\/search\/v5\/hotCourse\/list$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.gotokeep\.com\/search\/v4\/hotHashtag\/list$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.gotokeep\.com\/search\/v4\/hotword\/list\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/ad\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{gotokeep}}}\.com\/search\/v6\/default\/keyword\/list\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{gotokeep}}}\.com\/twins\/v4\/feed\/followPage\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{gotokeep}}}\.com\/twins\/union\/feed\/function\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{gotokeep}}}\.com\/guide-webapp\/v1\/popup\/getPopUp\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{gotokeep}}}\.com\/search\/v5\/hotCourse\/list$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{gotokeep}}}\.com\/search\/v4\/hotHashtag\/list$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{gotokeep}}}\.com\/search\/v4\/hotword\/list\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 阿里云盘去广告 · 2025-05-13
 # desc = 移除首页广告横幅、弹窗和顶部奖励。
-^https:\/\/member\.alipan\.com\/v2\/activity\/sign_in_luckyBottle data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.alipan\.com\/adrive\/v1\/file\/getTopFolders data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/member\.{{{alipan}}}\.com\/v2\/activity\/sign_in_luckyBottle data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{alipan}}}\.com\/adrive\/v1\/file\/getTopFolders data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 爱奇艺去广告 · 2025-05-13
 # desc = 移除开屏广告、焦点图广告、瀑布流广告、搜索页面广告、移除青少年弹窗，精简底栏和我的页面。
-^https?:\/\/iface2\.iqiyi\.com\/control\/3\.0\/init_proxy\? data-type=text data="{}" status-code=200
-^https?:\/\/act\.vip\.iqiyi\.com\/interact\/api\/v2\/show\? data-type=text data="{}" status-code=200
-^https?:\/\/iface2\.iqiyi\.com\/ivos\/interact\/video\/data\? data-type=text data="{}" status-code=200
-^https?:\/\/iface2\.iqiyi\.com\/video\/3\.0\/v_interface_proxy\? data-type=text data="{}" status-code=200
-^https?:\/\/iface2\.iqiyi\.com\/views_pop\/3\.0\/pop_control\? data-type=text data="{}" status-code=200
+^https?:\/\/iface2\.{{{iqiyi}}}\.com\/control\/3\.0\/init_proxy\? data-type=text data="{}" status-code=200
+^https?:\/\/act\.vip\.{{{iqiyi}}}\.com\/interact\/api\/v2\/show\? data-type=text data="{}" status-code=200
+^https?:\/\/iface2\.{{{iqiyi}}}\.com\/ivos\/interact\/video\/data\? data-type=text data="{}" status-code=200
+^https?:\/\/iface2\.{{{iqiyi}}}\.com\/video\/3\.0\/v_interface_proxy\? data-type=text data="{}" status-code=200
+^https?:\/\/iface2\.{{{iqiyi}}}\.com\/views_pop\/3\.0\/pop_control\? data-type=text data="{}" status-code=200
 
 # > 百度地图去广告 · 2025-05-13
 # desc = 移除开屏广告、出行页面推广、周边页面推广、打车页面推广，精简我的页面。此插件需要IPA签名方可使用，App Store用户请勿使用此插件，务必点击下方主页链接查看详细教程。
-^https:\/\/afd\.baidu\.com\/afd\/entry\?action=(update|query) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/yongche\.baidu\.com\/gomarketing\/api\/popup\/getentrancecordovaurl$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/yongche\.baidu\.com\/goorder\/passenger\/cobuild\/pull\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/yongche\.baidu\.com\/goorder\/passenger\/operationgirdle$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/yongche\.baidu\.com\/goorder\/passenger\/baseinfo$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/ecom\.map\.baidu\.com\/ad-ops\/afd\/popup\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/maphotel\.baidu\.com\/hotel\/goextranet\/activity\/detail\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/afd\.{{{baidu}}}\.com\/afd\/entry\?action=(update|query) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/yongche\.{{{baidu}}}\.com\/gomarketing\/api\/popup\/getentrancecordovaurl$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/yongche\.{{{baidu}}}\.com\/goorder\/passenger\/cobuild\/pull\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/yongche\.{{{baidu}}}\.com\/goorder\/passenger\/operationgirdle$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/yongche\.{{{baidu}}}\.com\/goorder\/passenger\/baseinfo$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/ecom\.map\.{{{baidu}}}\.com\/ad-ops\/afd\/popup\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/maphotel\.{{{baidu}}}\.com\/hotel\/goextranet\/activity\/detail\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 百度网盘去广告 · 2026-01-02
 # desc = 移除开屏广告、首页卡片广告、传输页面广告、各类弹窗，精简侧拉抽屉和我的页面。
-^https:\/\/pan\.baidu\.com\/api\/getconfig\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/pan\.baidu\.com\/api\/getsyscfg\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/pan\.baidu\.com\/api\/taskscore\/tasklist\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/pan\.baidu\.com\/act\/api\/activityentry\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/pan\.baidu\.com\/rest\/\d\.\d\/pcs\/adv\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/pan\.baidu\.com\/api\/plugin\/get\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/pan\.baidu\.com\/recommend\/query\/list\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/pan\.{{{baidu}}}\.com\/api\/getconfig\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/pan\.{{{baidu}}}\.com\/api\/getsyscfg\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/pan\.{{{baidu}}}\.com\/api\/taskscore\/tasklist\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/pan\.{{{baidu}}}\.com\/act\/api\/activityentry\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/pan\.{{{baidu}}}\.com\/rest\/\d\.\d\/pcs\/adv\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/pan\.{{{baidu}}}\.com\/api\/plugin\/get\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/pan\.{{{baidu}}}\.com\/recommend\/query\/list\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 哔哩哔哩漫画去广告 · 2025-05-13
 # desc = 移除开屏广告、应用内悬浮窗、各类横幅广告、你可能喜欢、小说推荐、首页弹窗，精简首页标签、底栏活动按钮和我的页面。
-^https:\/\/manga\.bilibili\.com\/twirp\/comic\.v\d\.Comic\/GetActivityTab data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/manga\.bilibili\.com\/twirp\/comic\.v\d\.Comic\/GetBubbles data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/manga\.bilibili\.com\/twirp\/comic\.v\d\.Comic\/GetCommonBanner data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/manga\.bilibili\.com\/twirp\/comic\.v\d\.Comic\/SearchBanner data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/manga\.bilibili\.com\/twirp\/user\.v\d\.SeasonV\d\/GetSeasonInfo data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/manga\.bilibili\.com\/twirp\/bookshelf\.v\d\.Bookshelf\/ListEmptyRecommend data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/manga\.bilibili\.com\/twirp\/bookshelf\.v\d\.Bookshelf\/NovelRecommend data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/manga\.bilibili\.com\/twirp\/novel\.v\d\.Novel\/MoreRecommend data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/manga\.bilibili\.com\/twirp\/comic\.v\d\.Comic\/AppInit data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/manga\.bilibili\.com\/twirp\/comic\.v\d\.Comic\/ListFlash data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/manga\.{{{bilibili}}}\.com\/twirp\/comic\.v\d\.Comic\/GetActivityTab data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/manga\.{{{bilibili}}}\.com\/twirp\/comic\.v\d\.Comic\/GetBubbles data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/manga\.{{{bilibili}}}\.com\/twirp\/comic\.v\d\.Comic\/GetCommonBanner data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/manga\.{{{bilibili}}}\.com\/twirp\/comic\.v\d\.Comic\/SearchBanner data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/manga\.{{{bilibili}}}\.com\/twirp\/user\.v\d\.SeasonV\d\/GetSeasonInfo data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/manga\.{{{bilibili}}}\.com\/twirp\/bookshelf\.v\d\.Bookshelf\/ListEmptyRecommend data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/manga\.{{{bilibili}}}\.com\/twirp\/bookshelf\.v\d\.Bookshelf\/NovelRecommend data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/manga\.{{{bilibili}}}\.com\/twirp\/novel\.v\d\.Novel\/MoreRecommend data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/manga\.{{{bilibili}}}\.com\/twirp\/comic\.v\d\.Comic\/AppInit data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/manga\.{{{bilibili}}}\.com\/twirp\/comic\.v\d\.Comic\/ListFlash data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 波点音乐去广告 · 2025-08-31
 # desc = 精简应用配置，禁用P2P传输。移除开屏广告、横幅推广、悬浮广告、歌曲广告、商城入口、搜索推广、评论区推广、试听语音提醒。
-^https:\/\/bd-api\.kuwo\.cn\/api\/(play|service|advert)\/advert\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/bd-api\.kuwo\.cn\/api\/service\/banner\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/bd-api\.kuwo\.cn\/api\/ucenter\/vip\/give\/config\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/bd-api\.kuwo\.cn\/api\/service\/home\/module\?.*&moduleId=6 data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/bd-api\.kuwo\.cn\/api\/pay\/vip\/lowPriceText\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/bd-api\.kuwo\.cn\/api\/service\/global\/config\/vipEnter\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/bd-api\.kuwo\.cn\/api\/popup\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/bd-api\.kuwo\.cn\/api\/pay\/vip\/invitation\/swell\/popup\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/bd-api\.kuwo\.cn\/api\/service\/version\/popup\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/bd-api\.kuwo\.cn\/api\/pay\/vip\/invitation\/assist\/popup\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/bd-api\.kuwo\.cn\/api\/pay\/h5\/common\/popup\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/(play|service|advert)\/advert\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/service\/banner\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/ucenter\/vip\/give\/config\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/service\/home\/module\?.*&moduleId=6 data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/pay\/vip\/lowPriceText\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/service\/global\/config\/vipEnter\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/popup\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/pay\/vip\/invitation\/swell\/popup\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/service\/version\/popup\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/pay\/vip\/invitation\/assist\/popup\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/pay\/h5\/common\/popup\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 财新去广告 · 2025-05-13
 # desc = 过滤财新广告
-^https:\/\/entities\.caixin\.com\/api\/(dataplus\/promotionHints|public\/push\/appIndex|public\/recommendNews) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/gateway\.caixin\.com\/api\/app-api\/cxAdInfo\/selectIndexAdInfo data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/mappsv5\.caixin\.com\/channelv5\/article_ad_ios_info\.json data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/gg\.caixin\.com\/s\?z=caixin&slot=\d+ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/msgapi\.caixin\.com\/msg_api\/annmsg\/annlist data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/entities\.{{{caixin}}}\.com\/api\/(dataplus\/promotionHints|public\/push\/appIndex|public\/recommendNews) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/gateway\.{{{caixin}}}\.com\/api\/app-api\/cxAdInfo\/selectIndexAdInfo data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/mappsv5\.{{{caixin}}}\.com\/channelv5\/article_ad_ios_info\.json data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/gg\.{{{caixin}}}\.com\/s\?z=caixin&slot=\d+ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/msgapi\.{{{caixin}}}\.com\/msg_api\/annmsg\/annlist data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 大麦去广告 · 2025-11-09
 # desc = 移除开屏广告、轮播图广告和弹窗广告，移除搜索填充词和专属推荐。
-^https:\/\/acs\.m\.taobao\.com\/gw\/mtop\.damai\.wireless\.home\.welcome\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/acs\.m\.taobao\.com\/gw\/mtop\.damai\.mec\.popup\.get\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/acs\.m\.{{{taobao}}}\.com\/gw\/mtop\.damai\.wireless\.home\.welcome\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/acs\.m\.{{{taobao}}}\.com\/gw\/mtop\.damai\.mec\.popup\.get\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 得物去广告 · 2025-12-05
 # desc = 移除开屏广告、弹窗、搜索词填充、热搜榜、猜你想搜、推荐关注、推荐信息流，精简消息中心和我的页面。
-^https:\/\/app\.dewu\.com\/api\/v1\/app\/advertisement\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/app\.dewu\.com\/hacking-newbie\/v1\/app\/coupon\/module\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/app\.dewu\.com\/api\/v1\/app\/search\/lexicon\/v3\/background_words\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/app\.dewu\.com\/api\/v1\/app\/search\/lexicon\/v1\/rank_words\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/app\.dewu\.com\/sns-rec\/v1\/attention\/feed\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/app\.dewu\.com\/sns-rec\/v1\/search\/word-skip\/new-list\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/app\.dewu\.com\/sns-rec\/v1\/search\/hotword-list\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/app\.{{{dewu}}}\.com\/api\/v1\/app\/advertisement\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/app\.{{{dewu}}}\.com\/hacking-newbie\/v1\/app\/coupon\/module\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/app\.{{{dewu}}}\.com\/api\/v1\/app\/search\/lexicon\/v3\/background_words\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/app\.{{{dewu}}}\.com\/api\/v1\/app\/search\/lexicon\/v1\/rank_words\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/app\.{{{dewu}}}\.com\/sns-rec\/v1\/attention\/feed\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/app\.{{{dewu}}}\.com\/sns-rec\/v1\/search\/word-skip\/new-list\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/app\.{{{dewu}}}\.com\/sns-rec\/v1\/search\/hotword-list\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 叮咚买菜去广告 · 2025-05-13
 # desc = 移除开屏广告、弹窗推广、搜索推荐、信息流广告、悬浮广告、各页面购物推荐、精简我的页面，移除底栏和各页面AI入口。
 ^https?:\/\/119\.29\.29\.\d+\/d data-type=text data=" " status-code=200
-^https:\/\/maicai\.api\.ddxq\.mobi\/vip\/getVipAd\/\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/maicai\.api\.ddxq\.mobi\/homeApi\/marketingNotice\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/maicai\.api\.ddxq\.mobi\/search\/rollHotKeyword\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/maicai\.api\.ddxq\.mobi\/search\/rankingList\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/maicai\.api\.ddxq\.mobi\/search\/hotKeyword\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/maicai\.api\.ddxq\.mobi\/order\/getRecommend$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/maicai\.api\.ddxq\.mobi\/homeApi\/userLike\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/user\.api\.ddxq\.mobi\/userportal-service\/api\/v1\/user\/queryMyPage\/\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/maicai\.api\.ddxq\.mobi\/guide-service\/userLike\/flowData$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/maicai\.api\.{{{ddxq}}}\.mobi\/vip\/getVipAd\/\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/maicai\.api\.{{{ddxq}}}\.mobi\/homeApi\/marketingNotice\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/maicai\.api\.{{{ddxq}}}\.mobi\/search\/rollHotKeyword\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/maicai\.api\.{{{ddxq}}}\.mobi\/search\/rankingList\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/maicai\.api\.{{{ddxq}}}\.mobi\/search\/hotKeyword\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/maicai\.api\.{{{ddxq}}}\.mobi\/order\/getRecommend$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/maicai\.api\.{{{ddxq}}}\.mobi\/homeApi\/userLike\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/user\.api\.{{{ddxq}}}\.mobi\/userportal-service\/api\/v1\/user\/queryMyPage\/\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/maicai\.api\.{{{ddxq}}}\.mobi\/guide-service\/userLike\/flowData$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 飞客去广告 · 2025-05-13
 # desc = 移除开屏广告、首页广告、板块广告、帖内广告和我的页面广告。
-^https:\/\/www\.flyert\.com\.cn\/api\/mobile\/index\.php\?module=vip_coupon data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/ptf\.flyertrip\.com\/static\/img\/common\/ic_plate_mine_button\.png data-type=tiny-gif status-code=200
-^https:\/\/www\.flyert\.com\.cn\/api\/mobile\/index\.php\?module=getdata data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/www\.{{{flyert}}}\.com\.cn\/api\/mobile\/index\.php\?module=vip_coupon data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/ptf\.{{{flyert}}}rip\.com\/static\/img\/common\/ic_plate_mine_button\.png data-type=tiny-gif status-code=200
+^https:\/\/www\.{{{flyert}}}\.com\.cn\/api\/mobile\/index\.php\?module=getdata data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 飞猪旅行去广告 · 2025-11-25
 # desc = 移除开屏广告、精简我的页面。
-^https:\/\/acs\.m\.taobao\.com\/gw\/mtop\.fliggy\.crm\.screen\.allresource\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/acs\.m\.taobao\.com\/gw\/mtop\.fliggy\.crm\.screen\.predict\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/acs\.m\.taobao\.com\/gw\/mtop\.fliggy\.tripzoo\.new\.couponlist\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/acs\.m\.taobao\.com\/gw\/mtop\.trip\.my\.recommendcard\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/acs\.m\.taobao\.com\/gw\/mtop\.fliggy\.recommend\.common\.guess\.tab\.feeds\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/acs\.m\.{{{taobao}}}\.com\/gw\/mtop\.fliggy\.crm\.screen\.allresource\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/acs\.m\.{{{taobao}}}\.com\/gw\/mtop\.fliggy\.crm\.screen\.predict\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/acs\.m\.{{{taobao}}}\.com\/gw\/mtop\.fliggy\.tripzoo\.new\.couponlist\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/acs\.m\.{{{taobao}}}\.com\/gw\/mtop\.trip\.my\.recommendcard\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/acs\.m\.{{{taobao}}}\.com\/gw\/mtop\.fliggy\.recommend\.common\.guess\.tab\.feeds\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 高德地图去广告 · 2026-02-22
 # desc = 过滤高德地图开屏广告、各页面推广，精简我的页面。
-^https:\/\/m5-zb\.amap\.com\/ws\/ride\/home\/page\/get_commuting_card\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/m5\.amap\.com\/ws\/shield\/search_business\/process\/orderList\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/m5\.amap\.com\/ws\/shield\/search\/new_hotword\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/m5\.amap\.com\/ws\/faas\/amap-navigation\/card-service-(?:car-end|route-plan) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/m5\.amap\.com\/ws\/shield\/search_poi\/tips_adv\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/oss\.amap\.com\/ws\/banner\/lists\/\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/ai\.amap\.com\/v1\/ai_rec\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/m5\.amap\.com\/ws\/aos\/main\/page\/product\/list\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/m5\.amap\.com\/ws\/faas\/amap-navigation\/(?:main-page-assets|main-page-location|ridewalk-end-fc|usr-profile-fc\/homeV2) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/m5\.amap\.com\/ws\/(?:mapapi\/hint_text\/offline_data|message\/notice\/list|shield\/search\/new_hotword) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/m5\.amap\.com\/ws\/shield\/scene\/recommend\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/m5\.amap\.com\/ws\/valueadded\/weather\/v2\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/sns\.amap\.com\/ws\/msgbox\/pull_mp\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/m5-zb\.amap\.com\/ws\/boss\/(?:order\/car\/(?:feedback\/get_card_questions|feedback\/viptips|king_toolbox_car_bubble|remark\/satisfactionConf|rights_information)|tips\/onscene_visual_optimization) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/m5-zb\.amap\.com\/ws\/boss\/(?:pay\/web\/paySuccess\/info\/request|transportation\/diversion\/resource\/driving) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/m5-zb\.{{{amap}}}\.com\/ws\/ride\/home\/page\/get_commuting_card\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/m5\.{{{amap}}}\.com\/ws\/shield\/search_business\/process\/orderList\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/m5\.{{{amap}}}\.com\/ws\/shield\/search\/new_hotword\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/m5\.{{{amap}}}\.com\/ws\/faas\/amap-navigation\/card-service-(?:car-end|route-plan) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/m5\.{{{amap}}}\.com\/ws\/shield\/search_poi\/tips_adv\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/oss\.{{{amap}}}\.com\/ws\/banner\/lists\/\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/ai\.{{{amap}}}\.com\/v1\/ai_rec\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/m5\.{{{amap}}}\.com\/ws\/aos\/main\/page\/product\/list\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/m5\.{{{amap}}}\.com\/ws\/faas\/amap-navigation\/(?:main-page-assets|main-page-location|ridewalk-end-fc|usr-profile-fc\/homeV2) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/m5\.{{{amap}}}\.com\/ws\/(?:mapapi\/hint_text\/offline_data|message\/notice\/list|shield\/search\/new_hotword) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/m5\.{{{amap}}}\.com\/ws\/shield\/scene\/recommend\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/m5\.{{{amap}}}\.com\/ws\/valueadded\/weather\/v2\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/sns\.{{{amap}}}\.com\/ws\/msgbox\/pull_mp\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/m5-zb\.{{{amap}}}\.com\/ws\/boss\/(?:order\/car\/(?:feedback\/get_card_questions|feedback\/viptips|king_toolbox_car_bubble|remark\/satisfactionConf|rights_information)|tips\/onscene_visual_optimization) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/m5-zb\.{{{amap}}}\.com\/ws\/boss\/(?:pay\/web\/paySuccess\/info\/request|transportation\/diversion\/resource\/driving) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 京东去广告 · 2025-05-13
 # desc = 移除京东开屏广告，精简我的页面产品推广。
-^https:\/\/api\.m\.jd\.com\/client\.action\?functionId=(searchBoxWord|stationPullService|uniformRecommend[06]) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.m\.{{{jd}}}\.com\/client\.action\?functionId=(searchBoxWord|stationPullService|uniformRecommend[06]) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 京东外卖去广告 · 2025-11-28
 # desc = 移除首页推广、点评页面非美食内容、购物车及我的页面推荐、搜索发现、搜索榜单，精简我的页面。
-^https:\/\/color\.jddj\.com\/client\.action\?functionId=uniformRecommend data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/color\.jddj\.com\/client\.action\?functionId=search_recommendRanking$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/color\.{{{jd}}}dj\.com\/client\.action\?functionId=uniformRecommend data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/color\.{{{jd}}}dj\.com\/client\.action\?functionId=search_recommendRanking$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 酷安去广告 · 2025-05-13
 # desc = 过滤酷安广告
-^https:\/\/api\.coolapk\.com\/v6\/search\?.*type=hotSearch data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{coolapk}}}\.com\/v6\/search\?.*type=hotSearch data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 快递100去广告 · 2025-05-13
 # desc = 移除横幅广告、弹窗广告，精简首页。
-^https?:\/\/p\.kuaidi100\.com\/advertisement\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https?:\/\/p\.kuaidi100\.com\/e-commerce\/act\/actInfo\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https?:\/\/p\.kuaidi100\.com\/apicenter\/card\.dox data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https?:\/\/p\.{{{kuaidi100}}}\.com\/advertisement\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https?:\/\/p\.{{{kuaidi100}}}\.com\/e-commerce\/act\/actInfo\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https?:\/\/p\.{{{kuaidi100}}}\.com\/apicenter\/card\.dox data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 芒果TV去广告 · 2025-11-09
 # desc = 移除开屏广告、信息流广告、播放页广告，精简我的页面。
-^https:\/\/dc\.bz\.mgtv\.com\/dynamic\/v\d\/skin\/config\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/dc\.bz\.mgtv\.com\/dynamic\/v\d\/channel\/ads\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^http:\/\/mobileso\.bz\.mgtv\.com\/spotlight\/search\/v\d\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/damang\.api\.mgtv\.com\/station\/album\/red\/dot\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/hb-boom\.api\.mgtv\.com\/release\/pullReleaseInfo$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/mobile\.api\.mgtv\.com\/v\d\/mobile\/checkUpdate\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https?:\/\/mobileso\.bz\.mgtv\.com\/mobile\/recommend\/v\d\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/dc\.bz\.mg{{{tv}}}\.com\/dynamic\/v\d\/skin\/config\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/dc\.bz\.mg{{{tv}}}\.com\/dynamic\/v\d\/channel\/ads\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^http:\/\/mobileso\.bz\.mg{{{tv}}}\.com\/spotlight\/search\/v\d\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/damang\.api\.mg{{{tv}}}\.com\/station\/album\/red\/dot\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/hb-boom\.api\.mg{{{tv}}}\.com\/release\/pullReleaseInfo$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/mobile\.api\.mg{{{tv}}}\.com\/v\d\/mobile\/checkUpdate\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https?:\/\/mobileso\.bz\.mg{{{tv}}}\.com\/mobile\/recommend\/v\d\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 墨迹天气去广告 · 2025-05-13
 # desc = 移除天气页面横幅、工具栏，移除时景关注页面推荐，精简我的页面。
-^https:\/\/vdo\.api\.moji\.com\/shortvideo\/card\/subscribe$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/vdo\.api\.moji\.com\/shortvideo\/video\/index_flow\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/vdo\.api\.moji\.com\/shortvideo\/video_user\/hotGuyRcm\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/vdo\.api\.moji\.com\/shortvideo\/zone\/follow_src_zone\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/sns\.api\.moji\.com\/user\/dynamic_v9\/json\/someone_interest\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/vdo\.api\.{{{moji}}}\.com\/shortvideo\/card\/subscribe$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/vdo\.api\.{{{moji}}}\.com\/shortvideo\/video\/index_flow\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/vdo\.api\.{{{moji}}}\.com\/shortvideo\/video_user\/hotGuyRcm\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/vdo\.api\.{{{moji}}}\.com\/shortvideo\/zone\/follow_src_zone\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/sns\.api\.{{{moji}}}\.com\/user\/dynamic_v9\/json\/someone_interest\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 拼多多去广告 · 2026-02-28
 # desc = 移除开屏广告、底栏多多视频、会场入口、聊天页面精选推荐及推广，精简首页和个人中心。
-^https:\/\/api\.pinduoduo\.com\/api\/aristotle\/unrated_order_for_unreceived_tab\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.pinduoduo\.com\/api\/aristotle\/query_order_list_tabs_element\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.pinduoduo\.com\/api\/aquarius\/hungary\/global\/homepage\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.pinduoduo\.com\/api\/caterham\/v3\/query\/order_express_group\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.pinduoduo\.com\/search_hotquery\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.pinduoduo\.com\/api\/zaire_biz\/chat\/resource\/get_list_data\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.pinduoduo\.com\/api\/caterham\/v3\/query\/new_chat_group\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.pinduoduo\.com\/api\/alexa\/goods\/back_up\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.pinduoduo\.com\/api\/caterham\/v3\/query\/personal\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.pinduoduo\.com\/api\/brand-olay\/goods_detail\/bybt_guide\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.pinduoduo\.com\/api\/engels\/reviews\/require\/append\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.pinduoduo\.com\/api\/caterham\/v3\/query\/my_order_group\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.pinduoduo\.com\/api\/caterham\/v3\/query\/likes\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.pinduoduo\.com\/api\/phantom\/gbdbpdv\/extra\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.pinduoduo\.com\/api\/manufacturer\/cross\/shortcut\/list\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.pinduoduo\.com\/api\/dunkirk\/liveactivity\/push\/create\/url\/report\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.pinduoduo\.com\/api\/growth\/nagato\/app\/index\/gather\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.pinduoduo\.com\/api\/engels\/wait\/receive\/review\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.pinduoduo\.com\/api\/buffon\/nasus\/recommend\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/aristotle\/unrated_order_for_unreceived_tab\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/aristotle\/query_order_list_tabs_element\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/aquarius\/hungary\/global\/homepage\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/caterham\/v3\/query\/order_express_group\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{pinduoduo}}}\.com\/search_hotquery\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/zaire_biz\/chat\/resource\/get_list_data\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/caterham\/v3\/query\/new_chat_group\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/alexa\/goods\/back_up\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/caterham\/v3\/query\/personal\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/brand-olay\/goods_detail\/bybt_guide\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/engels\/reviews\/require\/append\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/caterham\/v3\/query\/my_order_group\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/caterham\/v3\/query\/likes\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/phantom\/gbdbpdv\/extra\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/manufacturer\/cross\/shortcut\/list\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/dunkirk\/liveactivity\/push\/create\/url\/report\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/growth\/nagato\/app\/index\/gather\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/engels\/wait\/receive\/review\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/buffon\/nasus\/recommend\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 什么值得买去广告 · 2025-11-27
 # desc = 移除开屏广告、信息流广告、各类横幅广告、搜索页广告、文章内广告，移除活动皮肤、精简我的页面。
-^https:\/\/app-api\.smzdm\.com\/util\/loading\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/app-api\.smzdm\.com\/mychannel\/list$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/user-api\.smzdm\.com\/vip\/bottom_card_list\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/article-api\.smzdm\.com\/publish\/get_bubble\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/s-api\.smzdm\.com\/sou\/search_default_keyword\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/s-api\.smzdm\.com\/sou\/popup_coupon\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/app-api\.{{{smzdm}}}\.com\/util\/loading\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/app-api\.{{{smzdm}}}\.com\/mychannel\/list$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/user-api\.{{{smzdm}}}\.com\/vip\/bottom_card_list\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/article-api\.{{{smzdm}}}\.com\/publish\/get_bubble\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/s-api\.{{{smzdm}}}\.com\/sou\/search_default_keyword\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/s-api\.{{{smzdm}}}\.com\/sou\/popup_coupon\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 顺丰速运去广告 · 2026-02-23
 # desc = 移除开屏广告、首页下拉抽屉、首页推广、应用内悬浮窗、横幅广告，移除主题，精简我的页面。
-^https:\/\/ccsp-egmas\.sf-express\.com\/cx-app-base\/base\/app\/ad\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/ucmp\.sf-express\.com\/proxy\/esgcempcore\/memberGoods\/pointMallService\/goodsList$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/ucmp(-static)?\.sf-express\.com\/proxy\/ccspBase\/module-config\/(login\/)?query\? data-type=text data="{"version":"2.0","success":true,"obj":[{"positionName":"APP2025","positionChannel":"app","sceneList":[{"urlType":"webview","sceneCode":"ddcb36295d5d2939ba4bbe2e5e02a4d8","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29130,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":0,"sceneName":"寄快递","updateTime":"2026-02-06 18:55:15","url":"{ \"needLogin\": true, \"classify\": \"MY_SERVICE\", \"params\": { \"jumpName\": \"快速寄件\" } }","positionId":"app-index-2025","createTime":"2026-02-06 18:55:15","background":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/15FF24D0AC094758ACD2600331214A1A.png","typeId":"primary","typeLabel":"一级入口","status":1},{"urlType":"webview","sceneCode":"71e3cad43945360ffa6299644d9fbce0","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29132,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":2,"sceneName":"校园一级","updateTime":"2026-02-06 18:55:16","url":"{\"needLogin\":true,\"clientVersionCode\": \"1096920\",\"params\":{\"isEncode\":true,\"domain\":\"mcs-mimp-web.sf-express.com\",\"extendNoSign\":\"&source=SFAPP&bizCode=6196@UHB1a1hjd0V1RDR4a3RTRnJhMmJVMTA1SnhreUh6Vk43U0xYMWZ6aWk4Wk1XclA3MXFRT3dhUjZnK29KY2lSZg==\",\"isLanguage\":true,\"needReqTime\":\"1\",\"needSign\":true,\"source\":{\"uri\":\"https://mcs-mimp-web.sf-express.com/mcs-mimp/share/app/shareRedirect\"},\"mustUserInfo\":true},\"pageRoute\":\"WedViewPage\"}","positionId":"app-index-2025","createTime":"2026-02-06 18:55:16","background":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/04560114349E4DCF9F9C82348D5FD5B8.png","typeId":"primary","typeLabel":"一级入口","status":1},{"urlType":"webview","sceneCode":"d3cf8b8a7be155edc8d507b21a491401","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29134,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":4,"sceneName":"寄大件","updateTime":"2026-02-06 18:55:17","url":"{ \"params\": { \"source\": { \"uri\": \"https://ucmp.sf-express.com/we/cxmodules/large-items-aggregation\" }, \"needSign\": true, \"isEncode\": true }, \"needLogin\": true, \"pageRoute\": \"WedViewPage\", \"clientVersionCode\": 1095600 }","positionId":"app-index-2025","createTime":"2026-02-06 18:55:17","background":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/A234EFA247C04A6A91DEBD06E91BA24B.png","typeId":"primary","typeLabel":"一级入口","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/781D64D298F148F7892A7E705D8C2B1D.png","urlType":"webview","sceneCode":"b83fbeb018acfafc5ad8b38362cf684a","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29136,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":6,"sceneName":"同城急送","subjectTagContent":"低至3折","updateTime":"2025-11-10 10:45:03","url":"{ \"params\": { \"title\": \"同城急送\", \"source\": { \"uri\": \"https://shopic.sf-express.com/crm/webapp?platform=syapp\" }, \"domain\": \"shopic.sf-express.com\", \"launch\": { \"text\": \"服务提示：深圳市顺丰同城物流有限公司向您提供相关服务并承担法律责任\", \"onlyOne\": true, \"delayTime\": 2, \"iconUrl\": \"https://ucmp-static.sf-express.com/appmsoss/app-ms/manage/f082fcd320254d5aaca06316fff9ef8c.jpeg\" } }, \"needLogin\": true, \"pageRoute\": \"WedViewPage\" }","subjectContent":"同城急送","positionId":"app-index-2025","createTime":"2025-11-10 10:45:03","typeId":"business","typeLabel":"BU业务入口","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/52B9DF2E9E6742DFAD64EF4F786CBDE5.png","urlType":"webview","sceneCode":"eabfae966908cdf6947f67bd58618b80","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29137,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":7,"sceneName":"港澳台寄递聚合","updateTime":"2025-11-10 10:45:07","url":"{ \"params\": { \"source\": { \"uri\": \"https://ucmp.sf-express.com/wxaccess/app/auth/CX_REGION_APP\" }, \"needSign\": true, \"extendNoSign\": \"&reserved=scene%3Dhmt%26source%3Dsfapp\", \"isEncode\": true }, \"needLogin\": true, \"pageRoute\": \"WedViewPage\", \"clientVersionCode\": 1092600 }","subjectContent":"港澳台寄递","positionId":"app-index-2025","createTime":"2025-11-10 10:45:07","typeId":"business","typeLabel":"BU业务入口","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/6392EB5E406C4815AC447454FE22AED6.png","urlType":"webview","sceneCode":"51473b493e2e6fdf6ad5be62a816e34b","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29138,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":8,"sceneName":"国际寄递聚合","updateTime":"2025-11-10 10:45:08","url":"{ \"params\": { \"source\": { \"uri\": \"https://ucmp.sf-express.com/wxaccess/app/auth/CX_REGION_APP\" }, \"needSign\": true, \"extendNoSign\": \"&reserved=scene%3Dinternational%26source%3Dsfapp\", \"isEncode\": true }, \"needLogin\": true, \"pageRoute\": \"WedViewPage\", \"clientVersionCode\": 1092600 }","subjectContent":"国际寄递","positionId":"app-index-2025","createTime":"2025-11-10 10:45:08","typeId":"business","typeLabel":"BU业务入口","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/FD5BD3BB180F4144BA66DAF9206407DA.png","urlType":"webview","sceneCode":"7a41415450ee35202fb1c9788ea8451f","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29139,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":9,"sceneName":"冷链服务","updateTime":"2025-11-10 10:47:57","url":"{\n \"routeName\":\"WedViewPage\",\n \"params\":{\n  \"source\":{\n   \"uri\":\"https://ucmp.sf-express.com/wxaccess/app/auth/COLD_ENTRY\"\n  },\n  \"needSign\":true,\n  \"extendNoSign\":\"&reserved=source%3Dsfapp\",\n  \"isEncode\":true\n },\n \"needLogin\":true\n}","subjectContent":"冷链服务","positionId":"app-index-2025","createTime":"2025-11-10 10:47:57","typeId":"business","typeLabel":"BU业务入口","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/905E0C4475AF44FB94AB9D3BDD5E52AD.png","urlType":"webview","sceneCode":"4b7e32005e03a27212dcb65130261768","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29140,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":10,"sceneName":"货运用车","updateTime":"2025-11-26 17:38:32","url":"{\"needLogin\":true,\"params\":{\"isEncode\":true,\"signOption\":{\"header\":true},\"source\":{\"uri\":\"https://ucmp.sf-express.com/wxaccess/weixin/activity/acsp-tc-h5?channelCode=cx_app\"}},\"pageRoute\":\"WedViewPage\", \"clientVersionCode\": 1098500}","subjectContent":"货运用车","positionId":"app-index-2025","createTime":"2025-11-26 17:38:32","typeId":"business","typeLabel":"BU业务入口","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/A3E53FCA8C43433B8357EA57C29DFDAC.png","urlType":"webview","sceneCode":"0df8bc7fe4dd8da1becaa565ae20a853","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29141,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":11,"sceneName":"扫码寄件","updateTime":"2025-11-10 10:45:04","url":"{ \"needLogin\":true, \"pageRoute\":\"OtherScanner\", \"params\":{} }","subjectContent":"扫码寄件","positionId":"app-index-2025","createTime":"2025-11-10 10:45:04","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/23A69EB0535B44E48AD54306ED04B6DA.png","urlType":"webview","sceneCode":"26d1dd3ac7109ae291897706e01dbbe8","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29142,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":12,"sceneName":"批量寄","updateTime":"2025-11-10 10:45:05","url":"{ \"needLogin\":true, \"pageRoute\":\"PlaceOrder\", \"params\":{ \"jumpName\":\"批量寄\" } }","subjectContent":"批量寄","positionId":"app-index-2025","createTime":"2025-11-10 10:45:05","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/E344425C8BB244D6964FFFB0B108CF2F.png","urlType":"webview","sceneCode":"da6824bb91638c9c71b33ee461b65751","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29143,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":13,"sceneName":"丰巢寄件","updateTime":"2025-11-10 10:45:06","url":"{ \"needLogin\":true, \"pageRoute\":\"PlaceOrder\", \"params\":{ \"jumpName\":\"丰巢寄件\" } }","subjectContent":"丰巢寄件","positionId":"app-index-2025","createTime":"2025-11-10 10:45:06","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/E1A0E6FC7EE348BB89668ABB8C11ABA0.png","urlType":"webview","sceneCode":"d8c6e0777988662130261992e8723f92","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29144,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":14,"sceneName":"服务点自寄","updateTime":"2025-11-20 18:13:51","url":"{ \"needLogin\":true, \"pageRoute\":\"PlaceOrder\", \"params\":{ \"orderStyle\":1,\"nServicePoint\" :true}}","subjectContent":"服务点自寄","positionId":"app-index-2025","createTime":"2025-11-20 18:13:51","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/895DB023B42D4E72A69EB59942441B27.png","graySceneId":"ereturn-stop","urlType":"webview","sceneCode":"b43d71308c69324de5010852b7d5a897","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29145,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":15,"sceneName":"网购退货","updateTime":"2026-02-11 19:24:46","url":"{\"needLogin\":true,\"params\":{\"isEncode\":true,\"domain\":\"mcs-mimp-web.sf-express.com\",\"extendNoSign\":\"&source=SFAPP&bizCode=6107@Mk5hR09FSGJlUXVxVTNSUUtFRWJ4cEpBUzh2U2pUVlVWNGlYdVFmbEhQOGxlV1dYeGMwTWxXL25Pb0lXLzZqdkkrMFI0WDdSWk44MlZhZDk3dGl3NHNYT1hDV1NOS1Z0V2YwcDZLb2c0WGR5Y0pnNUs3bGtibDA1RWdsTkFmbCs=\",\"isLanguage\":true,\"needReqTime\":\"1\",\"needSign\":true,\"source\":{\"uri\":\"https://mcs-mimp-web.sf-express.com/mcs-mimp/share/app/shareRedirect\"},\"mustUserInfo\":true},\"pageRoute\":\"WedViewPage\"}","subjectContent":"网购退货","positionId":"app-index-2025","createTime":"2026-02-11 19:24:46","typeId":"featuredShipping","typeLabel":"特色寄","status":0},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/B6CD5E4A8A034850A85A1ACD08E85321.png","urlType":"webview","sceneCode":"b5c548c150ca439568161a24dc212ade","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29147,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":17,"sceneName":"寄快递二级","updateTime":"2025-11-10 11:03:34","url":"{ \"needLogin\":true,\"clientVersionCode\": \"1096920\", \"classify\":\"MY_SERVICE\", \"pageRoute\":\"PlaceOrder\", \"params\":{ \"orderStyle\":0 } }","subjectContent":"寄快递","positionId":"app-index-2025","createTime":"2025-11-10 11:03:34","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/1C97E1AD956E4BA096E167170A412274.png","graySceneId":"handling-documents","urlType":"webview","sceneCode":"3df254ebeee83568c56308bff1f7e86f","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29148,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":18,"sceneName":"跑腿服务","subjectTagContent":"帮我拿","updateTime":"2025-11-11 15:46:58","url":"{ \"needLogin\":true, \"classify\":\"MY_SERVICE\", \"pageRoute\":\"RunErrands\", \"params\":{ \"title\":\"跑腿服务\" } }","subjectContent":"跑腿服务","positionId":"app-index-2025","createTime":"2025-11-11 15:46:58","typeId":"featuredShipping","typeLabel":"特色寄","status":0},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/1071250D3EB947C0AFFFFD9514A01F4B.png","urlType":"webview","sceneCode":"5eaa2c330b1fc1a5ed7dab99c6617620","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29149,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":19,"sceneName":"礼物寄递","subjectTagContent":"送心意","updateTime":"2025-11-10 11:01:32","url":"{ \"needLogin\":true, \"pageRoute\":\"PlaceOrder\", \"clientVersionCode\": \"1094200\", \"params\":{ \"title\": \"\", \"jumpName\":\"无忧送礼\" } }","subjectContent":"礼品寄","positionId":"app-index-2025","createTime":"2025-11-10 11:01:32","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/78D77A27A5D149D6B5A514C104DE1112.png","urlType":"webview","sceneCode":"3b2705c751c4e259cab3ddcafdc91302","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29150,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":20,"sceneName":"雪具寄","updateTime":"2025-11-10 10:47:56","url":"{ \"needLogin\": true, \"pageRoute\": \"PlaceOrder\", \"clientVersionCode\":1096000,\"params\":{ \"title\": \"雪具寄\", \"orderStyle\" : 0, \"pickupEntranceCode\": \"XUEJUJIAPP\", \"tabIndex\": { \"first\": -1, \"second\": -1 } } }","subjectContent":"雪具寄","positionId":"app-index-2025","createTime":"2025-11-10 10:47:56","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/3A47AF90F705440DA5250D6FCDEB1798.png","urlType":"webview","sceneCode":"3e4fc16a26b75a72a68009c93eef6457","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29151,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":21,"sceneName":"行李寄存","subjectTagContent":"行李管家","updateTime":"2025-11-10 10:47:55","url":"{\"needLogin\":true,\"params\":{\"isEncode\":true,\"domain\":\"ucmp.sf-express.com\",\"extendNoSign\":\"&source=SFAPP&bizCode=6115@eHg3d1NZT1pPZU9SclhnYkhMUG9rNWRKK2FlZ1l5cklwNXUrbHVnbFYrTFVRRkVoZGRyRTltbjRCeDN6S1dwSQ==\",\"isLanguage\":true,\"needReqTime\":\"1\",\"needSign\":true,\"source\":{\"uri\":\"https://ucmp.sf-express.com/wxaccess/app/auth/cultural-tourism-agg\"},\"mustUserInfo\":true},\"pageRoute\":\"WedViewPage\"}","subjectContent":"轻松行","positionId":"app-index-2025","createTime":"2025-11-10 10:47:55","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/7842459BBA804A3DB3408EB00007AA7C.png","urlType":"webview","sceneCode":"94c646cdbc3e11682dc1fe5232119702","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29152,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":22,"sceneName":"校园专区","updateTime":"2025-12-15 20:46:41","url":"{\"needLogin\":true,\"params\":{\"isEncode\":true,\"domain\":\"mcs-mimp-web.sf-express.com\",\"extendNoSign\":\"&source=SFAPP&bizCode=%7B%22path%22%3A%22%2Forigin%2Fa%2Fmimp%2Dmember%2Dright%2FcampusZone%22%2C%22linkCode%22%3A%22SFAC20250321142854983%22%2C%22supportShare%22%3A%22YES%22%2C%22from%22%3A%22campuscxapp250321%22%7D\",\"isLanguage\":true,\"needReqTime\":\"1\",\"needSign\":true,\"source\":{\"uri\":\"https://mcs-mimp-web.sf-express.com/mcs-mimp/share/app/activityRedirect\"},\"mustUserInfo\":true},\"pageRoute\":\"WedViewPage\",\"clientVersionCode\": \"1097520\"}","subjectContent":"校园专享","positionId":"app-index-2025","createTime":"2025-12-15 20:46:41","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/00A17C284C654B17982A619CD6BC6E8C.png","urlType":"webview","sceneCode":"4dfb74ad847240da74ef779a71983e23","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29153,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":23,"sceneName":"代收货款","updateTime":"2025-11-10 11:03:29","url":"{\n    \"params\": {\n        \"title\": \"代收货款\"\n    },\n    \"needLogin\": true,\n    \"pageRoute\": \"WedViewPage\",\n    \"appId\": \"202112031150033323\",\n    \"isFromShare\": true\n}","subjectContent":"代收货款","positionId":"app-index-2025","createTime":"2025-11-10 11:03:29","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/2E5BA6994EB748A0B54ABC4E77BC8404.png","urlType":"webview","sceneCode":"61a4cc135ec404643b365081dd07a47b","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29154,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":24,"sceneName":"生鲜寄","updateTime":"2025-11-10 10:47:54","url":"{ \"needLogin\":true, \"pageRoute\":\"PlaceOrder\", \"params\":{ \"jumpName\":\"生鲜\" }, \"clientVersionCode\":\"1093300\"}","subjectContent":"生鲜寄","positionId":"app-index-2025","createTime":"2025-11-10 10:47:54","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/EDC51E372833483DA66B148F0CC38E1B.png","graySceneId":"campus_new_combine","urlType":"webview","sceneCode":"b95064ca6295426c4417a37ac1d867e4","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29155,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":25,"sceneName":"新校园专区","updateTime":"2025-11-10 14:26:45","url":"{\"needLogin\":true,\"params\":{\"isEncode\":true,\"domain\":\"mcs-mimp-web.sf-express.com\",\"extendNoSign\":\"&source=SFAPP&bizCode=%7B%22path%22%3A%22%2Forigin%2Fa%2Fmimp%2Dmember%2Dright%2FcampusZone%22%2C%22linkCode%22%3A%22SFAC20250321142854983%22%2C%22supportShare%22%3A%22YES%22%2C%22from%22%3A%22campuscxapp250321%22%7D\",\"isLanguage\":true,\"needReqTime\":\"1\",\"needSign\":true,\"source\":{\"uri\":\"https://mcs-mimp-web.sf-express.com/mcs-mimp/share/app/activityRedirect\"},\"mustUserInfo\":true},\"pageRoute\":\"WedViewPage\",\"clientVersionCode\": \"1097520\"}","subjectContent":"校园专享","positionId":"app-index-2025","createTime":"2025-11-10 14:26:45","typeId":"featuredShipping","typeLabel":"特色寄","status":0},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/898C16DD4D044C4AAAC8D6747E46176B.png","urlType":"webview","sceneCode":"18d0097382b3a34785905db39f7e0fbb","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29156,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":26,"sceneName":"顺丰集运","updateTime":"2025-11-10 11:03:30","url":"{\n    \"params\":{\n        \"title\":\"顺丰集运\"\n    },\n    \"needLogin\":true,\n    \"pageRoute\":\"WedViewPage\",\n    \"appId\":\"202112201117443948\",\n\"isFromShare\":true\n}","subjectContent":"顺丰集运","positionId":"app-index-2025","createTime":"2025-11-10 11:03:30","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/DF2501714CE24B7888FA3B3B4F3DCBDB.png","urlType":"webview","sceneCode":"357d56bec5fecc0d7aa91c6ed950155a","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29157,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":27,"sceneName":"微友寄","updateTime":"2025-11-10 11:03:31","url":"{\n\"params\": {\n\"appInfo\": {\n\"appId\": \"__UNI__4148A0B\",\n\"redirectPath\": \"\",\n\"version\": {\n\"name\": \"1.8.6\",\n\"code\": \"186\"\n},\n\"zipUrl\": \"https://ccsp-egmas-static.sf-express.com/sfoss/download/WeFriendMail/CCMAS/微友寄-186.zip\"\n},\n\"needSign\": true,\n\"mustUserInfo\": true,\n\"isEncode\": true,\n\"extendSign\": \"\",\n\"extendNoSign\": \"\"\n},\n\"needLogin\": true,\n\"pageRoute\": \"UniAppStartController\",\n\"clientVersionCode\": \"1093000\"\n}","subjectContent":"微友寄","positionId":"app-index-2025","createTime":"2025-11-10 11:03:31","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/4D055100B7D249FD8BE46667B409ED7D.png","urlType":"webview","sceneCode":"aa5344ca1a2e17ac68a867d47b5eca4c","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29159,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":29,"sceneName":"球包寄","updateTime":"2026-01-21 18:52:18","url":"{ \"needLogin\":true, \"pageRoute\":\"GolfPreOrderPage\", \"clientVersionCode\":1098700,\"params\":{ \"title\":\"球包寄\"}}","subjectContent":"球包寄","positionId":"app-index-2025","createTime":"2026-01-21 18:52:18","typeId":"featuredShipping","typeLabel":"特色寄","status":1}],"id":"app-index-2025"},{"positionName":"跑腿服务聚合页-APP","positionChannel":"app","sceneList":[{"buttonName":"去使用","icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/C463C2F7093A4D1092843F7A1E187E20.png","graySceneId":"handling-documents","urlType":"webview","subSubjectContent":"香港证件代领，专业又安全","sceneCode":"3dc41995434864d883d6627607cf0260","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":28090,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":0,"sceneName":"代领证件","updateTime":"2025-11-28 18:47:05","url":"{\n \"params\": {\n  \"source\": {\n   \"uri\": \"https://ucmp.sf-express.com/wechat-act/weixin/activity/ibu-cios-h5-scan?originCode=HK_DBZJ\"\n  },\n\"signOption\": {\n        \"header\": true\n      },\n  \"isEncode\": true\n },\n \"needLogin\": true,\n \"pageRoute\": \"WedViewPage\"\n}","subjectContent":"代领证件","positionId":"run-errands-app","createTime":"2025-11-28 18:47:05","status":0},{"buttonName":"去使用","icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/9EADDED6E6EA4FDCAF3AA138CBDA52D6.png","urlType":"webview","subSubjectContent":"附近物品代取代送","sceneCode":"3af8615506597215e3051ddb9704604f","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":28091,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":1,"sceneName":"帮我拿","updateTime":"2025-12-18 16:29:14","url":"{\n \"params\": {\n  \"source\": {\n   \"uri\": \"https://ucmp.sf-express.com/wxaccess/weixin/auth2?state=CARRY-H5&source=APP\"\n  },\n\"signOption\": {\n        \"header\": true\n      },\n  \"isEncode\": true\n },\n \"needLogin\": true,\n \"pageRoute\": \"WedViewPage\"\n}","subjectContent":"帮我拿","positionId":"run-errands-app","createTime":"2025-12-18 16:29:14","status":1}],"id":"run-errands-app"},{"positionName":"文旅专区聚合页-APP","positionChannel":"app","sceneList":[{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/9FD5B3B79E494E54A5440CE858DB6764.png","urlType":"webview","subSubjectContent":"一键下单，上门取送","sceneCode":"7c53ff994fecf766d5122ae78a43bba3","id":28809,"authType":1,"seq":0,"sceneName":"行李寄递","updateTime":"2026-02-09 09:39:55","subjectContent":"行李寄递","positionId":"travel_aggregation_page-app","createTime":"2026-02-09 09:39:55","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/49FB62B6CFAE46BA8054E07C784C077E.png","urlType":"webview","subSubjectContent":"随存随取，安全省心","sceneCode":"ff1ad1f975a57617c6347a843f7f464c","id":28810,"authType":1,"seq":1,"sceneName":"行李寄存","updateTime":"2025-12-18 11:30:10","url":"https://ucmp.sf-express.com/wxaccess/weixin/auth2?state=cx_luggage_storage","subjectContent":"行李寄存","positionId":"travel_aggregation_page-app","createTime":"2025-12-18 11:30:10","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/2DD4F459D6274638B894FC7CD07AF6EF.png","urlType":"webview","subSubjectContent":"专业加固，整装待发","sceneCode":"bcdb757976b8b9c57f008c3c9a65575c","id":28811,"authType":1,"seq":2,"sceneName":"行李打包","updateTime":"2025-12-18 11:30:44","url":"https://ucmp.sf-express.com/wxaccess/weixin/auth2?state=ustorage-pack-h5","subjectContent":"行李打包","positionId":"travel_aggregation_page-app","createTime":"2025-12-18 11:30:44","status":1},{"icon":"https://ucmp-static.sf-express.com/sfoss/ad-act/infoflow/AE31889D9E4B4954B8CF98B31FD6FA2C.png","urlType":"webview","subSubjectContent":"直送机场/酒店","sceneCode":"39e72b24e9a6f8b3dea76f374c4ce232","id":28812,"authType":1,"seq":3,"sceneName":"行李托运","updateTime":"2025-12-18 11:31:58","url":"https://ucmp.sf-express.com/wxaccess/weixin/auth2?state=ustorage-consign-h5","subjectContent":"行李托运","positionId":"travel_aggregation_page-app","createTime":"2025-12-18 11:31:58","status":1}],"id":"travel_aggregation_page-app"}]}" status-code=200 header="Content-Type:application/json"
+^https:\/\/ccsp-egmas\.{{{sf-express}}}\.com\/cx-app-base\/base\/app\/ad\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/ucmp\.{{{sf-express}}}\.com\/proxy\/esgcempcore\/memberGoods\/pointMallService\/goodsList$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/ucmp(-static)?\.{{{sf-express}}}\.com\/proxy\/ccspBase\/module-config\/(login\/)?query\? data-type=text data="{"version":"2.0","success":true,"obj":[{"positionName":"APP2025","positionChannel":"app","sceneList":[{"urlType":"webview","sceneCode":"ddcb36295d5d2939ba4bbe2e5e02a4d8","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29130,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":0,"sceneName":"寄快递","updateTime":"2026-02-06 18:55:15","url":"{ \"needLogin\": true, \"classify\": \"MY_SERVICE\", \"params\": { \"jumpName\": \"快速寄件\" } }","positionId":"app-index-2025","createTime":"2026-02-06 18:55:15","background":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/15FF24D0AC094758ACD2600331214A1A.png","typeId":"primary","typeLabel":"一级入口","status":1},{"urlType":"webview","sceneCode":"71e3cad43945360ffa6299644d9fbce0","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29132,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":2,"sceneName":"校园一级","updateTime":"2026-02-06 18:55:16","url":"{\"needLogin\":true,\"clientVersionCode\": \"1096920\",\"params\":{\"isEncode\":true,\"domain\":\"mcs-mimp-web.{{{sf-express}}}.com\",\"extendNoSign\":\"&source=SFAPP&bizCode=6196@UHB1a1hjd0V1RDR4a3RTRnJhMmJVMTA1SnhreUh6Vk43U0xYMWZ6aWk4Wk1XclA3MXFRT3dhUjZnK29KY2lSZg==\",\"isLanguage\":true,\"needReqTime\":\"1\",\"needSign\":true,\"source\":{\"uri\":\"https://mcs-mimp-web.{{{sf-express}}}.com/mcs-mimp/share/app/shareRedirect\"},\"mustUserInfo\":true},\"pageRoute\":\"WedViewPage\"}","positionId":"app-index-2025","createTime":"2026-02-06 18:55:16","background":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/04560114349E4DCF9F9C82348D5FD5B8.png","typeId":"primary","typeLabel":"一级入口","status":1},{"urlType":"webview","sceneCode":"d3cf8b8a7be155edc8d507b21a491401","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29134,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":4,"sceneName":"寄大件","updateTime":"2026-02-06 18:55:17","url":"{ \"params\": { \"source\": { \"uri\": \"https://ucmp.{{{sf-express}}}.com/we/cxmodules/large-items-aggregation\" }, \"needSign\": true, \"isEncode\": true }, \"needLogin\": true, \"pageRoute\": \"WedViewPage\", \"clientVersionCode\": 1095600 }","positionId":"app-index-2025","createTime":"2026-02-06 18:55:17","background":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/A234EFA247C04A6A91DEBD06E91BA24B.png","typeId":"primary","typeLabel":"一级入口","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/781D64D298F148F7892A7E705D8C2B1D.png","urlType":"webview","sceneCode":"b83fbeb018acfafc5ad8b38362cf684a","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29136,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":6,"sceneName":"同城急送","subjectTagContent":"低至3折","updateTime":"2025-11-10 10:45:03","url":"{ \"params\": { \"title\": \"同城急送\", \"source\": { \"uri\": \"https://shopic.{{{sf-express}}}.com/crm/webapp?platform=syapp\" }, \"domain\": \"shopic.{{{sf-express}}}.com\", \"launch\": { \"text\": \"服务提示：深圳市顺丰同城物流有限公司向您提供相关服务并承担法律责任\", \"onlyOne\": true, \"delayTime\": 2, \"iconUrl\": \"https://ucmp-static.{{{sf-express}}}.com/appmsoss/app-ms/manage/f082fcd320254d5aaca06316fff9ef8c.jpeg\" } }, \"needLogin\": true, \"pageRoute\": \"WedViewPage\" }","subjectContent":"同城急送","positionId":"app-index-2025","createTime":"2025-11-10 10:45:03","typeId":"business","typeLabel":"BU业务入口","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/52B9DF2E9E6742DFAD64EF4F786CBDE5.png","urlType":"webview","sceneCode":"eabfae966908cdf6947f67bd58618b80","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29137,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":7,"sceneName":"港澳台寄递聚合","updateTime":"2025-11-10 10:45:07","url":"{ \"params\": { \"source\": { \"uri\": \"https://ucmp.{{{sf-express}}}.com/wxaccess/app/auth/CX_REGION_APP\" }, \"needSign\": true, \"extendNoSign\": \"&reserved=scene%3Dhmt%26source%3Dsfapp\", \"isEncode\": true }, \"needLogin\": true, \"pageRoute\": \"WedViewPage\", \"clientVersionCode\": 1092600 }","subjectContent":"港澳台寄递","positionId":"app-index-2025","createTime":"2025-11-10 10:45:07","typeId":"business","typeLabel":"BU业务入口","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/6392EB5E406C4815AC447454FE22AED6.png","urlType":"webview","sceneCode":"51473b493e2e6fdf6ad5be62a816e34b","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29138,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":8,"sceneName":"国际寄递聚合","updateTime":"2025-11-10 10:45:08","url":"{ \"params\": { \"source\": { \"uri\": \"https://ucmp.{{{sf-express}}}.com/wxaccess/app/auth/CX_REGION_APP\" }, \"needSign\": true, \"extendNoSign\": \"&reserved=scene%3Dinternational%26source%3Dsfapp\", \"isEncode\": true }, \"needLogin\": true, \"pageRoute\": \"WedViewPage\", \"clientVersionCode\": 1092600 }","subjectContent":"国际寄递","positionId":"app-index-2025","createTime":"2025-11-10 10:45:08","typeId":"business","typeLabel":"BU业务入口","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/FD5BD3BB180F4144BA66DAF9206407DA.png","urlType":"webview","sceneCode":"7a41415450ee35202fb1c9788ea8451f","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29139,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":9,"sceneName":"冷链服务","updateTime":"2025-11-10 10:47:57","url":"{\n \"routeName\":\"WedViewPage\",\n \"params\":{\n  \"source\":{\n   \"uri\":\"https://ucmp.{{{sf-express}}}.com/wxaccess/app/auth/COLD_ENTRY\"\n  },\n  \"needSign\":true,\n  \"extendNoSign\":\"&reserved=source%3Dsfapp\",\n  \"isEncode\":true\n },\n \"needLogin\":true\n}","subjectContent":"冷链服务","positionId":"app-index-2025","createTime":"2025-11-10 10:47:57","typeId":"business","typeLabel":"BU业务入口","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/905E0C4475AF44FB94AB9D3BDD5E52AD.png","urlType":"webview","sceneCode":"4b7e32005e03a27212dcb65130261768","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29140,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":10,"sceneName":"货运用车","updateTime":"2025-11-26 17:38:32","url":"{\"needLogin\":true,\"params\":{\"isEncode\":true,\"signOption\":{\"header\":true},\"source\":{\"uri\":\"https://ucmp.{{{sf-express}}}.com/wxaccess/weixin/activity/acsp-tc-h5?channelCode=cx_app\"}},\"pageRoute\":\"WedViewPage\", \"clientVersionCode\": 1098500}","subjectContent":"货运用车","positionId":"app-index-2025","createTime":"2025-11-26 17:38:32","typeId":"business","typeLabel":"BU业务入口","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/A3E53FCA8C43433B8357EA57C29DFDAC.png","urlType":"webview","sceneCode":"0df8bc7fe4dd8da1becaa565ae20a853","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29141,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":11,"sceneName":"扫码寄件","updateTime":"2025-11-10 10:45:04","url":"{ \"needLogin\":true, \"pageRoute\":\"OtherScanner\", \"params\":{} }","subjectContent":"扫码寄件","positionId":"app-index-2025","createTime":"2025-11-10 10:45:04","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/23A69EB0535B44E48AD54306ED04B6DA.png","urlType":"webview","sceneCode":"26d1dd3ac7109ae291897706e01dbbe8","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29142,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":12,"sceneName":"批量寄","updateTime":"2025-11-10 10:45:05","url":"{ \"needLogin\":true, \"pageRoute\":\"PlaceOrder\", \"params\":{ \"jumpName\":\"批量寄\" } }","subjectContent":"批量寄","positionId":"app-index-2025","createTime":"2025-11-10 10:45:05","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/E344425C8BB244D6964FFFB0B108CF2F.png","urlType":"webview","sceneCode":"da6824bb91638c9c71b33ee461b65751","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29143,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":13,"sceneName":"丰巢寄件","updateTime":"2025-11-10 10:45:06","url":"{ \"needLogin\":true, \"pageRoute\":\"PlaceOrder\", \"params\":{ \"jumpName\":\"丰巢寄件\" } }","subjectContent":"丰巢寄件","positionId":"app-index-2025","createTime":"2025-11-10 10:45:06","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/E1A0E6FC7EE348BB89668ABB8C11ABA0.png","urlType":"webview","sceneCode":"d8c6e0777988662130261992e8723f92","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29144,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":14,"sceneName":"服务点自寄","updateTime":"2025-11-20 18:13:51","url":"{ \"needLogin\":true, \"pageRoute\":\"PlaceOrder\", \"params\":{ \"orderStyle\":1,\"nServicePoint\" :true}}","subjectContent":"服务点自寄","positionId":"app-index-2025","createTime":"2025-11-20 18:13:51","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/895DB023B42D4E72A69EB59942441B27.png","graySceneId":"ereturn-stop","urlType":"webview","sceneCode":"b43d71308c69324de5010852b7d5a897","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29145,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":15,"sceneName":"网购退货","updateTime":"2026-02-11 19:24:46","url":"{\"needLogin\":true,\"params\":{\"isEncode\":true,\"domain\":\"mcs-mimp-web.{{{sf-express}}}.com\",\"extendNoSign\":\"&source=SFAPP&bizCode=6107@Mk5hR09FSGJlUXVxVTNSUUtFRWJ4cEpBUzh2U2pUVlVWNGlYdVFmbEhQOGxlV1dYeGMwTWxXL25Pb0lXLzZqdkkrMFI0WDdSWk44MlZhZDk3dGl3NHNYT1hDV1NOS1Z0V2YwcDZLb2c0WGR5Y0pnNUs3bGtibDA1RWdsTkFmbCs=\",\"isLanguage\":true,\"needReqTime\":\"1\",\"needSign\":true,\"source\":{\"uri\":\"https://mcs-mimp-web.{{{sf-express}}}.com/mcs-mimp/share/app/shareRedirect\"},\"mustUserInfo\":true},\"pageRoute\":\"WedViewPage\"}","subjectContent":"网购退货","positionId":"app-index-2025","createTime":"2026-02-11 19:24:46","typeId":"featuredShipping","typeLabel":"特色寄","status":0},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/B6CD5E4A8A034850A85A1ACD08E85321.png","urlType":"webview","sceneCode":"b5c548c150ca439568161a24dc212ade","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29147,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":17,"sceneName":"寄快递二级","updateTime":"2025-11-10 11:03:34","url":"{ \"needLogin\":true,\"clientVersionCode\": \"1096920\", \"classify\":\"MY_SERVICE\", \"pageRoute\":\"PlaceOrder\", \"params\":{ \"orderStyle\":0 } }","subjectContent":"寄快递","positionId":"app-index-2025","createTime":"2025-11-10 11:03:34","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/1C97E1AD956E4BA096E167170A412274.png","graySceneId":"handling-documents","urlType":"webview","sceneCode":"3df254ebeee83568c56308bff1f7e86f","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29148,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":18,"sceneName":"跑腿服务","subjectTagContent":"帮我拿","updateTime":"2025-11-11 15:46:58","url":"{ \"needLogin\":true, \"classify\":\"MY_SERVICE\", \"pageRoute\":\"RunErrands\", \"params\":{ \"title\":\"跑腿服务\" } }","subjectContent":"跑腿服务","positionId":"app-index-2025","createTime":"2025-11-11 15:46:58","typeId":"featuredShipping","typeLabel":"特色寄","status":0},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/1071250D3EB947C0AFFFFD9514A01F4B.png","urlType":"webview","sceneCode":"5eaa2c330b1fc1a5ed7dab99c6617620","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29149,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":19,"sceneName":"礼物寄递","subjectTagContent":"送心意","updateTime":"2025-11-10 11:01:32","url":"{ \"needLogin\":true, \"pageRoute\":\"PlaceOrder\", \"clientVersionCode\": \"1094200\", \"params\":{ \"title\": \"\", \"jumpName\":\"无忧送礼\" } }","subjectContent":"礼品寄","positionId":"app-index-2025","createTime":"2025-11-10 11:01:32","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/78D77A27A5D149D6B5A514C104DE1112.png","urlType":"webview","sceneCode":"3b2705c751c4e259cab3ddcafdc91302","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29150,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":20,"sceneName":"雪具寄","updateTime":"2025-11-10 10:47:56","url":"{ \"needLogin\": true, \"pageRoute\": \"PlaceOrder\", \"clientVersionCode\":1096000,\"params\":{ \"title\": \"雪具寄\", \"orderStyle\" : 0, \"pickupEntranceCode\": \"XUEJUJIAPP\", \"tabIndex\": { \"first\": -1, \"second\": -1 } } }","subjectContent":"雪具寄","positionId":"app-index-2025","createTime":"2025-11-10 10:47:56","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/3A47AF90F705440DA5250D6FCDEB1798.png","urlType":"webview","sceneCode":"3e4fc16a26b75a72a68009c93eef6457","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29151,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":21,"sceneName":"行李寄存","subjectTagContent":"行李管家","updateTime":"2025-11-10 10:47:55","url":"{\"needLogin\":true,\"params\":{\"isEncode\":true,\"domain\":\"ucmp.{{{sf-express}}}.com\",\"extendNoSign\":\"&source=SFAPP&bizCode=6115@eHg3d1NZT1pPZU9SclhnYkhMUG9rNWRKK2FlZ1l5cklwNXUrbHVnbFYrTFVRRkVoZGRyRTltbjRCeDN6S1dwSQ==\",\"isLanguage\":true,\"needReqTime\":\"1\",\"needSign\":true,\"source\":{\"uri\":\"https://ucmp.{{{sf-express}}}.com/wxaccess/app/auth/cultural-tourism-agg\"},\"mustUserInfo\":true},\"pageRoute\":\"WedViewPage\"}","subjectContent":"轻松行","positionId":"app-index-2025","createTime":"2025-11-10 10:47:55","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/7842459BBA804A3DB3408EB00007AA7C.png","urlType":"webview","sceneCode":"94c646cdbc3e11682dc1fe5232119702","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29152,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":22,"sceneName":"校园专区","updateTime":"2025-12-15 20:46:41","url":"{\"needLogin\":true,\"params\":{\"isEncode\":true,\"domain\":\"mcs-mimp-web.{{{sf-express}}}.com\",\"extendNoSign\":\"&source=SFAPP&bizCode=%7B%22path%22%3A%22%2Forigin%2Fa%2Fmimp%2Dmember%2Dright%2FcampusZone%22%2C%22linkCode%22%3A%22SFAC20250321142854983%22%2C%22supportShare%22%3A%22YES%22%2C%22from%22%3A%22campuscxapp250321%22%7D\",\"isLanguage\":true,\"needReqTime\":\"1\",\"needSign\":true,\"source\":{\"uri\":\"https://mcs-mimp-web.{{{sf-express}}}.com/mcs-mimp/share/app/activityRedirect\"},\"mustUserInfo\":true},\"pageRoute\":\"WedViewPage\",\"clientVersionCode\": \"1097520\"}","subjectContent":"校园专享","positionId":"app-index-2025","createTime":"2025-12-15 20:46:41","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/00A17C284C654B17982A619CD6BC6E8C.png","urlType":"webview","sceneCode":"4dfb74ad847240da74ef779a71983e23","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29153,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":23,"sceneName":"代收货款","updateTime":"2025-11-10 11:03:29","url":"{\n    \"params\": {\n        \"title\": \"代收货款\"\n    },\n    \"needLogin\": true,\n    \"pageRoute\": \"WedViewPage\",\n    \"appId\": \"202112031150033323\",\n    \"isFromShare\": true\n}","subjectContent":"代收货款","positionId":"app-index-2025","createTime":"2025-11-10 11:03:29","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/2E5BA6994EB748A0B54ABC4E77BC8404.png","urlType":"webview","sceneCode":"61a4cc135ec404643b365081dd07a47b","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29154,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":24,"sceneName":"生鲜寄","updateTime":"2025-11-10 10:47:54","url":"{ \"needLogin\":true, \"pageRoute\":\"PlaceOrder\", \"params\":{ \"jumpName\":\"生鲜\" }, \"clientVersionCode\":\"1093300\"}","subjectContent":"生鲜寄","positionId":"app-index-2025","createTime":"2025-11-10 10:47:54","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/EDC51E372833483DA66B148F0CC38E1B.png","graySceneId":"campus_new_combine","urlType":"webview","sceneCode":"b95064ca6295426c4417a37ac1d867e4","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29155,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":25,"sceneName":"新校园专区","updateTime":"2025-11-10 14:26:45","url":"{\"needLogin\":true,\"params\":{\"isEncode\":true,\"domain\":\"mcs-mimp-web.{{{sf-express}}}.com\",\"extendNoSign\":\"&source=SFAPP&bizCode=%7B%22path%22%3A%22%2Forigin%2Fa%2Fmimp%2Dmember%2Dright%2FcampusZone%22%2C%22linkCode%22%3A%22SFAC20250321142854983%22%2C%22supportShare%22%3A%22YES%22%2C%22from%22%3A%22campuscxapp250321%22%7D\",\"isLanguage\":true,\"needReqTime\":\"1\",\"needSign\":true,\"source\":{\"uri\":\"https://mcs-mimp-web.{{{sf-express}}}.com/mcs-mimp/share/app/activityRedirect\"},\"mustUserInfo\":true},\"pageRoute\":\"WedViewPage\",\"clientVersionCode\": \"1097520\"}","subjectContent":"校园专享","positionId":"app-index-2025","createTime":"2025-11-10 14:26:45","typeId":"featuredShipping","typeLabel":"特色寄","status":0},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/898C16DD4D044C4AAAC8D6747E46176B.png","urlType":"webview","sceneCode":"18d0097382b3a34785905db39f7e0fbb","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29156,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":26,"sceneName":"顺丰集运","updateTime":"2025-11-10 11:03:30","url":"{\n    \"params\":{\n        \"title\":\"顺丰集运\"\n    },\n    \"needLogin\":true,\n    \"pageRoute\":\"WedViewPage\",\n    \"appId\":\"202112201117443948\",\n\"isFromShare\":true\n}","subjectContent":"顺丰集运","positionId":"app-index-2025","createTime":"2025-11-10 11:03:30","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/DF2501714CE24B7888FA3B3B4F3DCBDB.png","urlType":"webview","sceneCode":"357d56bec5fecc0d7aa91c6ed950155a","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29157,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":27,"sceneName":"微友寄","updateTime":"2025-11-10 11:03:31","url":"{\n\"params\": {\n\"appInfo\": {\n\"appId\": \"__UNI__4148A0B\",\n\"redirectPath\": \"\",\n\"version\": {\n\"name\": \"1.8.6\",\n\"code\": \"186\"\n},\n\"zipUrl\": \"https://ccsp-egmas-static.{{{sf-express}}}.com/sfoss/download/WeFriendMail/CCMAS/微友寄-186.zip\"\n},\n\"needSign\": true,\n\"mustUserInfo\": true,\n\"isEncode\": true,\n\"extendSign\": \"\",\n\"extendNoSign\": \"\"\n},\n\"needLogin\": true,\n\"pageRoute\": \"UniAppStartController\",\n\"clientVersionCode\": \"1093000\"\n}","subjectContent":"微友寄","positionId":"app-index-2025","createTime":"2025-11-10 11:03:31","typeId":"featuredShipping","typeLabel":"特色寄","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/4D055100B7D249FD8BE46667B409ED7D.png","urlType":"webview","sceneCode":"aa5344ca1a2e17ac68a867d47b5eca4c","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":29159,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":29,"sceneName":"球包寄","updateTime":"2026-01-21 18:52:18","url":"{ \"needLogin\":true, \"pageRoute\":\"GolfPreOrderPage\", \"clientVersionCode\":1098700,\"params\":{ \"title\":\"球包寄\"}}","subjectContent":"球包寄","positionId":"app-index-2025","createTime":"2026-01-21 18:52:18","typeId":"featuredShipping","typeLabel":"特色寄","status":1}],"id":"app-index-2025"},{"positionName":"跑腿服务聚合页-APP","positionChannel":"app","sceneList":[{"buttonName":"去使用","icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/C463C2F7093A4D1092843F7A1E187E20.png","graySceneId":"handling-documents","urlType":"webview","subSubjectContent":"香港证件代领，专业又安全","sceneCode":"3dc41995434864d883d6627607cf0260","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":28090,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":0,"sceneName":"代领证件","updateTime":"2025-11-28 18:47:05","url":"{\n \"params\": {\n  \"source\": {\n   \"uri\": \"https://ucmp.{{{sf-express}}}.com/wechat-act/weixin/activity/ibu-cios-h5-scan?originCode=HK_DBZJ\"\n  },\n\"signOption\": {\n        \"header\": true\n      },\n  \"isEncode\": true\n },\n \"needLogin\": true,\n \"pageRoute\": \"WedViewPage\"\n}","subjectContent":"代领证件","positionId":"run-errands-app","createTime":"2025-11-28 18:47:05","status":0},{"buttonName":"去使用","icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/9EADDED6E6EA4FDCAF3AA138CBDA52D6.png","urlType":"webview","subSubjectContent":"附近物品代取代送","sceneCode":"3af8615506597215e3051ddb9704604f","extendField1":"{\"boundApp\":\"Android,iOS\"}","id":28091,"extendFieldOneDTO":{"boundApp":"Android,iOS"},"seq":1,"sceneName":"帮我拿","updateTime":"2025-12-18 16:29:14","url":"{\n \"params\": {\n  \"source\": {\n   \"uri\": \"https://ucmp.{{{sf-express}}}.com/wxaccess/weixin/auth2?state=CARRY-H5&source=APP\"\n  },\n\"signOption\": {\n        \"header\": true\n      },\n  \"isEncode\": true\n },\n \"needLogin\": true,\n \"pageRoute\": \"WedViewPage\"\n}","subjectContent":"帮我拿","positionId":"run-errands-app","createTime":"2025-12-18 16:29:14","status":1}],"id":"run-errands-app"},{"positionName":"文旅专区聚合页-APP","positionChannel":"app","sceneList":[{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/9FD5B3B79E494E54A5440CE858DB6764.png","urlType":"webview","subSubjectContent":"一键下单，上门取送","sceneCode":"7c53ff994fecf766d5122ae78a43bba3","id":28809,"authType":1,"seq":0,"sceneName":"行李寄递","updateTime":"2026-02-09 09:39:55","subjectContent":"行李寄递","positionId":"travel_aggregation_page-app","createTime":"2026-02-09 09:39:55","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/49FB62B6CFAE46BA8054E07C784C077E.png","urlType":"webview","subSubjectContent":"随存随取，安全省心","sceneCode":"ff1ad1f975a57617c6347a843f7f464c","id":28810,"authType":1,"seq":1,"sceneName":"行李寄存","updateTime":"2025-12-18 11:30:10","url":"https://ucmp.{{{sf-express}}}.com/wxaccess/weixin/auth2?state=cx_luggage_storage","subjectContent":"行李寄存","positionId":"travel_aggregation_page-app","createTime":"2025-12-18 11:30:10","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/2DD4F459D6274638B894FC7CD07AF6EF.png","urlType":"webview","subSubjectContent":"专业加固，整装待发","sceneCode":"bcdb757976b8b9c57f008c3c9a65575c","id":28811,"authType":1,"seq":2,"sceneName":"行李打包","updateTime":"2025-12-18 11:30:44","url":"https://ucmp.{{{sf-express}}}.com/wxaccess/weixin/auth2?state=ustorage-pack-h5","subjectContent":"行李打包","positionId":"travel_aggregation_page-app","createTime":"2025-12-18 11:30:44","status":1},{"icon":"https://ucmp-static.{{{sf-express}}}.com/sfoss/ad-act/infoflow/AE31889D9E4B4954B8CF98B31FD6FA2C.png","urlType":"webview","subSubjectContent":"直送机场/酒店","sceneCode":"39e72b24e9a6f8b3dea76f374c4ce232","id":28812,"authType":1,"seq":3,"sceneName":"行李托运","updateTime":"2025-12-18 11:31:58","url":"https://ucmp.{{{sf-express}}}.com/wxaccess/weixin/auth2?state=ustorage-consign-h5","subjectContent":"行李托运","positionId":"travel_aggregation_page-app","createTime":"2025-12-18 11:31:58","status":1}],"id":"travel_aggregation_page-app"}]}" status-code=200 header="Content-Type:application/json"
 
 # > 淘票票去广告 · 2025-11-08
 # desc = 移除开屏广告、悬浮广告、轮播图广告和弹窗广告，移除搜索填充词和为你推荐。
-^https:\/\/acs\.m\.taobao\.com\/gw\/mtop\.film\.life\.popup\.get\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/acs\.m\.taobao\.com\/gw\/mtop\.film\.mtopindependentadvertiseapi\.queryadvertise\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/acs\.m\.taobao\.com\/gw\/mtop\.film\.mtopitemadvertiseapi\.queryadvertise\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/acs\.m\.{{{taobao}}}\.com\/gw\/mtop\.film\.life\.popup\.get\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/acs\.m\.{{{taobao}}}\.com\/gw\/mtop\.film\.mtopindependentadvertiseapi\.queryadvertise\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/acs\.m\.{{{taobao}}}\.com\/gw\/mtop\.film\.mtopitemadvertiseapi\.queryadvertise\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 网易有道词典去广告 · 2025-05-13
 # desc = 移除开屏广告、弹窗广告、横幅广告、信息流广告、旧版翻译页面广告及搜索填充词。
-^https:\/\/gorgon\.youdao\.com\/gorgon\/brand\/prefetch\.s\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/gorgon\.youdao\.com\/gorgon\/request\.s\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/gorgon\.{{{youdao}}}\.com\/gorgon\/brand\/prefetch\.s\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/gorgon\.{{{youdao}}}\.com\/gorgon\/request\.s\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 网易邮箱大师去广告 · 2025-05-13
 # desc = 移除网易邮箱大师开屏广告、签到任务提醒，精简侧拉抽屉和我的页面。
-^https:\/\/appconf\.mail\.163\.com\/mailmaster\/api\/http\/urlConfig\.do$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/dashi\.163\.com\/task-center-api\/fapi\/task\/list$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/appconf\.mail\.163\.com\/mailoperating\/mailmaster\/api\/operator\/get$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/appconf\.mail\.{{{163}}}\.com\/mailmaster\/api\/http\/urlConfig\.do$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/dashi\.{{{163}}}\.com\/task-center-api\/fapi\/task\/list$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/appconf\.mail\.{{{163}}}\.com\/mailoperating\/mailmaster\/api\/operator\/get$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 微博去广告 · 2026-02-22
 # desc = 过滤微博广告及去除各部分推广模块
-^https:\/\/api\.weibo\.cn\/2\/(?:ug\/checkin\/list|push\/daily|push\/info) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.weibo\.cn\/2\/!\/live\/media_homelist\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.weibo\.cn\/2\/comments\/bullet_screens\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.weibo\.cn\/2\/photo\/info\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.weibo\.cn\/2\/statuses\/(?:container_positive|push_info) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.weibo\.cn\/2\/vote\/get_vote_detail\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.weibo\.cn\/2\/!\/chaohua\/discovery\/home_bottom\/switch\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.weibo\.cn\/2\/!\/huati\/(?:discovery_home_bottom_getdotinfo|mobile_discovery_searchchange) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.weibo\.cn\/2\/!\/wbox\/\w+\/(?:home_bottom_modal|interest_category) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.weibo\.cn\/2\/search\/(?:container_discover|finder_nav_polling)\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.weibo\.cn\/2\/hot\/hours_spotlight\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.weibo\.cn\/2\/video\/redpacket\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.weibo\.cn\/2\/!\/(?:search\/finder_nav_polling|sug\/list\/finderchange|was\/finder\/searchbarchange)\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.weibo\.cn\/2\/video\/tiny_video_info_show\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/bootrealtime\.uve\.weibo\.com\/v[23]\/ad\/realtime data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/sdkapp\.uve\.weibo\.com\/interface\/sdk\/(?:get-lbs-cell-info\.php|sdkconfig\.php) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/card\.weibo\.com\/article\/m\/aj\/(?:reward|uvead) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/weibo\.com\/ttarticle\/x\/m\/aj\/(?:reward|uvead) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{weibo}}}\.cn\/2\/(?:ug\/checkin\/list|push\/daily|push\/info) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{weibo}}}\.cn\/2\/!\/live\/media_homelist\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{weibo}}}\.cn\/2\/comments\/bullet_screens\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{weibo}}}\.cn\/2\/photo\/info\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{weibo}}}\.cn\/2\/statuses\/(?:container_positive|push_info) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{weibo}}}\.cn\/2\/vote\/get_vote_detail\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{weibo}}}\.cn\/2\/!\/chaohua\/discovery\/home_bottom\/switch\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{weibo}}}\.cn\/2\/!\/huati\/(?:discovery_home_bottom_getdotinfo|mobile_discovery_searchchange) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{weibo}}}\.cn\/2\/!\/wbox\/\w+\/(?:home_bottom_modal|interest_category) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{weibo}}}\.cn\/2\/search\/(?:container_discover|finder_nav_polling)\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{weibo}}}\.cn\/2\/hot\/hours_spotlight\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{weibo}}}\.cn\/2\/video\/redpacket\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{weibo}}}\.cn\/2\/!\/(?:search\/finder_nav_polling|sug\/list\/finderchange|was\/finder\/searchbarchange)\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{weibo}}}\.cn\/2\/video\/tiny_video_info_show\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/bootrealtime\.uve\.{{{weibo}}}\.com\/v[23]\/ad\/realtime data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/sdkapp\.uve\.{{{weibo}}}\.com\/interface\/sdk\/(?:get-lbs-cell-info\.php|sdkconfig\.php) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/card\.{{{weibo}}}\.com\/article\/m\/aj\/(?:reward|uvead) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/{{{weibo}}}\.com\/ttarticle\/x\/m\/aj\/(?:reward|uvead) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 微信公众号去广告 · 2025-05-13
 # desc = 过滤微信公众号广告
-^https:\/\/mp\.weixin\.qq\.com\/mp\/(cps_product_info|getappmsgad|jsmonitor|masonryfeed|relatedarticle)\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/mp\.weixin\.qq\.com\/mp\/relatedsearchword data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/mp\.weixin\.{{{qq}}}\.com\/mp\/(cps_product_info|getappmsgad|jsmonitor|masonryfeed|relatedarticle)\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/mp\.weixin\.{{{qq}}}\.com\/mp\/relatedsearchword data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 喜马拉雅去广告 · 2025-07-11
 # desc = 移除开屏广告、播放器广告、各类推荐内容，精简频道和我的页面。
-^https:\/\/(search|searchwsa)\.ximalaya\.com\/hub\/(guideWord|hotWord)V\d\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/(mobile|mobilehera|mobwsa)\.ximalaya\.com\/discovery-feed\/v\d\/scene\/listen\/refresh\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/(m|mwsa)\.ximalaya\.com\/x-web-activity\/signIn\/getHomePageSignInInfo\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/(mobile|mobilehera|mobwsa)\.ximalaya\.com\/subscribe\/v\d\/subscribe\/tagAlbumList$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/(mobile|mobilehera|mobwsa)\.ximalaya\.com\/track-feed\/v\d\/chase\/recommend\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/(mobile|mobilehera|mobwsa)\.ximalaya\.com\/social-web\/follow-stream\/category\/\d+$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/(mobile|mobilehera|mobwsa)\.ximalaya\.com\/mobile-playpage\/playpage\/recommendContentV\d\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/(mobile|mobilehera|mobwsa)\.ximalaya\.com\/mobile-playpage\/playpage\/recommend\/resource\/allocation\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/(mobile|mobilehera|mobwsa)\.ximalaya\.com\/firework-portal\/v\d+\/sync\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/(mobile|mobilehera|mobwsa)\.ximalaya\.com\/business-sale-promotion-guide-mobile-web\/popup\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/(mobile|mobilehera|mobwsa)\.ximalaya\.com\/app-skin-service\/skin\/setting\/info\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/(live|livewsa)\.ximalaya\.com\/lamia\/v1\/subscribe\/status$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/(mobile|mobilehera|mobwsa)\.ximalaya\.com\/subscribe\/v\d\/subscribe\/recommend\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/(mobile|mobilehera|mobwsa)\.ximalaya\.com\/mobile-user\/v\d\/purchased\/recommend\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/(m|mwsa)\.ximalaya\.com\/community\/square\/v\d\/stream\? data-type=text data="{"data":{"cards":[{"content":{},"type":"RECOMMENDS"}]},"ret":0}" status-code=200 header="Content-Type:application/json"
+^https:\/\/(search|searchwsa)\.{{{ximalaya}}}\.com\/hub\/(guideWord|hotWord)V\d\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/(mobile|mobilehera|mobwsa)\.{{{ximalaya}}}\.com\/discovery-feed\/v\d\/scene\/listen\/refresh\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/(m|mwsa)\.{{{ximalaya}}}\.com\/x-web-activity\/signIn\/getHomePageSignInInfo\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/(mobile|mobilehera|mobwsa)\.{{{ximalaya}}}\.com\/subscribe\/v\d\/subscribe\/tagAlbumList$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/(mobile|mobilehera|mobwsa)\.{{{ximalaya}}}\.com\/track-feed\/v\d\/chase\/recommend\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/(mobile|mobilehera|mobwsa)\.{{{ximalaya}}}\.com\/social-web\/follow-stream\/category\/\d+$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/(mobile|mobilehera|mobwsa)\.{{{ximalaya}}}\.com\/mobile-playpage\/playpage\/recommendContentV\d\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/(mobile|mobilehera|mobwsa)\.{{{ximalaya}}}\.com\/mobile-playpage\/playpage\/recommend\/resource\/allocation\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/(mobile|mobilehera|mobwsa)\.{{{ximalaya}}}\.com\/firework-portal\/v\d+\/sync\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/(mobile|mobilehera|mobwsa)\.{{{ximalaya}}}\.com\/business-sale-promotion-guide-mobile-web\/popup\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/(mobile|mobilehera|mobwsa)\.{{{ximalaya}}}\.com\/app-skin-service\/skin\/setting\/info\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/(live|livewsa)\.{{{ximalaya}}}\.com\/lamia\/v1\/subscribe\/status$ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/(mobile|mobilehera|mobwsa)\.{{{ximalaya}}}\.com\/subscribe\/v\d\/subscribe\/recommend\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/(mobile|mobilehera|mobwsa)\.{{{ximalaya}}}\.com\/mobile-user\/v\d\/purchased\/recommend\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/(m|mwsa)\.{{{ximalaya}}}\.com\/community\/square\/v\d\/stream\? data-type=text data="{"data":{"cards":[{"content":{},"type":"RECOMMENDS"}]},"ret":0}" status-code=200 header="Content-Type:application/json"
 
 # > 下厨房去广告 · 2026-02-22
 # desc = 移除开屏广告、页面推广及横幅，精简首页标签。
-^https:\/\/api\.xiachufang\.com\/v2\/ad\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.xiachufang\.com\/v2\/account\/feeds_v7\.json data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.xiachufang\.com\/v2\/homepage1810\/init_page\.json data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.xiachufang\.com\/v2\/mark_mission\/get_sticker_info\.json data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{xiachufang}}}\.com\/v2\/ad\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{xiachufang}}}\.com\/v2\/account\/feeds_v7\.json data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{xiachufang}}}\.com\/v2\/homepage1810\/init_page\.json data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{xiachufang}}}\.com\/v2\/mark_mission\/get_sticker_info\.json data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 闲鱼去广告 · 2025-12-26
 # desc = 移除开屏广告、商品信息流广告、关注推荐、搜索栏填充词、首页签到入口及悬浮广告，精简我的页面。
-^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idlecommerce\.splash\.ads\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idle\.user\.strategy\.list\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idle\.item\.recommend\.list\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idle\.local\.near\.by\.corner\.info\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idle\.item\.buy\.feeds\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idlemtopsearch\.search\.shade\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idle\.playboy\.recommend\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idlecommerce\.splash\.ads\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idle\.user\.strategy\.list\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idle\.item\.recommend\.list\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idle\.local\.near\.by\.corner\.info\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idle\.item\.buy\.feeds\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idlemtopsearch\.search\.shade\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idle\.playboy\.recommend\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 小黑盒去广告 · 2025-05-13
 # desc = 移除开屏广告和热点板块信息流广告
-^https:\/\/api\.xiaoheihe\.cn\/account\/get_ads_info_v2 data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{xiaoheihe}}}\.cn\/account\/get_ads_info_v2 data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 小红书去广告 · 2026-02-22
 # desc = 过滤信息流推广，移除图片及视频水印，如有异常，请先清除缓存再尝试。
-^https:\/\/ci\.xiaohongshu\.com\/system_config\/watermark data-type=tiny-gif status-code=200
-^https:\/\/edith\.xiaohongshu\.com\/api\/sns\/v1\/surprisebox\/(?:get_style|open|submit_action) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/www\.xiaohongshu\.com\/api\/marketing\/box\/trigger\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/edith\.xiaohongshu\.com\/api\/sns\/(?:v2\/guide\/user_banner|v3\/note\/guide) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/www\.xiaohongshu\.com\/api\/sns\/(?:v1\/ads\/resource|v2\/hey\/\w+\/hey_gallery) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/ci\.{{{xiaohongshu}}}\.com\/system_config\/watermark data-type=tiny-gif status-code=200
+^https:\/\/edith\.{{{xiaohongshu}}}\.com\/api\/sns\/v1\/surprisebox\/(?:get_style|open|submit_action) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/www\.{{{xiaohongshu}}}\.com\/api\/marketing\/box\/trigger\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/edith\.{{{xiaohongshu}}}\.com\/api\/sns\/(?:v2\/guide\/user_banner|v3\/note\/guide) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/www\.{{{xiaohongshu}}}\.com\/api\/sns\/(?:v1\/ads\/resource|v2\/hey\/\w+\/hey_gallery) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 小象超市去广告 · 2025-05-13
 # desc = 移除开屏广告、应用内弹窗、猜你想买、横幅推广和悬浮窗。
-^https:\/\/mall\.meituan\.com\/api\/c\/homepage\/splash data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/mall\.meituan\.com\/api\/c\/homepage\/bubble\/operate\/info data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/mall\.meituan\.com\/api\/c\/jigsaw\/code\/category-banner-\d+\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/mall\.meituan\.com\/api\/c\/poi\/\d+\/order\/recommend\/v\d data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/mall\.meituan\.com\/api\/c\/banner\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/mall\.meituan\.com\/api\/c\/poi\/\d+\/personal\/recommend data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/mall\.{{{meituan}}}\.com\/api\/c\/homepage\/splash data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/mall\.{{{meituan}}}\.com\/api\/c\/homepage\/bubble\/operate\/info data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/mall\.{{{meituan}}}\.com\/api\/c\/jigsaw\/code\/category-banner-\d+\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/mall\.{{{meituan}}}\.com\/api\/c\/poi\/\d+\/order\/recommend\/v\d data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/mall\.{{{meituan}}}\.com\/api\/c\/banner\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/mall\.{{{meituan}}}\.com\/api\/c\/poi\/\d+\/personal\/recommend data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 ^https:\/\/businessapi\.ksedt\.com\/signupindex\/jxlist data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 知乎去广告 · 2026-02-22
 # desc = 移除各部分广告，移除知乎安全中心跳转，建议卸载知乎重新安装。如遇安全中心页面移除失败的，请积极反馈。
-^https:\/\/api\.zhihu\.com\/commercial_api\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.zhihu\.com\/content-distribution-core\/bubble\/common\/settings data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.zhihu\.com\/(?:moments\/lastread|drama\/hot-drama-list) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.zhihu\.com\/root\/window data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.zhihu\.com\/(?:bazaar\/float_window|market\/popovers_v2) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.zhihu\.com\/me\/guides data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.zhihu\.com\/people\/homepage_entry_v2 data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.zhihu\.com\/search\/(hot_search|preset_words) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/www\.zhihu\.com\/api\/v4\/search\/clicked_recommendation\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/www\.zhihu\.com\/api\/v4\/search\/related_queries\/(?:article|answer)\/\d+ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.zhihu\.com\/comment_v5\/(?:articles|answers)\/\d+\/list-headers data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.zhihu\.com\/prague\/related_suggestion_native\/feed\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.zhihu\.com\/v5\.1\/topics\/answer\/\d+\/relation data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.zhihu\.com\/ab\/api\/v1\/products\/zhihu\/platforms\/ios\/config data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.zhihu\.com\/ad-style-service\/request data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/appcloud2\.zhihu\.com\/v3\/resource\?group_name=mp data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/api\.zhihu\.com\/distribute\/rhea\/qa_ad_card\/h5\/recommendation\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/www\.zhihu\.com\/api\/v4\/hot_recommendation data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/www\.zhihu\.com\/api\/v4\/mcn\/v2\/linkcards\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/www\.zhihu\.com\/api\/v4/(?:answers|questions)\/\d+/related-readings data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/www\.zhihu\.com\/commercial_api\/banners_v3\/mobile_banner data-type=text data="{}" status-code=200 header="Content-Type:application/json"
-^https:\/\/zhuanlan\.zhihu\.com\/api\/articles\/\d+\/recommendation data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{zhihu}}}\.com\/commercial_api\/ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{zhihu}}}\.com\/content-distribution-core\/bubble\/common\/settings data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{zhihu}}}\.com\/(?:moments\/lastread|drama\/hot-drama-list) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{zhihu}}}\.com\/root\/window data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{zhihu}}}\.com\/(?:bazaar\/float_window|market\/popovers_v2) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{zhihu}}}\.com\/me\/guides data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{zhihu}}}\.com\/people\/homepage_entry_v2 data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{zhihu}}}\.com\/search\/(hot_search|preset_words) data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/www\.{{{zhihu}}}\.com\/api\/v4\/search\/clicked_recommendation\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/www\.{{{zhihu}}}\.com\/api\/v4\/search\/related_queries\/(?:article|answer)\/\d+ data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{zhihu}}}\.com\/comment_v5\/(?:articles|answers)\/\d+\/list-headers data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{zhihu}}}\.com\/prague\/related_suggestion_native\/feed\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{zhihu}}}\.com\/v5\.1\/topics\/answer\/\d+\/relation data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{zhihu}}}\.com\/ab\/api\/v1\/products\/zhihu\/platforms\/ios\/config data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{zhihu}}}\.com\/ad-style-service\/request data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/appcloud2\.{{{zhihu}}}\.com\/v3\/resource\?group_name=mp data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/api\.{{{zhihu}}}\.com\/distribute\/rhea\/qa_ad_card\/h5\/recommendation\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/www\.{{{zhihu}}}\.com\/api\/v4\/hot_recommendation data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/www\.{{{zhihu}}}\.com\/api\/v4\/mcn\/v2\/linkcards\? data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/www\.{{{zhihu}}}\.com\/api\/v4/(?:answers|questions)\/\d+/related-readings data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/www\.{{{zhihu}}}\.com\/commercial_api\/banners_v3\/mobile_banner data-type=text data="{}" status-code=200 header="Content-Type:application/json"
+^https:\/\/zhuanlan\.{{{zhihu}}}\.com\/api\/articles\/\d+\/recommendation data-type=text data="{}" status-code=200 header="Content-Type:application/json"
 
 # > 中国联通 去广告
 # desc = 去开屏
-^https?:\/\/m\.client\.10010\.com\/mobileService\/customer\/accountListData\.htm data-type=text data='{"imgIndex":"0","adv":{"startup_adv":{"advCntList":[],"buttonList":[]}},"respCode":"0000"}' header='Content-Type:application/json'
+^https?:\/\/m\.client\.{{{10010}}}\.com\/mobileService\/customer\/accountListData\.htm data-type=text data='{"imgIndex":"0","adv":{"startup_adv":{"advCntList":[],"buttonList":[]}},"respCode":"0000"}' header='Content-Type:application/json'
 
 [Script]
 # > 12306去广告 · 2025-05-13
 # desc = 过滤12306应用内广告及开屏广告
-# hostname = ad.12306.cn, mobile.12306.cn
-{{{12306}}} = type=http-request, pattern=^https:\/\/ad\.12306\.cn\/ad\/ser\/getAdList$, script-path=https://kelee.one/Resource/JavaScript/12306/12306_remove_splashscreen_ads.js, requires-body=true
-{{{12306}}} = type=http-request, pattern=^https:\/\/mobile\.12306\.cn\/otsmobile\/app\/mgs\/mgw\.htm$, script-path=https://kelee.one/Resource/JavaScript/12306/12306_remove_ads.js
+# hostname = ad.{{{12306}}}.cn, mobile.{{{12306}}}.cn
+移除12306开屏广告 = type=http-request, pattern=^https:\/\/ad\.{{{12306}}}\.cn\/ad\/ser\/getAdList$, script-path=https://kelee.one/Resource/JavaScript/12306/12306_remove_splashscreen_ads.js, requires-body=true
+移除12306应用内广告 = type=http-request, pattern=^https:\/\/mobile\.{{{12306}}}\.cn\/otsmobile\/app\/mgs\/mgw\.htm$, script-path=https://kelee.one/Resource/JavaScript/12306/12306_remove_ads.js
 
 # > IT之家去广告 · 2025-12-01
 # desc = 过滤IT之家信息流广告和文末广告，自定义移除置顶和轮播图，自定义移除项需在插件配置。
-# hostname = napi.ithome.com, api.zuihuimai.com, dat.ruanmei.com
-{{{ithome}}} = type=http-response, pattern=^https:\/\/napi\.ithome\.com\/api\/(news\/indexv2\/iphone\/\d+|topmenu\/getfeeds\?), script-path=https://kelee.one/Resource/JavaScript/IThome/IThome_remove_ads.js, requires-body=true, argument="[{{{removeAllBanners}}},{{{removePinnedArticles}}}]"
+# hostname = napi.{{{ithome}}}.com, api.zuihuimai.com, dat.ruanmei.com
+IT之家去广告 = type=http-response, pattern=^https:\/\/napi\.{{{ithome}}}\.com\/api\/(news\/indexv2\/iphone\/\d+|topmenu\/getfeeds\?), script-path=https://kelee.one/Resource/JavaScript/IThome/IThome_remove_ads.js, requires-body=true, argument="[{{{removeAllBanners}}},{{{removePinnedArticles}}}]"
 
 # > 阿里云盘去广告 · 2025-05-13
 # desc = 移除首页广告横幅、弹窗和顶部奖励。
-# hostname = api.alipan.com, member.alipan.com, bizapi.alipan.com
-{{{alipan}}} = type=http-response, pattern=^https:\/\/(biz)?api\.alipan\.com\/apps\/v\d\/users?\/home\/(news|widgets), script-path=https://kelee.one/Resource/JavaScript/AliYunDrive/AliYunDrive_remove_ads.js, requires-body=true
-{{{alipan}}} = type=http-response, pattern=^https:\/\/member\.alipan\.com\/v1\/users\/onboard_list, script-path=https://kelee.one/Resource/JavaScript/AliYunDrive/AliYunDrive_remove_ads.js, requires-body=true
+# hostname = api.{{{alipan}}}.com, member.{{{alipan}}}.com, bizapi.{{{alipan}}}.com
+移除阿里云盘广告 = type=http-response, pattern=^https:\/\/(biz)?api\.{{{alipan}}}\.com\/apps\/v\d\/users?\/home\/(news|widgets), script-path=https://kelee.one/Resource/JavaScript/AliYunDrive/AliYunDrive_remove_ads.js, requires-body=true
+移除阿里云盘广告 = type=http-response, pattern=^https:\/\/member\.{{{alipan}}}\.com\/v1\/users\/onboard_list, script-path=https://kelee.one/Resource/JavaScript/AliYunDrive/AliYunDrive_remove_ads.js, requires-body=true
 
 # > 百度网页去广告 · 2025-05-13
 # desc = 移除百度搜索移动端网页的首页广告信息流
-# hostname = m.baidu.com, www.baidu.com
-{{{baidu}}} = type=http-response, pattern="^https?:\/\/(www|m)\.baidu\.com\/?($|\?from=\w{8,9})", script-path=https://kelee.one/Resource/JavaScript/BaiduSearch/BaiduSearchHomePage_remove_ads.js, requires-body=true
+# hostname = m.{{{baidu}}}.com, www.{{{baidu}}}.com
+移除百度搜索首页信息流广告 = type=http-response, pattern="^https?:\/\/(www|m)\.{{{baidu}}}\.com\/?($|\?from=\w{8,9})", script-path=https://kelee.one/Resource/JavaScript/BaiduSearch/BaiduSearchHomePage_remove_ads.js, requires-body=true
 
 # > 哔哩哔哩漫画去广告 · 2025-05-13
 # desc = 移除开屏广告、应用内悬浮窗、各类横幅广告、你可能喜欢、小说推荐、首页弹窗，精简首页标签、底栏活动按钮和我的页面。
-# hostname = manga.bilibili.com
-{{{bilibili}}} = type=http-response, pattern=^https:\/\/manga\.bilibili\.com\/twirp\/comic\.v\d\.Comic\/GetClassPageAllTabs, script-path=https://kelee.one/Resource/JavaScript/BiliComic/BiliComic_remove_ads.js, requires-body=true
-{{{bilibili}}} = type=http-response, pattern=^https:\/\/manga\.bilibili\.com\/twirp\/user\.v\d\.User\/UCenterConf, script-path=https://kelee.one/Resource/JavaScript/BiliComic/BiliComic_remove_ads.js, requires-body=true
+# hostname = manga.{{{bilibili}}}.com
+移除顶部标签 = type=http-response, pattern=^https:\/\/manga\.{{{bilibili}}}\.com\/twirp\/comic\.v\d\.Comic\/GetClassPageAllTabs, script-path=https://kelee.one/Resource/JavaScript/BiliComic/BiliComic_remove_ads.js, requires-body=true
+精简我的页面 = type=http-response, pattern=^https:\/\/manga\.{{{bilibili}}}\.com\/twirp\/user\.v\d\.User\/UCenterConf, script-path=https://kelee.one/Resource/JavaScript/BiliComic/BiliComic_remove_ads.js, requires-body=true
 
 # > 财新去广告 · 2025-05-13
 # desc = 过滤财新广告
-# hostname = e*.caixin.com, g*.caixin.com, m*.caixin.com
-{{{caixin}}} = type=http-response, pattern=^https:\/\/entities\.caixin\.com\/api\/dataplus\/columns, script-path=https://kelee.one/Resource/JavaScript/CaixinMedia/CaixinMedia_remove_ads.js, requires-body=true
-{{{caixin}}} = type=http-response, pattern=^https:\/\/gateway\.caixin\.com\/api\/app-api\/(caixinapp\/appinfo|search\/getkeyword), script-path=https://kelee.one/Resource/JavaScript/CaixinMedia/CaixinMedia_remove_ads.js, requires-body=true
-{{{caixin}}} = type=http-response, pattern=^https:\/\/gateway\.caixin\.com\/api\/app-content\/fm\/index\/list\?, script-path=https://kelee.one/Resource/JavaScript/CaixinMedia/CaixinMedia_remove_ads.js, requires-body=true
-{{{caixin}}} = type=http-response, pattern=^https:\/\/gg\.caixin\.com\/s\?z=caixin&op=\d, script-path=https://kelee.one/Resource/JavaScript/CaixinMedia/CaixinMedia_remove_ads.js, requires-body=true
-{{{caixin}}} = type=http-response, pattern=^https:\/\/mappsv5\.caixin\.com\/articlev5\/\d+\/\d+\.json$, script-path=https://kelee.one/Resource/JavaScript/CaixinMedia/CaixinMedia_remove_ads.js, requires-body=true
-{{{caixin}}} = type=http-response, pattern=^https:\/\/mapps?v5\.caixin\.com\/(channelv5\/list|\/?index_page_v5\/)\w+, script-path=https://kelee.one/Resource/JavaScript/CaixinMedia/CaixinMedia_remove_ads.js, requires-body=true
+# hostname = e*.{{{caixin}}}.com, g*.{{{caixin}}}.com, m*.{{{caixin}}}.com
+移除财新数据通广告 = type=http-response, pattern=^https:\/\/entities\.{{{caixin}}}\.com\/api\/dataplus\/columns, script-path=https://kelee.one/Resource/JavaScript/CaixinMedia/CaixinMedia_remove_ads.js, requires-body=true
+移除文末广告 = type=http-response, pattern=^https:\/\/gateway\.{{{caixin}}}\.com\/api\/app-api\/(caixinapp\/appinfo|search\/getkeyword), script-path=https://kelee.one/Resource/JavaScript/CaixinMedia/CaixinMedia_remove_ads.js, requires-body=true
+移除财新FM广告 = type=http-response, pattern=^https:\/\/gateway\.{{{caixin}}}\.com\/api\/app-content\/fm\/index\/list\?, script-path=https://kelee.one/Resource/JavaScript/CaixinMedia/CaixinMedia_remove_ads.js, requires-body=true
+移除开屏广告 = type=http-response, pattern=^https:\/\/gg\.{{{caixin}}}\.com\/s\?z=caixin&op=\d, script-path=https://kelee.one/Resource/JavaScript/CaixinMedia/CaixinMedia_remove_ads.js, requires-body=true
+移除正文广告 = type=http-response, pattern=^https:\/\/mappsv5\.{{{caixin}}}\.com\/articlev5\/\d+\/\d+\.json$, script-path=https://kelee.one/Resource/JavaScript/CaixinMedia/CaixinMedia_remove_ads.js, requires-body=true
+移除正文广告 = type=http-response, pattern=^https:\/\/mapps?v5\.{{{caixin}}}\.com\/(channelv5\/list|\/?index_page_v5\/)\w+, script-path=https://kelee.one/Resource/JavaScript/CaixinMedia/CaixinMedia_remove_ads.js, requires-body=true
 
 # > 飞客去广告 · 2025-05-13
 # desc = 移除开屏广告、首页广告、板块广告、帖内广告和我的页面广告。
-# hostname = www.flyert.com.cn, ptf.flyertrip.com
-{{{flyert}}} = type=http-response, pattern=^https:\/\/www\.flyert\.com\.cn\/api\/mobile\/index\.php\?version=5, script-path=https://kelee.one/Resource/JavaScript/FlyerTea/FlyerTea_remove_ads.js, requires-body=true
-{{{flyert}}} = type=http-response, pattern=^https:\/\/www\.flyert\.com\.cn\/api\/mobile\/index\.php\?module=plugin&id=k_misign:sign, script-path=https://kelee.one/Resource/JavaScript/FlyerTea/FlyerTea_remove_ads.js, requires-body=true
+# hostname = www.{{{flyert}}}.com.cn, ptf.{{{flyert}}}rip.com
+移除板块广告 = type=http-response, pattern=^https:\/\/www\.{{{flyert}}}\.com\.cn\/api\/mobile\/index\.php\?version=5, script-path=https://kelee.one/Resource/JavaScript/FlyerTea/FlyerTea_remove_ads.js, requires-body=true
+移除签到弹窗广告 = type=http-response, pattern=^https:\/\/www\.{{{flyert}}}\.com\.cn\/api\/mobile\/index\.php\?module=plugin&id=k_misign:sign, script-path=https://kelee.one/Resource/JavaScript/FlyerTea/FlyerTea_remove_ads.js, requires-body=true
 
 # > 高德地图去广告 · 2026-02-22
 # desc = 过滤高德地图开屏广告、各页面推广，精简我的页面。
-# hostname = *.amap.com
-{{{amap}}} = type=http-response, pattern=^https:\/\/m5\.amap\.com\/ws\/aos\/perception\/publicTravel\/beforeNavi\?, script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
-{{{amap}}} = type=http-response, pattern=^https:\/\/m5\.amap\.com\/ws\/bus\/plan\/integrate\?, script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
-{{{amap}}} = type=http-response, pattern=^https:\/\/m5\.amap\.com\/ws\/c3frontend\/(?:af-(?:hotel|launch)\/page\/main|af-nearby\/nearby), script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
-{{{amap}}} = type=http-response, pattern=^https:\/\/m5\.amap\.com\/ws\/perception\/drive\/(?:routeInfo|routePlan), script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
-{{{amap}}} = type=http-response, pattern=^https:\/\/m5\.amap\.com\/ws\/shield\/search_bff\/hotword\?, script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
-{{{amap}}} = type=http-response, pattern=^https:\/\/m5\.amap\.com\/ws\/shield\/search_poi\/(?:mps|search\/sp|sug|tips_operation_location), script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
-{{{amap}}} = type=http-response, pattern=^https:\/\/m5\.amap\.com\/ws\/faas\/amap-navigation\/(?:card-service-plan-home|main-page), script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
-{{{amap}}} = type=http-response, pattern=^https:\/\/m5\.amap\.com\/ws\/shield\/frogserver\/aocs\/updatable\/1\?, script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
-{{{amap}}} = type=http-response, pattern=^https:\/\/m5\.amap\.com\/ws\/shield\/dsp\/profile\/index\/nodefaasv3\?, script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
-{{{amap}}} = type=http-response, pattern=^https:\/\/m5\.amap\.com\/ws\/shield\/search\/nearbyrec_smart\?, script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
-{{{amap}}} = type=http-response, pattern=^https:\/\/m5\.amap\.com\/ws\/valueadded\/alimama\/splash_screen\?, script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
-{{{amap}}} = type=http-response, pattern=^https:\/\/m5-zb\.amap\.com\/ws\/boss\/(?:car\/order\/content_info|order_web\/friendly_information), script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
-{{{amap}}} = type=http-response, pattern=^https:\/\/m5-zb\.amap\.com\/ws\/promotion-web\/resource(\/home)?\?, script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
-{{{amap}}} = type=http-response, pattern=^https:\/\/(?:info|m5)\.amap\.com\/ws\/shield\/search\/(?:common\/coupon\/info|poi\/detail), script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
+# hostname = *.{{{amap}}}.com
+移除路线规划推广 = type=http-response, pattern=^https:\/\/m5\.{{{amap}}}\.com\/ws\/aos\/perception\/publicTravel\/beforeNavi\?, script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
+移除路线规划、导航结束页推广 = type=http-response, pattern=^https:\/\/m5\.{{{amap}}}\.com\/ws\/bus\/plan\/integrate\?, script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
+移除导航详情页底部酒店、处理附近页 = type=http-response, pattern=^https:\/\/m5\.{{{amap}}}\.com\/ws\/c3frontend\/(?:af-(?:hotel|launch)\/page\/main|af-nearby\/nearby), script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
+移除路线规划推广 = type=http-response, pattern=^https:\/\/m5\.{{{amap}}}\.com\/ws\/perception\/drive\/(?:routeInfo|routePlan), script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
+移除搜索栏推广 = type=http-response, pattern=^https:\/\/m5\.{{{amap}}}\.com\/ws\/shield\/search_bff\/hotword\?, script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
+移除搜索详情页推广 = type=http-response, pattern=^https:\/\/m5\.{{{amap}}}\.com\/ws\/shield\/search_poi\/(?:mps|search\/sp|sug|tips_operation_location), script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
+移除首页推广 = type=http-response, pattern=^https:\/\/m5\.{{{amap}}}\.com\/ws\/faas\/amap-navigation\/(?:card-service-plan-home|main-page), script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
+移除首页推广 = type=http-response, pattern=^https:\/\/m5\.{{{amap}}}\.com\/ws\/shield\/frogserver\/aocs\/updatable\/1\?, script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
+移除我的页面推广 = type=http-response, pattern=^https:\/\/m5\.{{{amap}}}\.com\/ws\/shield\/dsp\/profile\/index\/nodefaasv3\?, script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
+移除附近页推广 = type=http-response, pattern=^https:\/\/m5\.{{{amap}}}\.com\/ws\/shield\/search\/nearbyrec_smart\?, script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
+移除开屏广告 = type=http-response, pattern=^https:\/\/m5\.{{{amap}}}\.com\/ws\/valueadded\/alimama\/splash_screen\?, script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
+移除打车页推广卡片、弹窗 = type=http-response, pattern=^https:\/\/m5-zb\.{{{amap}}}\.com\/ws\/boss\/(?:car\/order\/content_info|order_web\/friendly_information), script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
+移除打车页红点角标、天气图标 = type=http-response, pattern=^https:\/\/m5-zb\.{{{amap}}}\.com\/ws\/promotion-web\/resource(\/home)?\?, script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
+移除导航详情页推广 = type=http-response, pattern=^https:\/\/(?:info|m5)\.{{{amap}}}\.com\/ws\/shield\/search\/(?:common\/coupon\/info|poi\/detail), script-path=https://kelee.one/Resource/JavaScript/Amap/Amap_remove_ads.js, requires-body=true
 
 # > 航旅纵横去广告 · 2025-05-13
 # desc = 过滤航旅纵横广告
-# hostname = 114.115.217.129, home.umetrip.com
-{{{umetrip}}} = type=http-response, pattern=^http?:\/\/(114\.115\.217\.129)|(home\.umetrip\.com)\/gateway\/api\/umetrip\/native$, script-path=https://kelee.one/Resource/JavaScript/Umetrip/Umetrip_remove_ads.js
+# hostname = 114.115.217.129, home.{{{umetrip}}}.com
+移除首页广告 = type=http-response, pattern=^http?:\/\/(114\.115\.217\.129)|(home\.{{{umetrip}}}\.com)\/gateway\/api\/umetrip\/native$, script-path=https://kelee.one/Resource/JavaScript/Umetrip/Umetrip_remove_ads.js
 
 # > 京东去广告 · 2025-05-13
 # desc = 移除京东开屏广告，精简我的页面产品推广。
-# hostname = api.m.jd.com
-{{{jd}}} = type=http-response, pattern=^https:\/\/api\.m\.jd\.com\/client\.action\?functionId=(deliverLayer|getTabHomeInfo|myOrderInfo|orderTrackBusiness|personinfoBusiness|start|welcomeHome), script-path=https://kelee.one/Resource/JavaScript/JD/JD_remove_ads.js, requires-body=true
+# hostname = api.m.{{{jd}}}.com
+移除京东广告 = type=http-response, pattern=^https:\/\/api\.m\.{{{jd}}}\.com\/client\.action\?functionId=(deliverLayer|getTabHomeInfo|myOrderInfo|orderTrackBusiness|personinfoBusiness|start|welcomeHome), script-path=https://kelee.one/Resource/JavaScript/JD/JD_remove_ads.js, requires-body=true
 
 # > 微博去广告 · 2026-02-22
 # desc = 过滤微博广告及去除各部分推广模块
-# hostname = *.weibo.cn, *.weibo.com, weibo.com
-{{{weibo}}} = type=http-response, pattern=^https:\/\/api\.weibo\.cn\/2\/(?:checkin\/show|client\/publisher_list|push\/active), script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
-{{{weibo}}} = type=http-response, pattern=^https:\/\/api\.weibo\.cn\/2\/groups\/allgroups\/v2\?, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
-{{{weibo}}} = type=http-response, pattern=^https:\/\/api\.weibo\.cn\/2\/(?:cardlist|page), script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
-{{{weibo}}} = type=http-response, pattern=^https:\/\/api\.weibo\.cn\/2\/comments\/build_comments\?, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
-{{{weibo}}} = type=http-response, pattern=^https:\/\/api\.weibo\.cn\/2\/(?:container\/asyn|flowlist|flowpage), script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
-{{{weibo}}} = type=http-response, pattern=^https:\/\/api\.weibo\.cn\/2\/friendships\/(?:create|destroy), script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
-{{{weibo}}} = type=http-response, pattern=^https:\/\/api\.weibo\.cn\/2\/profile\/(?:container_timeline|dealatt|me|statuses\/tab|userinfo), script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
-{{{weibo}}} = type=http-response, pattern=^https:\/\/api\.weibo\.cn\/2\/shproxy\/chaohua\/discovery\/searchactive\?, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
-{{{weibo}}} = type=http-response, pattern=^https:\/\/api\.weibo\.cn\/2\/statuses\/(?:container_detail(_comment)?|container_timeline(?:_hot|_topic|_topicpage|_unread)?|repost_timeline|unread_hot_timeline), script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
-{{{weibo}}} = type=http-response, pattern=^https:\/\/api\.weibo\.cn\/2\/statuses\/(?:extend|show)\?, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
-{{{weibo}}} = type=http-response, pattern=^https:\/\/api\.weibo\.cn\/2\/video\/(?:full_screen_stream|tiny_stream_mid_detail|tiny_stream_video_list)\?, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
-{{{weibo}}} = type=http-response, pattern=^https:\/\/api\.weibo\.cn\/2\/!\/huati\/discovery_home_bottom_channels\?, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
-{{{weibo}}} = type=http-response, pattern=^https:\/\/api\.weibo\.cn\/2\/direct_messages\/user_list\?, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
-{{{weibo}}} = type=http-response, pattern=^https:\/\/api\.weibo\.cn\/2\/messageflow\/notice\?, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
-{{{weibo}}} = type=http-response, pattern=^https:\/\/api\.weibo\.cn\/2\/search\/(?:container_timeline|finder)\?, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
-{{{weibo}}} = type=http-response, pattern=^https:\/\/api\.weibo\.cn\/2\/searchall\?, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
-{{{weibo}}} = type=http-response, pattern=^https:\/\/bootpreload\.uve\.weibo\.com\/v[12]\/ad\/preload, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
-{{{weibo}}} = type=http-response, pattern=^https:\/\/sdkapp\.uve\.weibo\.com\/interface\/sdk\/sdkad\.php, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
-{{{weibo}}} = type=http-response, pattern=^https:\/\/wbapp\.uve\.weibo\.com\/(?:preload\/get_ad|wbapplua\/wbpullad\.lua), script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
+# hostname = *.{{{weibo}}}.cn, *.{{{weibo}}}.com, {{{weibo}}}.com
+移除首页推广 = type=http-response, pattern=^https:\/\/api\.{{{weibo}}}\.cn\/2\/(?:checkin\/show|client\/publisher_list|push\/active), script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
+移除首页顶部标签 = type=http-response, pattern=^https:\/\/api\.{{{weibo}}}\.cn\/2\/groups\/allgroups\/v2\?, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
+移除信息流广告 = type=http-response, pattern=^https:\/\/api\.{{{weibo}}}\.cn\/2\/(?:cardlist|page), script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
+移除评论区广告 = type=http-response, pattern=^https:\/\/api\.{{{weibo}}}\.cn\/2\/comments\/build_comments\?, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
+移除个人微博详情页广告 = type=http-response, pattern=^https:\/\/api\.{{{weibo}}}\.cn\/2\/(?:container\/asyn|flowlist|flowpage), script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
+移除关注、取消关注弹窗 = type=http-response, pattern=^https:\/\/api\.{{{weibo}}}\.cn\/2\/friendships\/(?:create|destroy), script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
+移除个人主页广告 = type=http-response, pattern=^https:\/\/api\.{{{weibo}}}\.cn\/2\/profile\/(?:container_timeline|dealatt|me|statuses\/tab|userinfo), script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
+移除超话搜索页广告 = type=http-response, pattern=^https:\/\/api\.{{{weibo}}}\.cn\/2\/shproxy\/chaohua\/discovery\/searchactive\?, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
+移除信息流广告 = type=http-response, pattern=^https:\/\/api\.{{{weibo}}}\.cn\/2\/statuses\/(?:container_detail(_comment)?|container_timeline(?:_hot|_topic|_topicpage|_unread)?|repost_timeline|unread_hot_timeline), script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
+移除微博详情页广告 = type=http-response, pattern=^https:\/\/api\.{{{weibo}}}\.cn\/2\/statuses\/(?:extend|show)\?, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
+移除视频流广告 = type=http-response, pattern=^https:\/\/api\.{{{weibo}}}\.cn\/2\/video\/(?:full_screen_stream|tiny_stream_mid_detail|tiny_stream_video_list)\?, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
+移除超话顶部标签 = type=http-response, pattern=^https:\/\/api\.{{{weibo}}}\.cn\/2\/!\/huati\/discovery_home_bottom_channels\?, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
+移除消息页列表广告 = type=http-response, pattern=^https:\/\/api\.{{{weibo}}}\.cn\/2\/direct_messages\/user_list\?, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
+移除消息页提醒 = type=http-response, pattern=^https:\/\/api\.{{{weibo}}}\.cn\/2\/messageflow\/notice\?, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
+移除热门微博信息流广告 = type=http-response, pattern=^https:\/\/api\.{{{weibo}}}\.cn\/2\/search\/(?:container_timeline|finder)\?, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
+移除发现页搜索结果广告 = type=http-response, pattern=^https:\/\/api\.{{{weibo}}}\.cn\/2\/searchall\?, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
+移除开屏广告 preload = type=http-response, pattern=^https:\/\/bootpreload\.uve\.{{{weibo}}}\.com\/v[12]\/ad\/preload, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
+移除开屏广告 sdkad = type=http-response, pattern=^https:\/\/sdkapp\.uve\.{{{weibo}}}\.com\/interface\/sdk\/sdkad\.php, script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
+移除开屏广告 wbapplua = type=http-response, pattern=^https:\/\/wbapp\.uve\.{{{weibo}}}\.com\/(?:preload\/get_ad|wbapplua\/wbpullad\.lua), script-path=https://kelee.one/Resource/JavaScript/Weibo/Weibo_remove_ads.js, requires-body=true
 
 # > 小红书去广告 · 2026-02-22
 # desc = 过滤信息流推广，移除图片及视频水印，如有异常，请先清除缓存再尝试。
-# hostname = ci.xiaohongshu.com, edith.xiaohongshu.com, rec.xiaohongshu.com, so.xiaohongshu.com, www.xiaohongshu.com
-{{{xiaohongshu}}} = type=http-response, pattern=^https:\/\/edith\.xiaohongshu\.com\/api\/sns\/v1\/note\/(?:imagefeed|live_photo\/save), script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
-{{{xiaohongshu}}} = type=http-response, pattern=^https:\/\/edith\.xiaohongshu\.com\/api\/sns\/v1\/system\/service\/ui\/config\?, script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
-{{{xiaohongshu}}} = type=http-response, pattern=^https:\/\/edith\.xiaohongshu\.com\/api\/sns\/v1\/system_service\/config\?, script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
-{{{xiaohongshu}}} = type=http-response, pattern=^https:\/\/edith\.xiaohongshu\.com\/api\/sns\/v2\/system_service\/splash_config, script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
-{{{xiaohongshu}}} = type=http-response, pattern=^https:\/\/edith\.xiaohongshu\.com\/api\/sns\/v2\/(?:note\/widgets|user\/followings\/followfeed), script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
-{{{xiaohongshu}}} = type=http-response, pattern=^https:\/\/edith\.xiaohongshu\.com\/api\/sns\/v4\/followfeed\?, script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
-{{{xiaohongshu}}} = type=http-response, pattern=^https:\/\/edith\.xiaohongshu\.com\/api\/sns\/v5\/recommend\/user\/follow_recommend\?, script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
-{{{xiaohongshu}}} = type=http-response, pattern=^https:\/\/edith\.xiaohongshu\.com\/api\/sns\/(?:v1\/interaction\/comment\/video\/download|v5\/note\/comment\/list), script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
-{{{xiaohongshu}}} = type=http-response, pattern=^https:\/\/edith\.xiaohongshu\.com\/api\/sns\/(?:v2\/note\/feed|v3\/note\/videofeed), script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
-{{{xiaohongshu}}} = type=http-response, pattern=^https:\/\/(?:edith|rec)\.xiaohongshu\.com\/api\/sns\/v6\/homefeed\?, script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
-{{{xiaohongshu}}} = type=http-response, pattern=^https:\/\/(?:edith|so)\.xiaohongshu\.com\/api\/sns\/v10\/search\/notes\?, script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
-{{{xiaohongshu}}} = type=http-response, pattern=^https:\/\/(?:edith|rec|www)\.xiaohongshu\.com\/api\/sns\/(?:v4\/note\/videofeed|v10\/note\/video\/save), script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
+# hostname = ci.{{{xiaohongshu}}}.com, edith.{{{xiaohongshu}}}.com, rec.{{{xiaohongshu}}}.com, so.{{{xiaohongshu}}}.com, www.{{{xiaohongshu}}}.com
+移除图片和实况照片水印 = type=http-response, pattern=^https:\/\/edith\.{{{xiaohongshu}}}\.com\/api\/sns\/v1\/note\/(?:imagefeed|live_photo\/save), script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
+移除界面整体配置 = type=http-response, pattern=^https:\/\/edith\.{{{xiaohongshu}}}\.com\/api\/sns\/v1\/system\/service\/ui\/config\?, script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
+移除开屏广告 = type=http-response, pattern=^https:\/\/edith\.{{{xiaohongshu}}}\.com\/api\/sns\/v1\/system_service\/config\?, script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
+移除开屏广告 = type=http-response, pattern=^https:\/\/edith\.{{{xiaohongshu}}}\.com\/api\/sns\/v2\/system_service\/splash_config, script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
+移除详情页小部件、关注页感兴趣的人 = type=http-response, pattern=^https:\/\/edith\.{{{xiaohongshu}}}\.com\/api\/sns\/v2\/(?:note\/widgets|user\/followings\/followfeed), script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
+移除信息流广告 = type=http-response, pattern=^https:\/\/edith\.{{{xiaohongshu}}}\.com\/api\/sns\/v4\/followfeed\?, script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
+移除详情页感兴趣的人 = type=http-response, pattern=^https:\/\/edith\.{{{xiaohongshu}}}\.com\/api\/sns\/v5\/recommend\/user\/follow_recommend\?, script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
+移除评论区实况照片水印 = type=http-response, pattern=^https:\/\/edith\.{{{xiaohongshu}}}\.com\/api\/sns\/(?:v1\/interaction\/comment\/video\/download|v5\/note\/comment\/list), script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
+移除图片和视频水印 = type=http-response, pattern=^https:\/\/edith\.{{{xiaohongshu}}}\.com\/api\/sns\/(?:v2\/note\/feed|v3\/note\/videofeed), script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
+移除信息流广告 = type=http-response, pattern=^https:\/\/(?:edith|rec)\.{{{xiaohongshu}}}\.com\/api\/sns\/v6\/homefeed\?, script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
+移除搜索页广告 = type=http-response, pattern=^https:\/\/(?:edith|so)\.{{{xiaohongshu}}}\.com\/api\/sns\/v10\/search\/notes\?, script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
+移除视频水印 = type=http-response, pattern=^https:\/\/(?:edith|rec|www)\.{{{xiaohongshu}}}\.com\/api\/sns\/(?:v4\/note\/videofeed|v10\/note\/video\/save), script-path=https://kelee.one/Resource/JavaScript/RedPaper/RedPaper_remove_ads.js, requires-body=true
 
 # > 小象超市去广告 · 2025-05-13
 # desc = 移除开屏广告、应用内弹窗、猜你想买、横幅推广和悬浮窗。
-# hostname = portal-portm.meituan.com, mall.meituan.com, businessapi.ksedt.com
-{{{meituan}}} = type=http-response, pattern=^https:\/\/portal-portm\.meituan\.com\/horn_ios\/mergeRequest, script-path=https://kelee.one/Resource/JavaScript/iMaiCai/iMaiCai_remove_ads.js, requires-body=true
+# hostname = portal-portm.{{{meituan}}}.com, mall.{{{meituan}}}.com, businessapi.ksedt.com
+移除下发广告 = type=http-response, pattern=^https:\/\/portal-portm\.{{{meituan}}}\.com\/horn_ios\/mergeRequest, script-path=https://kelee.one/Resource/JavaScript/iMaiCai/iMaiCai_remove_ads.js, requires-body=true
 
 # > 知乎去广告 · 2026-02-22
 # desc = 移除各部分广告，移除知乎安全中心跳转，建议卸载知乎重新安装。如遇安全中心页面移除失败的，请积极反馈。
-# hostname = *.zhihu.com
-{{{zhihu}}} = type=http-response, pattern=^https:\/\/(?:api|page-info)\.zhihu\.com\/(?:answers|articles)\/v2\/\d+, script-path=https://kelee.one/Resource/JavaScript/Zhihu/Zhihu_remove_ads.js, requires-body=true
-{{{zhihu}}} = type=http-response, pattern=^https:\/\/api\.zhihu\.com\/commercial_api\/app_float_layer, script-path=https://kelee.one/Resource/JavaScript/Zhihu/Zhihu_remove_ads.js, requires-body=true
-{{{zhihu}}} = type=http-response, pattern=^https:\/\/api\.zhihu\.com\/feed\/render\/tab\/config\?, script-path=https://kelee.one/Resource/JavaScript/Zhihu/Zhihu_remove_ads.js, requires-body=true
-{{{zhihu}}} = type=http-response, pattern=^https:\/\/api\.zhihu\.com\/(?:moments_v3|topstory\/hot-lists\/total|topstory\/recommend), script-path=https://kelee.one/Resource/JavaScript/Zhihu/Zhihu_remove_ads.js, requires-body=true
-{{{zhihu}}} = type=http-response, pattern=^https:\/\/api\.zhihu\.com\/root\/tab, script-path=https://kelee.one/Resource/JavaScript/Zhihu/Zhihu_remove_ads.js, requires-body=true
-{{{zhihu}}} = type=http-response, pattern=^https:\/\/api\.zhihu\.com\/v2\/topstory\/hot-lists\/everyone-seeing\?, script-path=https://kelee.one/Resource/JavaScript/Zhihu/Zhihu_remove_ads.js, requires-body=true
-{{{zhihu}}} = type=http-response, pattern=^https:\/\/api\.zhihu\.com\/next-(?:bff|data|render), script-path=https://kelee.one/Resource/JavaScript/Zhihu/Zhihu_remove_ads.js, requires-body=true
-{{{zhihu}}} = type=http-response, pattern=^https:\/\/www\.zhihu\.com\/api\/v4\/(?:articles|answers)\/\d+\/recommendations?\?, script-path=https://kelee.one/Resource/JavaScript/Zhihu/Zhihu_remove_ads.js, requires-body=true
-{{{zhihu}}} = type=http-response, pattern=^https:\/\/appcloud2\.zhihu\.com\/v3\/config, script-path=https://kelee.one/Resource/JavaScript/Zhihu/Zhihu_remove_ads.js, requires-body=true
-{{{zhihu}}} = type=http-response, pattern=^https:\/\/m-cloud\.zhihu\.com\/api\/cloud\/zhihu\/config\/all\?, script-path=https://kelee.one/Resource/JavaScript/Zhihu/Zhihu_remove_ads.js, requires-body=true
+# hostname = *.{{{zhihu}}}.com
+移除回答底部卡片推广 = type=http-response, pattern=^https:\/\/(?:api|page-info)\.{{{zhihu}}}\.com\/(?:answers|articles)\/v2\/\d+, script-path=https://kelee.one/Resource/JavaScript/Zhihu/Zhihu_remove_ads.js, requires-body=true
+移除首页悬浮图标 = type=http-response, pattern=^https:\/\/api\.{{{zhihu}}}\.com\/commercial_api\/app_float_layer, script-path=https://kelee.one/Resource/JavaScript/Zhihu/Zhihu_remove_ads.js, requires-body=true
+移除推荐信息流推广 = type=http-response, pattern=^https:\/\/api\.{{{zhihu}}}\.com\/feed\/render\/tab\/config\?, script-path=https://kelee.one/Resource/JavaScript/Zhihu/Zhihu_remove_ads.js, requires-body=true
+移除推荐信息流推广 = type=http-response, pattern=^https:\/\/api\.{{{zhihu}}}\.com\/(?:moments_v3|topstory\/hot-lists\/total|topstory\/recommend), script-path=https://kelee.one/Resource/JavaScript/Zhihu/Zhihu_remove_ads.js, requires-body=true
+精简顶部标签 = type=http-response, pattern=^https:\/\/api\.{{{zhihu}}}\.com\/root\/tab, script-path=https://kelee.one/Resource/JavaScript/Zhihu/Zhihu_remove_ads.js, requires-body=true
+移除热榜信息流推广 = type=http-response, pattern=^https:\/\/api\.{{{zhihu}}}\.com\/v2\/topstory\/hot-lists\/everyone-seeing\?, script-path=https://kelee.one/Resource/JavaScript/Zhihu/Zhihu_remove_ads.js, requires-body=true
+移除下一个回答推广、评论区顶部推广 = type=http-response, pattern=^https:\/\/api\.{{{zhihu}}}\.com\/next-(?:bff|data|render), script-path=https://kelee.one/Resource/JavaScript/Zhihu/Zhihu_remove_ads.js, requires-body=true
+移除回答详情页推广 = type=http-response, pattern=^https:\/\/www\.{{{zhihu}}}\.com\/api\/v4\/(?:articles|answers)\/\d+\/recommendations?\?, script-path=https://kelee.one/Resource/JavaScript/Zhihu/Zhihu_remove_ads.js, requires-body=true
+拦截服务器推送配置 config = type=http-response, pattern=^https:\/\/appcloud2\.{{{zhihu}}}\.com\/v3\/config, script-path=https://kelee.one/Resource/JavaScript/Zhihu/Zhihu_remove_ads.js, requires-body=true
+拦截服务器推送配置 config all = type=http-response, pattern=^https:\/\/m-cloud\.{{{zhihu}}}\.com\/api\/cloud\/zhihu\/config\/all\?, script-path=https://kelee.one/Resource/JavaScript/Zhihu/Zhihu_remove_ads.js, requires-body=true
 
 [URL Rewrite]
 # > IT之家去广告 · 2025-12-01
@@ -688,265 +688,265 @@ IP-CIDR6,2402:4e00:1200:ed00:0:9089:6dac:96b6/128,REJECT,no-resolve,pre-matching
 
 # > Line去广告 · 2026-02-12
 # desc = 移除Line各类广告
-^https:\/\/gw\.line\.naver\.jp\/ext\/lgfp\/lad\/v\d$ - reject
-^https:\/\/gw\.line\.naver\.jp\/lass\/api\/v\d\/ads$ - reject
-^https:\/\/gw\.line\.naver\.jp\/tr\/event$ - reject
-^https:\/\/legy\.line-apps\.com:443\/ext\/lgfp\/lad\/v\d$ - reject
-^https:\/\/legy\.line-apps\.com:443\/ext\/smartch\/banner\/sch\/v\d$ - reject
-^https:\/\/legy\.line-apps\.com\/line\.gcs\.GcsModuleService\/GetModulesByModuleIds$ - reject
-^https:\/\/legy\.line-apps\.com:443\/tr\/event$ - reject
-^https:\/\/lan\.line\.me\/v\d\/line\/ios - reject
-^https:\/\/buy\.line\.me\/api\/graphql\?variables - reject
-^https:\/\/nelo2-col\.linecorp\.com\/_store$ - reject
-^https:\/\/cix\.line-apps\.com\/R\d\? - reject
-^https:\/\/ad\.line-scdn\.net\/0h - reject
-^https:\/\/static\.line-scdn\.net\/ad-sdk\/ - reject
-^https:\/\/scdn\.line-apps\.com\/appresources\/moretab\/list\.json - reject
+^https:\/\/gw\.{{{line}}}\.naver\.jp\/ext\/lgfp\/lad\/v\d$ - reject
+^https:\/\/gw\.{{{line}}}\.naver\.jp\/lass\/api\/v\d\/ads$ - reject
+^https:\/\/gw\.{{{line}}}\.naver\.jp\/tr\/event$ - reject
+^https:\/\/legy\.{{{line}}}-apps\.com:443\/ext\/lgfp\/lad\/v\d$ - reject
+^https:\/\/legy\.{{{line}}}-apps\.com:443\/ext\/smartch\/banner\/sch\/v\d$ - reject
+^https:\/\/legy\.{{{line}}}-apps\.com\/{{{line}}}\.gcs\.GcsModuleService\/GetModulesByModuleIds$ - reject
+^https:\/\/legy\.{{{line}}}-apps\.com:443\/tr\/event$ - reject
+^https:\/\/lan\.{{{line}}}\.me\/v\d\/line\/ios - reject
+^https:\/\/buy\.{{{line}}}\.me\/api\/graphql\?variables - reject
+^https:\/\/nelo2-col\.{{{line}}}corp\.com\/_store$ - reject
+^https:\/\/cix\.{{{line}}}-apps\.com\/R\d\? - reject
+^https:\/\/ad\.{{{line}}}-scdn\.net\/0h - reject
+^https:\/\/static\.{{{line}}}-scdn\.net\/ad-sdk\/ - reject
+^https:\/\/scdn\.{{{line}}}-apps\.com\/appresources\/moretab\/list\.json - reject
 
 # > 菜鸟去广告 · 2025-12-31
 # desc = 过滤菜鸟广告
-^https:\/\/nbcps-mtop\.cainiao\.com\/gw\/mtop\.cainiao\.nbcps\.presentation\.fetch\.cn - reject
-^https:\/\/netflow-mtop\.cainiao\.com\/gw\/mtop\.cainiao\.guoguo\.nbnetflow\.ads\.index - reject
-^https:\/\/cn-acs\.m\.cainiao\.com\/gw\/mtop\.cainiao\.adkeyword\.get\.cn - reject
-^https:\/\/cn-acs\.m\.cainiao\.com\/gw\/mtop\.cainiao\.guoguo\.nbnetflow\.ads\.m?show - reject
+^https:\/\/nbcps-mtop\.{{{cainiao}}}\.com\/gw\/mtop\.{{{cainiao}}}\.nbcps\.presentation\.fetch\.cn - reject
+^https:\/\/netflow-mtop\.{{{cainiao}}}\.com\/gw\/mtop\.{{{cainiao}}}\.guoguo\.nbnetflow\.ads\.index - reject
+^https:\/\/cn-acs\.m\.{{{cainiao}}}\.com\/gw\/mtop\.{{{cainiao}}}\.adkeyword\.get\.cn - reject
+^https:\/\/cn-acs\.m\.{{{cainiao}}}\.com\/gw\/mtop\.{{{cainiao}}}\.guoguo\.nbnetflow\.ads\.m?show - reject
 
 # > 叮咚买菜去广告 · 2025-05-13
 # desc = 移除开屏广告、弹窗推广、搜索推荐、信息流广告、悬浮广告、各页面购物推荐、精简我的页面，移除底栏和各页面AI入口。
-^https?:\/\/maicai\.api\.ddxq\.mobi\/advert\/ - reject
-^https?:\/\/maicai\.api\.ddxq\.mobi\/homeApi\/getHomeAdPop - reject
+^https?:\/\/maicai\.api\.{{{ddxq}}}\.mobi\/advert\/ - reject
+^https?:\/\/maicai\.api\.{{{ddxq}}}\.mobi\/homeApi\/getHomeAdPop - reject
 
 # > 飞客去广告 · 2025-05-13
 # desc = 移除开屏广告、首页广告、板块广告、帖内广告和我的页面广告。
-^https:\/\/www\.flyert\.com\.cn\/api\/mobile\/index\.php\?module=advis - reject
+^https:\/\/www\.{{{flyert}}}\.com\.cn\/api\/mobile\/index\.php\?module=advis - reject
 
 # > 墨迹天气去广告 · 2025-05-13
 # desc = 移除天气页面横幅、工具栏，移除时景关注页面推荐，精简我的页面。
-^https:\/\/fcard\.api\.moji\.com\/flycard\/flyCard\? - reject
+^https:\/\/fcard\.api\.{{{moji}}}\.com\/flycard\/flyCard\? - reject
 
 # > 什么值得买去广告 · 2025-11-27
 # desc = 移除开屏广告、信息流广告、各类横幅广告、搜索页广告、文章内广告，移除活动皮肤、精简我的页面。
-^https:\/\/h5\.smzdm\.com\/user\/coupon\/coupon_list\? - reject
+^https:\/\/h5\.{{{smzdm}}}\.com\/user\/coupon\/coupon_list\? - reject
 
 # > 香港抖音去广告 · 2025-05-13
 # desc = 精简左右侧边栏、移除底栏切换，其余内容后续再完善。
 ^https:\/\/api5-normal-lq\.amemv\.com\/api\/ad\/ - reject
-^https:\/\/(aweme\.snssdk\.com|api5-normal-m\.amemv\.com)\/api\/ad\/ - reject
+^https:\/\/(awe{{{me}}}\.snssdk\.com|api5-normal-m\.amemv\.com)\/api\/ad\/ - reject
 ^https:\/\/zlink\.ugsdk\.cn\/ad\/ - reject
 
 # > 知乎去广告 · 2026-02-22
 # desc = 移除各部分广告，移除知乎安全中心跳转，建议卸载知乎重新安装。如遇安全中心页面移除失败的，请积极反馈。
-^https:\/\/api\.zhihu\.com\/unlimited\/go\/my_card - reject
-^https:\/\/www\.zhihu\.com\/appview\/v3\/zhmore - reject
-^https:\/\/link\.zhihu\.com\/\?target=(?:https?)?(?:%3A|:)?(?:\/\/|%2F%2F)?(.*) http://$1 302
+^https:\/\/api\.{{{zhihu}}}\.com\/unlimited\/go\/my_card - reject
+^https:\/\/www\.{{{zhihu}}}\.com\/appview\/v3\/zhmore - reject
+^https:\/\/link\.{{{zhihu}}}\.com\/\?target=(?:https?)?(?:%3A|:)?(?:\/\/|%2F%2F)?(.*) http://$1 302
 
 [Body Rewrite]
 # > ECOVACS HOME去广告 · 2026-02-27
 # desc = 移除横幅推广，精简底栏。
-http-response-jq ^https:\/\/gl-cn-api\.ecovacs\.cn\/v3\/private\/ '.data.navigateInfoResponseList |= map(select(.positionType == "Robot" or .positionType == "Mine"))'
+http-response-jq ^https:\/\/gl-cn-api\.{{{eco}}}vacs\.cn\/v3\/private\/ '.data.navigateInfoResponseList |= map(select(.positionType == "Robot" or .positionType == "Mine"))'
 
 # > Keep去广告 · 2025-09-18
 # desc = 移除开屏广告、搜索推荐和弹窗广告，精简底栏和首页标签。移除关注推荐、文章相关推荐和信息流中的课程推广。
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","adTimeoutReport"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","spotShowReport"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","adSupplementIntervalMinutes"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","adSupplementSwitch"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","hotFeedSpotAdRequestMoment"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","activityBrandFeedSpotAdRequestMoment"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","searchFeedSpotAdRequestMoment"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","feedDetailSpotAdRequestMoment"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","homePageFeedSpotAdRequestMoment"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","followFeedSpotAdRequestMoment"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","hotFeedRecommendSpotAdRequestMoment"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","activityFeedSpotAdRequestMoment"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","hotFeedFindSpotAdRequestMoment"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","hotFeedSpotFixedPositionSecond"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","searchFeedSpotFixedPositionSecond"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","followFeedSpotFixedPositionSecond"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","activityFeedSpotFixedPositionSecond"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","searchFeedSpotFixedPositionThird"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","hotFeedFindSpotFixedPositionSecond"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","hotFeedFindSpotFixedPositionThird"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","activityFeedSpotFixedPositionInitial"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","activityFeedSpotFixedPositionThird"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","hotFeedDynamicSpotPosition"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","feedDetailDynamicSpotPosition"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","hotFeedRecommendDynamicSpotPosition"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","hotFeedFindDynamicSpotPosition"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","homePageFeedDynamicSpotPosition"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","followFeedDynamicSpotPosition"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","searchFeedSpotPositionDynamic"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","activityFeedSpotPositionDynamic"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","activityBrandFeedSpotPositionDynamic"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","splashAdLoadTimeLimit"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","courseAdLoadTimeLimit"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","feedAdLoadTimeLimit"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","aliHCSpotConfig"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","gdtSpotConfig"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","pugcThresholdPercent"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","pugcStepMinSeconds"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","pugcStepMaxSeconds"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","pugcPreLoadEarlySeconds"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","pugcLoadPostPreRolls"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","closeConfirmButtonText"]])'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/twins\/union\/feed\/union_feed_all$ '.data.modules |= map(select(.code == "unionFeedEntry"))'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/twins\/v4\/feed\/entryDetail\? 'if (getpath([]) | has("data")) then (setpath(["data"]; {})) else . end'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/config\/v3\/basic\? '.data.bottomBarControl.tabs |= map(select(.tabType | . == "home" or . == "schedule" or . == "dynamic_sports" or . == "personal")) | .data.homeTabs |= map(select(.type | . == "socialTab" or . == "union_feed_all" or . == "homeRecommend" or . == "suitTab" or . == "union_feed_route"))'
-http-response-jq ^https:\/\/api\.gotokeep\.com\/pencil-webapp\/play\/v1\/games\? '.data.games[].microGames[] |= if .leftIcon? and .leftIcon.type == "aiMode" then del(.leftIcon) else . end'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","adTimeoutReport"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","spotShowReport"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","adSupplementIntervalMinutes"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","adSupplementSwitch"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","hotFeedSpotAdRequestMoment"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","activityBrandFeedSpotAdRequestMoment"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","searchFeedSpotAdRequestMoment"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","feedDetailSpotAdRequestMoment"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","homePageFeedSpotAdRequestMoment"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","followFeedSpotAdRequestMoment"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","hotFeedRecommendSpotAdRequestMoment"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","activityFeedSpotAdRequestMoment"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","hotFeedFindSpotAdRequestMoment"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","hotFeedSpotFixedPositionSecond"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","searchFeedSpotFixedPositionSecond"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","followFeedSpotFixedPositionSecond"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","activityFeedSpotFixedPositionSecond"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","searchFeedSpotFixedPositionThird"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","hotFeedFindSpotFixedPositionSecond"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","hotFeedFindSpotFixedPositionThird"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","activityFeedSpotFixedPositionInitial"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","activityFeedSpotFixedPositionThird"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","hotFeedDynamicSpotPosition"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","feedDetailDynamicSpotPosition"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","hotFeedRecommendDynamicSpotPosition"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","hotFeedFindDynamicSpotPosition"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","homePageFeedDynamicSpotPosition"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","followFeedDynamicSpotPosition"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","searchFeedSpotPositionDynamic"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","activityFeedSpotPositionDynamic"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","activityBrandFeedSpotPositionDynamic"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","splashAdLoadTimeLimit"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","courseAdLoadTimeLimit"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","feedAdLoadTimeLimit"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","aliHCSpotConfig"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","gdtSpotConfig"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","pugcThresholdPercent"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","pugcStepMinSeconds"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","pugcStepMaxSeconds"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","pugcPreLoadEarlySeconds"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","pugcLoadPostPreRolls"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/op-engine-webapp\/v1\/configs$ 'delpaths([["data","closeConfirmButtonText"]])'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/twins\/union\/feed\/union_feed_all$ '.data.modules |= map(select(.code == "unionFeedEntry"))'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/twins\/v4\/feed\/entryDetail\? 'if (getpath([]) | has("data")) then (setpath(["data"]; {})) else . end'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/config\/v3\/basic\? '.data.bottomBarControl.tabs |= map(select(.tabType | . == "home" or . == "schedule" or . == "dynamic_sports" or . == "personal")) | .data.homeTabs |= map(select(.type | . == "socialTab" or . == "union_feed_all" or . == "homeRecommend" or . == "suitTab" or . == "union_feed_route"))'
+http-response-jq ^https:\/\/api\.{{{gotokeep}}}\.com\/pencil-webapp\/play\/v1\/games\? '.data.games[].microGames[] |= if .leftIcon? and .leftIcon.type == "aiMode" then del(.leftIcon) else . end'
 
 # > Reddit去广告 · 2025-05-13
 # desc = 过滤应用内推广，阻止NSFW提示。
-http-response-jq ^https?:\/\/gql(-fed)?\.reddit\.com ' walk(   if type == "object" then      (if .isNsfw == true then .isNsfw = false else . end)     | (if .isNsfwMediaBlocked == true then .isNsfwMediaBlocked = false else . end)     | (if .isNsfwContentShown == false then .isNsfwContentShown = true else . end)      | (if (.commentsPageAds | type == "array") then (.commentsPageAds = []) else . end)      | (if ( (.node | type == "object") and (.node.cells | type == "array") and (.node.cells | any(.__typename? == "AdMetadataCell" or .isAdPost? == true)) ) then empty else . end)     | (if (.node | type == "object") and (.node.adPayload | type == "object") then empty else . end)     | (if .__typename == "AdPost" then empty else . end)   else .  end)'
+http-response-jq ^https?:\/\/gql(-fed)?\.{{{reddit}}}\.com ' walk(   if type == "object" then      (if .isNsfw == true then .isNsfw = false else . end)     | (if .isNsfwMediaBlocked == true then .isNsfwMediaBlocked = false else . end)     | (if .isNsfwContentShown == false then .isNsfwContentShown = true else . end)      | (if (.commentsPageAds | type == "array") then (.commentsPageAds = []) else . end)      | (if ( (.node | type == "object") and (.node.cells | type == "array") and (.node.cells | any(.__typename? == "AdMetadataCell" or .isAdPost? == true)) ) then empty else . end)     | (if (.node | type == "object") and (.node.adPayload | type == "object") then empty else . end)     | (if .__typename == "AdPost" then empty else . end)   else .  end)'
 
 # > 爱奇艺去广告 · 2025-05-13
 # desc = 移除开屏广告、焦点图广告、瀑布流广告、搜索页面广告、移除青少年弹窗，精简底栏和我的页面。
-http-response-jq ^https:\/\/cards\.iqiyi\.com\/views_home\/3\.0\/qy_home\? 'delpaths([["base","statistics"]])'
-http-response-jq ^https:\/\/cards\.iqiyi\.com\/views_home\/3\.0\/qy_home\? 'del(.cards[] | select(.alias_name == "focus" or .alias_name == "ad_mobile_flow" or .alias_name == "ad_trueview"))'
-http-response-jq ^https:\/\/cards\.iqiyi\.com\/views_category\/3\.0\/category_home\? 'del(.base.statistics | select(.ad_str)) | del(.cards[] | select(.alias_name == "entrence_focus" or .alias_name == "ad_trueview"))'
-http-response-jq ^https:\/\/cards\.iqiyi\.com\/waterfall(-plt)?\/3\.0\/feed\? 'del(.base.statistics | select(.ad_str)) | del(.. | select(.block_class?))'
-http-response-jq ^https:\/\/cards\.iqiyi\.com\/views_plt\/3\.0\/player_tabs_v2\? 'delpaths([["kv_pair","activity_tab"]])'
-http-response-jq ^https:\/\/cards\.iqiyi\.com\/views_plt\/3\.0\/player_tabs_v2\? 'del(.cards[] | select(.alias_name == "play_vip_promotion" or .alias_name == "play_detail_tag" or .alias_name == "play_chat_entrance" or .alias_name == "play_ad_no_vip" or .alias_name == "play_vertical_short_video" or .alias_name == "play_rap_custom" or .alias_name == "play_topical_tab" or .alias_name == "play_vertical" or .alias_name == "play_water_fall_like")) | del(.. | select(.block_class?))'
-http-response-jq ^https:\/\/comment-card\.iqiyi\.com\/views_comment\/3\.0\/long_video_comments\? ''
-http-response-jq ^https:\/\/cards\.iqiyi\.com\/views_search\/3\.0\/hot_query_search\? '.cards |= map(select(.alias_name as $name | $name != "ad_trueview" and $name != "ad_mobile_flow" and $name != "search_mid_text_ad")) | if .base.statistics.ad_str? then del(.base.statistics) else . end'
-http-response-jq ^https?:\/\/comment-card\.iqiyi\.com\/views_comment\/3\.0\/long_video_comments\? '.cards |= map(select(has("alias_name")))'
-http-response-jq ^https?:\/\/iface2\.iqiyi\.com\/views_menus\/3\.0\/bottom_theme\? 'delpaths([["theme_list"]])'
-http-response-jq ^https?:\/\/iface2\.iqiyi\.com\/views_menus\/3\.0\/bottom_theme\? '.cards |= map(.items |= map(select(.other.bottom_tab_type == "rec" or .other.bottom_tab_type == "my")))'
-http-response-jq ^https?:\/\/iface2\.iqiyi\.com\/views_menus\/3\.0\/home_top_menu\? '.nav_group_data[].nav_list |= map(select(. == "0" or . == "2" or . == "1007" or . == "1" or . == "6" or . == "3"))'
-http-response-jq ^https?:\/\/iface2\.iqiyi\.com\/fusion\/3\.0\/common_switch\? 'delpaths([["content","resource","cast_device_ad"]])'
-http-response-jq ^https?:\/\/iface2\.iqiyi\.com\/fusion\/3\.0\/common_switch\? 'if (getpath(["content","switchs","app_ad"]) | has("app_ad_enable")) then (setpath(["content","switchs","app_ad","app_ad_enable"]; 0)) else . end'
-http-response-jq ^https?:\/\/iface2\.iqiyi\.com\/fusion\/3\.0\/common_switch\? 'if (getpath(["content","switchs","app_ad"]) | has("app_ad_duration")) then (setpath(["content","switchs","app_ad","app_ad_duration"]; 0)) else . end'
-http-response-jq ^https?:\/\/iface2\.iqiyi\.com\/fusion\/3\.0\/common_switch\? 'if (getpath(["content","switchs","ios_tech"]) | has("kPreadAdHintSwitch")) then (setpath(["content","switchs","ios_tech","kPreadAdHintSwitch"]; 0)) else . end'
-http-response-jq ^https?:\/\/iface2\.iqiyi\.com\/fusion\/3\.0\/common_switch\? 'if (getpath(["content","switchs","ios_tech"]) | has("ad_download")) then (setpath(["content","switchs","ios_tech","ad_download"]; 0)) else . end'
-http-response-jq ^https?:\/\/iface2\.iqiyi\.com\/fusion\/3\.0\/common_switch\? 'if (getpath(["content","switchs","m_qiyi_ios_tech"]) | has("KFocusAdVideoPlayTimesIn4G")) then (setpath(["content","switchs","m_qiyi_ios_tech","KFocusAdVideoPlayTimesIn4G"]; 0)) else . end'
-http-response-jq ^https?:\/\/(kjp|t7z)\.cupid\.iqiyi\.com\/mixer\? 'delpaths([["adSlots"]])'
-http-response-jq ^https?:\/\/search\.video\.iqiyi\.com\/q\? 'delpaths([["data"]])'
-http-response-jq ^https?:\/\/iface2\.iqiyi\.com\/aggregate\/3\.0\/getMyMenus\? '.data |= map(select(.statistic.block != "wd_liebiao_2") | select(all(.menuList[]?.statistic2.block; . != "wd_liebiao_3")))'
+http-response-jq ^https:\/\/cards\.{{{iqiyi}}}\.com\/views_home\/3\.0\/qy_home\? 'delpaths([["base","statistics"]])'
+http-response-jq ^https:\/\/cards\.{{{iqiyi}}}\.com\/views_home\/3\.0\/qy_home\? 'del(.cards[] | select(.alias_name == "focus" or .alias_name == "ad_mobile_flow" or .alias_name == "ad_trueview"))'
+http-response-jq ^https:\/\/cards\.{{{iqiyi}}}\.com\/views_category\/3\.0\/category_home\? 'del(.base.statistics | select(.ad_str)) | del(.cards[] | select(.alias_name == "entrence_focus" or .alias_name == "ad_trueview"))'
+http-response-jq ^https:\/\/cards\.{{{iqiyi}}}\.com\/waterfall(-plt)?\/3\.0\/feed\? 'del(.base.statistics | select(.ad_str)) | del(.. | select(.block_class?))'
+http-response-jq ^https:\/\/cards\.{{{iqiyi}}}\.com\/views_plt\/3\.0\/player_tabs_v2\? 'delpaths([["kv_pair","activity_tab"]])'
+http-response-jq ^https:\/\/cards\.{{{iqiyi}}}\.com\/views_plt\/3\.0\/player_tabs_v2\? 'del(.cards[] | select(.alias_name == "play_vip_promotion" or .alias_name == "play_detail_tag" or .alias_name == "play_chat_entrance" or .alias_name == "play_ad_no_vip" or .alias_name == "play_vertical_short_video" or .alias_name == "play_rap_custom" or .alias_name == "play_topical_tab" or .alias_name == "play_vertical" or .alias_name == "play_water_fall_like")) | del(.. | select(.block_class?))'
+http-response-jq ^https:\/\/comment-card\.{{{iqiyi}}}\.com\/views_comment\/3\.0\/long_video_comments\? ''
+http-response-jq ^https:\/\/cards\.{{{iqiyi}}}\.com\/views_search\/3\.0\/hot_query_search\? '.cards |= map(select(.alias_name as $name | $name != "ad_trueview" and $name != "ad_mobile_flow" and $name != "search_mid_text_ad")) | if .base.statistics.ad_str? then del(.base.statistics) else . end'
+http-response-jq ^https?:\/\/comment-card\.{{{iqiyi}}}\.com\/views_comment\/3\.0\/long_video_comments\? '.cards |= map(select(has("alias_name")))'
+http-response-jq ^https?:\/\/iface2\.{{{iqiyi}}}\.com\/views_menus\/3\.0\/bottom_theme\? 'delpaths([["theme_list"]])'
+http-response-jq ^https?:\/\/iface2\.{{{iqiyi}}}\.com\/views_menus\/3\.0\/bottom_theme\? '.cards |= map(.items |= map(select(.other.bottom_tab_type == "rec" or .other.bottom_tab_type == "my")))'
+http-response-jq ^https?:\/\/iface2\.{{{iqiyi}}}\.com\/views_menus\/3\.0\/home_top_menu\? '.nav_group_data[].nav_list |= map(select(. == "0" or . == "2" or . == "1007" or . == "1" or . == "6" or . == "3"))'
+http-response-jq ^https?:\/\/iface2\.{{{iqiyi}}}\.com\/fusion\/3\.0\/common_switch\? 'delpaths([["content","resource","cast_device_ad"]])'
+http-response-jq ^https?:\/\/iface2\.{{{iqiyi}}}\.com\/fusion\/3\.0\/common_switch\? 'if (getpath(["content","switchs","app_ad"]) | has("app_ad_enable")) then (setpath(["content","switchs","app_ad","app_ad_enable"]; 0)) else . end'
+http-response-jq ^https?:\/\/iface2\.{{{iqiyi}}}\.com\/fusion\/3\.0\/common_switch\? 'if (getpath(["content","switchs","app_ad"]) | has("app_ad_duration")) then (setpath(["content","switchs","app_ad","app_ad_duration"]; 0)) else . end'
+http-response-jq ^https?:\/\/iface2\.{{{iqiyi}}}\.com\/fusion\/3\.0\/common_switch\? 'if (getpath(["content","switchs","ios_tech"]) | has("kPreadAdHintSwitch")) then (setpath(["content","switchs","ios_tech","kPreadAdHintSwitch"]; 0)) else . end'
+http-response-jq ^https?:\/\/iface2\.{{{iqiyi}}}\.com\/fusion\/3\.0\/common_switch\? 'if (getpath(["content","switchs","ios_tech"]) | has("ad_download")) then (setpath(["content","switchs","ios_tech","ad_download"]; 0)) else . end'
+http-response-jq ^https?:\/\/iface2\.{{{iqiyi}}}\.com\/fusion\/3\.0\/common_switch\? 'if (getpath(["content","switchs","m_qiyi_ios_tech"]) | has("KFocusAdVideoPlayTimesIn4G")) then (setpath(["content","switchs","m_qiyi_ios_tech","KFocusAdVideoPlayTimesIn4G"]; 0)) else . end'
+http-response-jq ^https?:\/\/(kjp|t7z)\.cupid\.{{{iqiyi}}}\.com\/mixer\? 'delpaths([["adSlots"]])'
+http-response-jq ^https?:\/\/search\.video\.{{{iqiyi}}}\.com\/q\? 'delpaths([["data"]])'
+http-response-jq ^https?:\/\/iface2\.{{{iqiyi}}}\.com\/aggregate\/3\.0\/getMyMenus\? '.data |= map(select(.statistic.block != "wd_liebiao_2") | select(all(.menuList[]?.statistic2.block; . != "wd_liebiao_3")))'
 
 # > 百度地图去广告 · 2025-05-13
 # desc = 移除开屏广告、出行页面推广、周边页面推广、打车页面推广，精简我的页面。此插件需要IPA签名方可使用，App Store用户请勿使用此插件，务必点击下方主页链接查看详细教程。
-http-response-jq ^https:\/\/newclient\.map\.baidu\.com\/feed\/govui\/rich_content 'delpaths([["data"]])'
-http-response-jq ^https:\/\/newclient\.map\.baidu\.com\/client\/noticebar\/get\? 'delpaths([["content","multi_data"]])'
-http-response-jq ^https:\/\/newclient\.map\.baidu\.com\/(client\/)?usersystem\/mine\/page\? 'if (getpath([]) | has("data")) then (setpath(["data"]; {})) else . end'
-http-response-jq ^https:\/\/newclient\.map\.baidu\.com\/client\/phpui2\/\?qt=ads&type=user_home_new_service 'delpaths([["ads"]])'
-http-response-jq ^https:\/\/newclient\.map\.baidu\.com\/living\/nearby\/api\? 'delpaths([["Result","cards",1]])'
-http-response-jq ^https:\/\/newclient\.map\.baidu\.com\/living\/nearby\/api\? 'delpaths([["Result","cards",4]])'
-http-response-jq ^https:\/\/newclient\.map\.baidu\.com\/living\/nearby\/api\? 'delpaths([["Result","cards",5]])'
-http-response-jq ^https:\/\/newclient\.map\.baidu\.com\/living\/nearby\/api\? 'delpaths([["Result","cards",9]])'
+http-response-jq ^https:\/\/newclient\.map\.{{{baidu}}}\.com\/feed\/govui\/rich_content 'delpaths([["data"]])'
+http-response-jq ^https:\/\/newclient\.map\.{{{baidu}}}\.com\/client\/noticebar\/get\? 'delpaths([["content","multi_data"]])'
+http-response-jq ^https:\/\/newclient\.map\.{{{baidu}}}\.com\/(client\/)?usersystem\/mine\/page\? 'if (getpath([]) | has("data")) then (setpath(["data"]; {})) else . end'
+http-response-jq ^https:\/\/newclient\.map\.{{{baidu}}}\.com\/client\/phpui2\/\?qt=ads&type=user_home_new_service 'delpaths([["ads"]])'
+http-response-jq ^https:\/\/newclient\.map\.{{{baidu}}}\.com\/living\/nearby\/api\? 'delpaths([["Result","cards",1]])'
+http-response-jq ^https:\/\/newclient\.map\.{{{baidu}}}\.com\/living\/nearby\/api\? 'delpaths([["Result","cards",4]])'
+http-response-jq ^https:\/\/newclient\.map\.{{{baidu}}}\.com\/living\/nearby\/api\? 'delpaths([["Result","cards",5]])'
+http-response-jq ^https:\/\/newclient\.map\.{{{baidu}}}\.com\/living\/nearby\/api\? 'delpaths([["Result","cards",9]])'
 
 # > 百度网盘去广告 · 2026-01-02
 # desc = 移除开屏广告、首页卡片广告、传输页面广告、各类弹窗，精简侧拉抽屉和我的页面。
-http-response-jq ^https:\/\/pan\.baidu\.com\/feed\/kingkongdistrict\? '.data.data |= map(select(.type != "novel" and .type != "shortplay" and .type != "print" and .type != "job_hunt"))'
+http-response-jq ^https:\/\/pan\.{{{baidu}}}\.com\/feed\/kingkongdistrict\? '.data.data |= map(select(.type != "novel" and .type != "shortplay" and .type != "print" and .type != "job_hunt"))'
 
 # > 波点音乐去广告 · 2025-08-31
 # desc = 精简应用配置，禁用P2P传输。移除开屏广告、横幅推广、悬浮广告、歌曲广告、商城入口、搜索推广、评论区推广、试听语音提醒。
-http-response-jq ^https:\/\/bd-api\.kuwo\.cn\/api\/service\/conf\/all\? 'delpaths([["data","groupSign","adStartAppDialog"]])'
-http-response-jq ^https:\/\/bd-api\.kuwo\.cn\/api\/service\/conf\/all\? 'delpaths([["data","groupSign","adGuideTest"]])'
-http-response-jq ^https:\/\/bd-api\.kuwo\.cn\/api\/service\/conf\/all\? 'delpaths([["data","groupSign","playTips"]])'
-http-response-jq ^https:\/\/bd-api\.kuwo\.cn\/api\/service\/conf\/all\? 'delpaths([["data","groupSign","adExitChange"]])'
-http-response-jq ^https:\/\/bd-api\.kuwo\.cn\/api\/service\/conf\/all\? 'delpaths([["data","conf","adGuidePopCount"]])'
-http-response-jq ^https:\/\/bd-api\.kuwo\.cn\/api\/service\/conf\/all\? 'delpaths([["data","conf","adDownListOpen"]])'
-http-response-jq ^https:\/\/bd-api\.kuwo\.cn\/api\/service\/conf\/all\? 'if (getpath(["data","conf","flowControlConfig"]) | has("uploadEnable")) then (setpath(["data","conf","flowControlConfig","uploadEnable"]; false)) else . end'
-http-response-jq ^https:\/\/bd-api\.kuwo\.cn\/api\/service\/conf\/all\? 'if (getpath(["data","conf","flowControlConfig"]) | has("p2pEnable")) then (setpath(["data","conf","flowControlConfig","p2pEnable"]; false)) else . end'
-http-response-jq ^https:\/\/ab-bodian\.kuwo\.cn\/abtest\/ui\/info\? 'delpaths([["data","mapTestInfo","CommentADPosition"]])'
-http-response-jq ^https:\/\/ab-bodian\.kuwo\.cn\/abtest\/ui\/info\? 'delpaths([["data","mapTestInfo","DiscoverADPosition"]])'
-http-response-jq ^https:\/\/ab-bodian\.kuwo\.cn\/abtest\/ui\/info\? 'delpaths([["data","mapTestInfo","DownloadAd"]])'
-http-response-jq ^https:\/\/ab-bodian\.kuwo\.cn\/abtest\/ui\/info\? 'delpaths([["data","mapTestInfo","FreeModVoiceReminder"]])'
-http-response-jq ^https:\/\/ab-bodian\.kuwo\.cn\/abtest\/ui\/info\? 'delpaths([["data","mapTestInfo","GamesTrans"]])'
-http-response-jq ^https:\/\/ab-bodian\.kuwo\.cn\/abtest\/ui\/info\? 'delpaths([["data","mapTestInfo","bodianmvdialog"]])'
-http-response-jq ^https:\/\/ab-bodian\.kuwo\.cn\/abtest\/ui\/info\? 'delpaths([["data","mapTestInfo","MvTryShowAds"]])'
-http-response-jq ^https:\/\/ab-bodian\.kuwo\.cn\/abtest\/ui\/info\? 'delpaths([["data","mapTestInfo","insert"]])'
-http-response-jq ^https:\/\/bd-api\.kuwo\.cn\/api\/service\/global\/config\/scene\? 'delpaths([["data","iosP2PCacheEnable"]])'
-http-response-jq ^https:\/\/bd-api\.kuwo\.cn\/api\/service\/global\/config\/scene\? 'delpaths([["data","warmStartDialog"]])'
-http-response-jq ^https:\/\/bd-api\.kuwo\.cn\/api\/service\/global\/config\/scene\? 'delpaths([["data","adsNotFinishVipPop4DayInterval"]])'
-http-response-jq ^https:\/\/bd-api\.kuwo\.cn\/api\/service\/global\/config\/scene\? 'if (getpath(["data"]) | has("showShopEntry")) then (setpath(["data","showShopEntry"]; false)) else . end'
-http-response-jq ^https:\/\/bd-api\.kuwo\.cn\/api\/service\/global\/config\/scene\? 'if (getpath(["data"]) | has("iosP2pEnableSendDataLimit")) then (setpath(["data","iosP2pEnableSendDataLimit"]; 1)) else . end'
-http-response-jq ^https:\/\/bd-api\.kuwo\.cn\/api\/search\/topic\/word\/list\? 'delpaths([["data","hotTopic"]])'
-http-response-jq ^https:\/\/bd-api\.kuwo\.cn\/api\/search\/topic\/word\/list\? 'delpaths([["data","searchFind"]])'
-http-response-jq ^https:\/\/bd-api\.kuwo\.cn\/api\/search\/topic\/word\/list\? 'delpaths([["data","globalJumpInfo"]])'
-http-response-jq ^https:\/\/bd-api\.kuwo\.cn\/api\/search\/topic\/word\/list\? 'delpaths([["data","hotWord"]])'
-http-response-jq ^https:\/\/bd-api\.kuwo\.cn\/api\/service\/home\/index\? '.data.moduleList |= map(select(.type | tostring | (. != "8" and . != "1")))'
-http-response-jq ^https:\/\/bd-api\.kuwo\.cn\/api\/service\/music\/recommendList\? '.data.musicList[] |= del(.showAd)'
-http-response-jq ^https:\/\/bd-api\.kuwo\.cn\/api\/comments\/v3\/topInfo\? 'delpaths([["data","putao"]])'
-http-response-jq ^https:\/\/bd-api\.kuwo\.cn\/api\/comments\/v3\/topInfo\? 'delpaths([["data","bannerVos"]])'
+http-response-jq ^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/service\/conf\/all\? 'delpaths([["data","groupSign","adStartAppDialog"]])'
+http-response-jq ^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/service\/conf\/all\? 'delpaths([["data","groupSign","adGuideTest"]])'
+http-response-jq ^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/service\/conf\/all\? 'delpaths([["data","groupSign","playTips"]])'
+http-response-jq ^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/service\/conf\/all\? 'delpaths([["data","groupSign","adExitChange"]])'
+http-response-jq ^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/service\/conf\/all\? 'delpaths([["data","conf","adGuidePopCount"]])'
+http-response-jq ^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/service\/conf\/all\? 'delpaths([["data","conf","adDownListOpen"]])'
+http-response-jq ^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/service\/conf\/all\? 'if (getpath(["data","conf","flowControlConfig"]) | has("uploadEnable")) then (setpath(["data","conf","flowControlConfig","uploadEnable"]; false)) else . end'
+http-response-jq ^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/service\/conf\/all\? 'if (getpath(["data","conf","flowControlConfig"]) | has("p2pEnable")) then (setpath(["data","conf","flowControlConfig","p2pEnable"]; false)) else . end'
+http-response-jq ^https:\/\/ab-bodian\.{{{kuwo}}}\.cn\/abtest\/ui\/info\? 'delpaths([["data","mapTestInfo","CommentADPosition"]])'
+http-response-jq ^https:\/\/ab-bodian\.{{{kuwo}}}\.cn\/abtest\/ui\/info\? 'delpaths([["data","mapTestInfo","DiscoverADPosition"]])'
+http-response-jq ^https:\/\/ab-bodian\.{{{kuwo}}}\.cn\/abtest\/ui\/info\? 'delpaths([["data","mapTestInfo","DownloadAd"]])'
+http-response-jq ^https:\/\/ab-bodian\.{{{kuwo}}}\.cn\/abtest\/ui\/info\? 'delpaths([["data","mapTestInfo","FreeModVoiceReminder"]])'
+http-response-jq ^https:\/\/ab-bodian\.{{{kuwo}}}\.cn\/abtest\/ui\/info\? 'delpaths([["data","mapTestInfo","GamesTrans"]])'
+http-response-jq ^https:\/\/ab-bodian\.{{{kuwo}}}\.cn\/abtest\/ui\/info\? 'delpaths([["data","mapTestInfo","bodianmvdialog"]])'
+http-response-jq ^https:\/\/ab-bodian\.{{{kuwo}}}\.cn\/abtest\/ui\/info\? 'delpaths([["data","mapTestInfo","MvTryShowAds"]])'
+http-response-jq ^https:\/\/ab-bodian\.{{{kuwo}}}\.cn\/abtest\/ui\/info\? 'delpaths([["data","mapTestInfo","insert"]])'
+http-response-jq ^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/service\/global\/config\/scene\? 'delpaths([["data","iosP2PCacheEnable"]])'
+http-response-jq ^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/service\/global\/config\/scene\? 'delpaths([["data","warmStartDialog"]])'
+http-response-jq ^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/service\/global\/config\/scene\? 'delpaths([["data","adsNotFinishVipPop4DayInterval"]])'
+http-response-jq ^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/service\/global\/config\/scene\? 'if (getpath(["data"]) | has("showShopEntry")) then (setpath(["data","showShopEntry"]; false)) else . end'
+http-response-jq ^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/service\/global\/config\/scene\? 'if (getpath(["data"]) | has("iosP2pEnableSendDataLimit")) then (setpath(["data","iosP2pEnableSendDataLimit"]; 1)) else . end'
+http-response-jq ^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/search\/topic\/word\/list\? 'delpaths([["data","hotTopic"]])'
+http-response-jq ^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/search\/topic\/word\/list\? 'delpaths([["data","searchFind"]])'
+http-response-jq ^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/search\/topic\/word\/list\? 'delpaths([["data","globalJumpInfo"]])'
+http-response-jq ^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/search\/topic\/word\/list\? 'delpaths([["data","hotWord"]])'
+http-response-jq ^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/service\/home\/index\? '.data.moduleList |= map(select(.type | tostring | (. != "8" and . != "1")))'
+http-response-jq ^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/service\/music\/recommendList\? '.data.musicList[] |= del(.showAd)'
+http-response-jq ^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/comments\/v3\/topInfo\? 'delpaths([["data","putao"]])'
+http-response-jq ^https:\/\/bd-api\.{{{kuwo}}}\.cn\/api\/comments\/v3\/topInfo\? 'delpaths([["data","bannerVos"]])'
 
 # > 菜鸟去广告 · 2025-12-31
 # desc = 过滤菜鸟广告
-http-response-jq ^https:\/\/(cn-acs\.m|e2e-mtop)\.cainiao\.com\/gw\/mtop\.cainiao\.app\.e2e\.engine\.page\.fetch 'del(.data.data.data.mainSearch.bizData.searchContents, .data.data.data.operationList)'
-http-response-jq ^https:\/\/e2e-mtop\.cainiao\.com\/gw\/mtop\.cainiao\.app\.e2e\.engine\.page\.fetch\.cn 'del(.data.data.banner, .data.data.activity, .data.data.vip)'
-http-response-jq ^https:\/\/longquan-mtop\.cainiao\.com\/gw\/mtop\.com\.cainiao\.longquan\.place\.getpageresourcecontent\.cn 'del(.data.result.placeContentMap["780001"].contentList)'
-http-response-jq ^https:\/\/netflow-mtop\.cainiao\.com\/gw\/mtop\.cainiao\.guoguo\.nbnetflow\.ads 'if .data.result[0].materialId == "39017" then . else .data = {} end'
+http-response-jq ^https:\/\/(cn-acs\.m|e2e-mtop)\.{{{cainiao}}}\.com\/gw\/mtop\.{{{cainiao}}}\.app\.e2e\.engine\.page\.fetch 'del(.data.data.data.mainSearch.bizData.searchContents, .data.data.data.operationList)'
+http-response-jq ^https:\/\/e2e-mtop\.{{{cainiao}}}\.com\/gw\/mtop\.{{{cainiao}}}\.app\.e2e\.engine\.page\.fetch\.cn 'del(.data.data.banner, .data.data.activity, .data.data.vip)'
+http-response-jq ^https:\/\/longquan-mtop\.{{{cainiao}}}\.com\/gw\/mtop\.com\.{{{cainiao}}}\.longquan\.place\.getpageresourcecontent\.cn 'del(.data.result.placeContentMap["780001"].contentList)'
+http-response-jq ^https:\/\/netflow-mtop\.{{{cainiao}}}\.com\/gw\/mtop\.{{{cainiao}}}\.guoguo\.nbnetflow\.ads 'if .data.result[0].materialId == "39017" then . else .data = {} end'
 
 # > 大麦去广告 · 2025-11-09
 # desc = 移除开屏广告、轮播图广告和弹窗广告，移除搜索填充词和专属推荐。
-http-response-jq ^https:\/\/acs\.m\.taobao\.com\/gw\/mtop\.damai\.wireless\.user\.my\.content\.get\/ 'delpaths([["data","banner"]])'
-http-response-jq ^https:\/\/acs\.m\.taobao\.com\/gw\/mtop\.damai\.wireless\.user\.my\.content\.get\/ 'delpaths([["data","performFilmVip","userProfitList"]])'
-http-response-jq ^https:\/\/acs\.m\.taobao\.com\/gw\/mtop\.damai\.wireless\.mypage\.feed\/ 'delpaths([["data","feedCard"]])'
-http-response-jq ^https:\/\/acs\.m\.taobao\.com\/gw\/mtop\.damai\.mec\.aristotle\.get\/ 'delpaths([["data","data","top","keywords"]])'
+http-response-jq ^https:\/\/acs\.m\.{{{taobao}}}\.com\/gw\/mtop\.damai\.wireless\.user\.my\.content\.get\/ 'delpaths([["data","banner"]])'
+http-response-jq ^https:\/\/acs\.m\.{{{taobao}}}\.com\/gw\/mtop\.damai\.wireless\.user\.my\.content\.get\/ 'delpaths([["data","performFilmVip","userProfitList"]])'
+http-response-jq ^https:\/\/acs\.m\.{{{taobao}}}\.com\/gw\/mtop\.damai\.wireless\.mypage\.feed\/ 'delpaths([["data","feedCard"]])'
+http-response-jq ^https:\/\/acs\.m\.{{{taobao}}}\.com\/gw\/mtop\.damai\.mec\.aristotle\.get\/ 'delpaths([["data","data","top","keywords"]])'
 
 # > 得物去广告 · 2025-12-05
 # desc = 移除开屏广告、弹窗、搜索词填充、热搜榜、猜你想搜、推荐关注、推荐信息流，精简消息中心和我的页面。
-http-response-jq ^https:\/\/app\.dewu\.com\/api\/v1\/app\/biz-aggregate\/me\/user-index\? '.data.modules |= map(if .key == "wallet" then .data.menus |= map(select(.key == "coupon" or .key == "allowance" or .key == "gift" or .key == "balance")) else . end) | .data.modules |= map(select(.key != "merchant" and .key != "discountCoupon"))'
-http-response-jq ^https:\/\/app\.dewu\.com\/api\/v1\/app\/account\/wallet\/page\/entrance\? '.data.groupInfoDTOS |= map(.moduleInfoDTO = {assetModule: .moduleInfoDTO.assetModule}) | .data.moduleNames = [.data.moduleNames[] | select(. == "assetModule")] | . as $full | $full | .data.groupNames |= (map(select(. == "MAIN" or . == "ASYNC_COMMON" or . == "ASYNC_GOODS_FEEDS")))'
-http-response-jq ^https:\/\/app\.dewu\.com\/identify-discovery\/v1\/discovery\/index\? '.data.groups |= map(.items |= map(select(.title == "消息中心")))'
+http-response-jq ^https:\/\/app\.{{{dewu}}}\.com\/api\/v1\/app\/biz-aggregate\/me\/user-index\? '.data.modules |= map(if .key == "wallet" then .data.menus |= map(select(.key == "coupon" or .key == "allowance" or .key == "gift" or .key == "balance")) else . end) | .data.modules |= map(select(.key != "merchant" and .key != "discountCoupon"))'
+http-response-jq ^https:\/\/app\.{{{dewu}}}\.com\/api\/v1\/app\/account\/wallet\/page\/entrance\? '.data.groupInfoDTOS |= map(.moduleInfoDTO = {assetModule: .moduleInfoDTO.assetModule}) | .data.moduleNames = [.data.moduleNames[] | select(. == "assetModule")] | . as $full | $full | .data.groupNames |= (map(select(. == "MAIN" or . == "ASYNC_COMMON" or . == "ASYNC_GOODS_FEEDS")))'
+http-response-jq ^https:\/\/app\.{{{dewu}}}\.com\/identify-discovery\/v1\/discovery\/index\? '.data.groups |= map(.items |= map(select(.title == "消息中心")))'
 
 # > 叮咚买菜去广告 · 2025-05-13
 # desc = 移除开屏广告、弹窗推广、搜索推荐、信息流广告、悬浮广告、各页面购物推荐、精简我的页面，移除底栏和各页面AI入口。
-http-response-jq ^https:\/\/maicai\.api\.ddxq\.mobi\/homeApi\/categoriesNewDetail\? 'delpaths([["data","ad_info"]])'
-http-response-jq ^https:\/\/maicai\.api\.ddxq\.mobi\/tool\/getConfig\? 'delpaths([["data","ai_enter_config"]])'
-http-response-jq ^https?:\/\/maicai\.api\.ddxq\.mobi\/homeApi\/newDetails\? 'delpaths([["data","top_advert_data"]])'
-http-response-jq ^https?:\/\/maicai\.api\.ddxq\.mobi\/homeApi\/newDetails\? 'delpaths([["data","suspension"]])'
-http-response-jq ^https?:\/\/maicai\.api\.ddxq\.mobi\/homeApi\/newDetails\? '.data.list |= map(select(has("capsule_freedom_zone") | not))'
-http-response-jq ^https:\/\/maicai\.api\.ddxq\.mobi\/guide-service\/productApi\/productDetail\/info\? 'delpaths([["data","detail","chatEntry"]])'
-http-response-jq ^https?:\/\/maicai\.api\.ddxq\.mobi\/homeApi\/bottomNavi 'del(.data.adId?) | if (.data.bottom_list? | length > 0) then .data.bottom_list |= map(select(.type != "eatwhat")) else . end'
-http-response-jq ^https?:\/\/maicai\.api\.ddxq\.mobi\/homeApi\/homeFlowDetail 'walk(if type == "object" and has("list") then .list |= map(if type == "object" and has("multi_advertise_data_list") then del(.multi_advertise_data_list) else . end) else . end)'
+http-response-jq ^https:\/\/maicai\.api\.{{{ddxq}}}\.mobi\/homeApi\/categoriesNewDetail\? 'delpaths([["data","ad_info"]])'
+http-response-jq ^https:\/\/maicai\.api\.{{{ddxq}}}\.mobi\/tool\/getConfig\? 'delpaths([["data","ai_enter_config"]])'
+http-response-jq ^https?:\/\/maicai\.api\.{{{ddxq}}}\.mobi\/homeApi\/newDetails\? 'delpaths([["data","top_advert_data"]])'
+http-response-jq ^https?:\/\/maicai\.api\.{{{ddxq}}}\.mobi\/homeApi\/newDetails\? 'delpaths([["data","suspension"]])'
+http-response-jq ^https?:\/\/maicai\.api\.{{{ddxq}}}\.mobi\/homeApi\/newDetails\? '.data.list |= map(select(has("capsule_freedom_zone") | not))'
+http-response-jq ^https:\/\/maicai\.api\.{{{ddxq}}}\.mobi\/guide-service\/productApi\/productDetail\/info\? 'delpaths([["data","detail","chatEntry"]])'
+http-response-jq ^https?:\/\/maicai\.api\.{{{ddxq}}}\.mobi\/homeApi\/bottomNavi 'del(.data.adId?) | if (.data.bottom_list? | length > 0) then .data.bottom_list |= map(select(.type != "eatwhat")) else . end'
+http-response-jq ^https?:\/\/maicai\.api\.{{{ddxq}}}\.mobi\/homeApi\/homeFlowDetail 'walk(if type == "object" and has("list") then .list |= map(if type == "object" and has("multi_advertise_data_list") then del(.multi_advertise_data_list) else . end) else . end)'
 
 # > 高德地图去广告 · 2026-02-22
 # desc = 过滤高德地图开屏广告、各页面推广，精简我的页面。
-http-response-jq ^https:\/\/m5\.amap\.com\/ws\/shield\/search_business\/process\/marketingOperationStructured\? 'delpaths([["data","commonMaterial"]])'
-http-response-jq ^https:\/\/m5\.amap\.com\/ws\/shield\/search_business\/process\/marketingOperationStructured\? 'delpaths([["data","tipsOperationLocation"]])'
-http-response-jq ^https:\/\/m5\.amap\.com\/ws\/shield\/search_business\/process\/marketingOperationStructured\? 'delpaths([["data","resourcePlacement"]])'
-http-response-jq ^https:\/\/m5\.amap\.com\/ws\/shield\/search_poi\/homepage\? 'delpaths([["history_tags"]])'
-http-response-jq ^https:\/\/m5-zb\.amap\.com\/ws\/sharedtrip\/taxi\/order_detail_car_tips\? 'delpaths([["data","carTips","data","popupInfo"]])'
+http-response-jq ^https:\/\/m5\.{{{amap}}}\.com\/ws\/shield\/search_business\/process\/marketingOperationStructured\? 'delpaths([["data","commonMaterial"]])'
+http-response-jq ^https:\/\/m5\.{{{amap}}}\.com\/ws\/shield\/search_business\/process\/marketingOperationStructured\? 'delpaths([["data","tipsOperationLocation"]])'
+http-response-jq ^https:\/\/m5\.{{{amap}}}\.com\/ws\/shield\/search_business\/process\/marketingOperationStructured\? 'delpaths([["data","resourcePlacement"]])'
+http-response-jq ^https:\/\/m5\.{{{amap}}}\.com\/ws\/shield\/search_poi\/homepage\? 'delpaths([["history_tags"]])'
+http-response-jq ^https:\/\/m5-zb\.{{{amap}}}\.com\/ws\/sharedtrip\/taxi\/order_detail_car_tips\? 'delpaths([["data","carTips","data","popupInfo"]])'
 
 # > 京东去广告 · 2025-05-13
 # desc = 移除京东开屏广告，精简我的页面产品推广。
-http-response-jq ^https:\/\/api\.m\.jd\.com\/client\.action\?functionId=basicConfig 'if (getpath(["data","JDMessage","socketmonitor"]) | has("isSocketEstablishedAhead")) then (setpath(["data","JDMessage","socketmonitor","isSocketEstablishedAhead"]; 0)) else . end'
-http-response-jq ^https:\/\/api\.m\.jd\.com\/client\.action\?functionId=basicConfig 'if (getpath(["data","JDMessage","socketmonitor"]) | has("isSocketReport")) then (setpath(["data","JDMessage","socketmonitor","isSocketReport"]; 0)) else . end'
-http-response-jq ^https:\/\/api\.m\.jd\.com\/client\.action\?functionId=basicConfig 'if (getpath(["data","JDHttpToolKit","httpdns"]) | has("httpdns")) then (setpath(["data","JDHttpToolKit","httpdns","httpdns"]; 0)) else . end'
+http-response-jq ^https:\/\/api\.m\.{{{jd}}}\.com\/client\.action\?functionId=basicConfig 'if (getpath(["data","JDMessage","socketmonitor"]) | has("isSocketEstablishedAhead")) then (setpath(["data","JDMessage","socketmonitor","isSocketEstablishedAhead"]; 0)) else . end'
+http-response-jq ^https:\/\/api\.m\.{{{jd}}}\.com\/client\.action\?functionId=basicConfig 'if (getpath(["data","JDMessage","socketmonitor"]) | has("isSocketReport")) then (setpath(["data","JDMessage","socketmonitor","isSocketReport"]; 0)) else . end'
+http-response-jq ^https:\/\/api\.m\.{{{jd}}}\.com\/client\.action\?functionId=basicConfig 'if (getpath(["data","JDHttpToolKit","httpdns"]) | has("httpdns")) then (setpath(["data","JDHttpToolKit","httpdns","httpdns"]; 0)) else . end'
 
 # > 京东外卖去广告 · 2025-11-28
 # desc = 移除首页推广、点评页面非美食内容、购物车及我的页面推荐、搜索发现、搜索榜单，精简我的页面。
-http-response-jq ^https:\/\/color\.jddj\.com\/client\.action\?functionId=hours_home$ 'del(.result.config.searchFloor.data[].searchWords) | .result.data |= map(if .tnConfigVO?.businessCode == "nearby_HourlyGo_Operation_Tags" then empty else . end)'
-http-response-jq ^https:\/\/color\.jddj\.com\/client\.action\?functionId=wmHome$ '(.floors |= map(del(.data.tnData.newsInfo?))) | .floors |= (map(select(.mId != "newWalletIdFloor" and .mId != "recommendfloor"))) | .floors |= (map(.data |= (if .tnData? then del(.tnData.cardList, .tnData.cardListStatic, .tnData.walletList) else . end)))'
-http-response-jq ^https:\/\/api\.m\.jd\.com\/client\.action$ 'delpaths([["data","searchDTO","searchWords"]])'
-http-response-jq ^https:\/\/api\.m\.jd\.com\/client\.action$ 'delpaths([["data","wishlistDTO","bubbleTip"]])'
-http-response-jq ^https:\/\/api\.m\.jd\.com\/client\.action$ '.data.tabList |= (map(select(.code == "recommendation" or .code == "find_food")) | map(if .code == "recommendation" then .dpHomeFeedTabResultDTOList = .dpHomeFeedTabResultDTOList[0:2] else . end | .dpHomeBannerResultDTOList = []))'
+http-response-jq ^https:\/\/color\.{{{jd}}}dj\.com\/client\.action\?functionId=hours_home$ 'del(.result.config.searchFloor.data[].searchWords) | .result.data |= map(if .tnConfigVO?.businessCode == "nearby_HourlyGo_Operation_Tags" then empty else . end)'
+http-response-jq ^https:\/\/color\.{{{jd}}}dj\.com\/client\.action\?functionId=wmHome$ '(.floors |= map(del(.data.tnData.newsInfo?))) | .floors |= (map(select(.mId != "newWalletIdFloor" and .mId != "recommendfloor"))) | .floors |= (map(.data |= (if .tnData? then del(.tnData.cardList, .tnData.cardListStatic, .tnData.walletList) else . end)))'
+http-response-jq ^https:\/\/api\.m\.{{{jd}}}\.com\/client\.action$ 'delpaths([["data","searchDTO","searchWords"]])'
+http-response-jq ^https:\/\/api\.m\.{{{jd}}}\.com\/client\.action$ 'delpaths([["data","wishlistDTO","bubbleTip"]])'
+http-response-jq ^https:\/\/api\.m\.{{{jd}}}\.com\/client\.action$ '.data.tabList |= (map(select(.code == "recommendation" or .code == "find_food")) | map(if .code == "recommendation" then .dpHomeFeedTabResultDTOList = .dpHomeFeedTabResultDTOList[0:2] else . end | .dpHomeBannerResultDTOList = []))'
 
 # > 酷安去广告 · 2025-05-13
 # desc = 过滤酷安广告
-http-response-jq ^https:\/\/api\.coolapk\.com\/v6\/feed\/detail\? '.data.hotReplyRows |= if . then map(select(.id?)) else . end | .data.topReplyRows |= if . then map(select(.id?)) else . end | reduce ("detailSponsorCard", "include_goods", "include_goods_ids") as $key (.; .data[$key]=[])'
-http-response-jq ^https:\/\/api\.coolapk\.com\/v6\/feed\/replyList 'if .data? and ((.data | type) == "array") and (.data | length > 0) then .data |= map(select(.id?)) else . end'
-http-response-jq ^https:\/\/api\.coolapk\.com\/v6\/main\/dataList '.data |= (if (type=="array" and length>0) then map(select((.entityTemplate!="sponsorCard") and (.title!="精选配件"))) else . end)'
-http-response-jq ^https:\/\/api\.coolapk\.com\/v6\/page\/dataList 'if (.data | length > 0) then .data |= map(select((.title? != "酷安热搜") and (.entityTemplate? != "imageScaleCard") and (.entityTemplate? != "sponsorCard"))) else . end'
-http-response-jq ^https:\/\/api\.coolapk\.com\/v6\/main\/indexV8 '.data |= (if length > 0 then map(select((.entityTemplate != "sponsorCard") and ([8639,29349,33006,32557] | index(.entityId) | not) and ((.title// "" | test("值得买|红包")) | not))) else . end)'
-http-response-jq ^https:\/\/api\.coolapk\.com\/v6\/main\/init '.data |= map(select(.entityId? | [944,945,6390] | index(.) | not) | if .entityId == 20131 then .entities |= map(select(.title != "酷品")) else . end)'
+http-response-jq ^https:\/\/api\.{{{coolapk}}}\.com\/v6\/feed\/detail\? '.data.hotReplyRows |= if . then map(select(.id?)) else . end | .data.topReplyRows |= if . then map(select(.id?)) else . end | reduce ("detailSponsorCard", "include_goods", "include_goods_ids") as $key (.; .data[$key]=[])'
+http-response-jq ^https:\/\/api\.{{{coolapk}}}\.com\/v6\/feed\/replyList 'if .data? and ((.data | type) == "array") and (.data | length > 0) then .data |= map(select(.id?)) else . end'
+http-response-jq ^https:\/\/api\.{{{coolapk}}}\.com\/v6\/main\/dataList '.data |= (if (type=="array" and length>0) then map(select((.entityTemplate!="sponsorCard") and (.title!="精选配件"))) else . end)'
+http-response-jq ^https:\/\/api\.{{{coolapk}}}\.com\/v6\/page\/dataList 'if (.data | length > 0) then .data |= map(select((.title? != "酷安热搜") and (.entityTemplate? != "imageScaleCard") and (.entityTemplate? != "sponsorCard"))) else . end'
+http-response-jq ^https:\/\/api\.{{{coolapk}}}\.com\/v6\/main\/indexV8 '.data |= (if length > 0 then map(select((.entityTemplate != "sponsorCard") and ([8639,29349,33006,32557] | index(.entityId) | not) and ((.title// "" | test("值得买|红包")) | not))) else . end)'
+http-response-jq ^https:\/\/api\.{{{coolapk}}}\.com\/v6\/main\/init '.data |= map(select(.entityId? | [944,945,6390] | index(.) | not) | if .entityId == 20131 then .entities |= map(select(.title != "酷品")) else . end)'
 
 # > 快递100去广告 · 2025-05-13
 # desc = 移除横幅广告、弹窗广告，精简首页。
-http-response-jq ^https?:\/\/p\.kuaidi100\.com\/mobile\/mobileapi\.do$ 'delpaths([["adsplash"]])'
-http-response-jq ^https?:\/\/p\.kuaidi100\.com\/mobile\/mobileapi\.do$ 'delpaths([["adIsConsumable"]])'
-http-response-jq ^https?:\/\/p\.kuaidi100\.com\/mobile\/mobileapi\.do$ 'delpaths([["adProductId"]])'
-http-response-jq ^https?:\/\/p\.kuaidi100\.com\/mobile\/mobileapi\.do$ 'delpaths([["nologin_tips"]])'
-http-response-jq ^https?:\/\/p\.kuaidi100\.com\/mobile\/mobileapi\.do$ 'delpaths([["index_banner"]])'
-http-response-jq ^https?:\/\/p\.kuaidi100\.com\/mobile\/mobileapi\.do$ 'delpaths([["me_banner"]])'
-http-response-jq ^https?:\/\/p\.kuaidi100\.com\/mobile\/mobileapi\.do$ 'delpaths([["index_banner_shadow"]])'
-http-response-jq ^https?:\/\/p\.kuaidi100\.com\/mobile\/mobileapi\.do$ 'delpaths([["adshongbao"]])'
-http-response-jq ^https?:\/\/p\.kuaidi100\.com\/mobile\/mobileapi\.do$ 'delpaths([["adsapp_homepage_ticket_pop"]])'
-http-response-jq ^https?:\/\/p\.kuaidi100\.com\/mobile\/mobileapi\.do$ 'delpaths([["adsoptimizationsend"]])'
-http-response-jq ^https?:\/\/p\.kuaidi100\.com\/mobile\/mobileapi\.do$ 'delpaths([["adsapp_activity_ad_array"]])'
-http-response-jq ^https?:\/\/p\.kuaidi100\.com\/mobile\/mobileapi\.do$ 'delpaths([["adbanner"]])'
-http-response-jq ^https?:\/\/p\.kuaidi100\.com\/mobile\/mobileapi\.do$ 'delpaths([["adposition"]])'
-http-response-jq ^https?:\/\/p\.kuaidi100\.com\/mobile\/mobileapi\.do$ 'delpaths([["adShowAgainTime"]])'
-http-response-jq ^https?:\/\/p\.kuaidi100\.com\/apicenter\/xcx\.dox 'delpaths([["data","secondMenuList"]])'
+http-response-jq ^https?:\/\/p\.{{{kuaidi100}}}\.com\/mobile\/mobileapi\.do$ 'delpaths([["adsplash"]])'
+http-response-jq ^https?:\/\/p\.{{{kuaidi100}}}\.com\/mobile\/mobileapi\.do$ 'delpaths([["adIsConsumable"]])'
+http-response-jq ^https?:\/\/p\.{{{kuaidi100}}}\.com\/mobile\/mobileapi\.do$ 'delpaths([["adProductId"]])'
+http-response-jq ^https?:\/\/p\.{{{kuaidi100}}}\.com\/mobile\/mobileapi\.do$ 'delpaths([["nologin_tips"]])'
+http-response-jq ^https?:\/\/p\.{{{kuaidi100}}}\.com\/mobile\/mobileapi\.do$ 'delpaths([["index_banner"]])'
+http-response-jq ^https?:\/\/p\.{{{kuaidi100}}}\.com\/mobile\/mobileapi\.do$ 'delpaths([["me_banner"]])'
+http-response-jq ^https?:\/\/p\.{{{kuaidi100}}}\.com\/mobile\/mobileapi\.do$ 'delpaths([["index_banner_shadow"]])'
+http-response-jq ^https?:\/\/p\.{{{kuaidi100}}}\.com\/mobile\/mobileapi\.do$ 'delpaths([["adshongbao"]])'
+http-response-jq ^https?:\/\/p\.{{{kuaidi100}}}\.com\/mobile\/mobileapi\.do$ 'delpaths([["adsapp_homepage_ticket_pop"]])'
+http-response-jq ^https?:\/\/p\.{{{kuaidi100}}}\.com\/mobile\/mobileapi\.do$ 'delpaths([["adsoptimizationsend"]])'
+http-response-jq ^https?:\/\/p\.{{{kuaidi100}}}\.com\/mobile\/mobileapi\.do$ 'delpaths([["adsapp_activity_ad_array"]])'
+http-response-jq ^https?:\/\/p\.{{{kuaidi100}}}\.com\/mobile\/mobileapi\.do$ 'delpaths([["adbanner"]])'
+http-response-jq ^https?:\/\/p\.{{{kuaidi100}}}\.com\/mobile\/mobileapi\.do$ 'delpaths([["adposition"]])'
+http-response-jq ^https?:\/\/p\.{{{kuaidi100}}}\.com\/mobile\/mobileapi\.do$ 'delpaths([["adShowAgainTime"]])'
+http-response-jq ^https?:\/\/p\.{{{kuaidi100}}}\.com\/apicenter\/xcx\.dox 'delpaths([["data","secondMenuList"]])'
 
 # > 芒果TV去广告 · 2025-11-09
 # desc = 移除开屏广告、信息流广告、播放页广告，精简我的页面。
@@ -963,190 +963,190 @@ http-response-jq ^https?:\/\/mobile\.api\.(mgtv|hunantv)\.com\/mobile\/config\? 
 http-response-jq ^https?:\/\/mobile\.api\.(mgtv|hunantv)\.com\/mobile\/config\? 'if (getpath(["data"]) | has("playview_box_ad_switch")) then (setpath(["data","playview_box_ad_switch"]; 0)) else . end'
 http-response-jq ^https?:\/\/mobile\.api\.(mgtv|hunantv)\.com\/mobile\/config\? 'if (getpath(["data"]) | has("topBarSwitch")) then (setpath(["data","topBarSwitch"]; 0)) else . end'
 http-response-jq ^https?:\/\/mobile\.api\.(mgtv|hunantv)\.com\/mobile\/config\? 'if (getpath(["data"]) | has("VIPSDKB2")) then (setpath(["data","VIPSDKB2"]; 0)) else . end'
-http-response-jq ^https:\/\/me\.bz\.mgtv\.com\/v3\/module\/list\? '.data.list |= map(select(.id | IN(1, 2, 4, 7))) | .data.list |= map(if .moduleType == 2 then .data |= map(select(.moduleType == 11)) elif .moduleType == 4 then .data |= map(select(.moduleType == 14 or .moduleType == 23)) elif .moduleType == 7 then .data |= map(select(.moduleType == 16 and .title != "音乐广场")) else . end)'
-http-response-jq ^https:\/\/me\.bz\.mgtv\.com\/v4\/module\/list\? '.data.list |= (map(select(.id != 3 and .id != 7))|map(if .id==2 then .data|=map(select(.id!=65))elif .id==4 then .data|=map(select(.title!="追更banner" and .id!=57))elif .id==5 then .data|=(map(select(.id==9 or .id==13))|map(if .id==9 then .list|=map(select(.id==20 or .id==60 or .id==18)) else . end))elif .id==6 then .data|=map(select(.id==15)) else . end))'
-http-response-jq ^https?:\/\/dc\d?\.bz\.mgtv\.com\/dynamic\/v\d\/channel\/index\/\w 'delpaths([["adInfo"]])'
-http-response-jq ^https?:\/\/dc\d?\.bz\.mgtv\.com\/dynamic\/v\d\/channel\/index\/\w '.data |= map(select(.moduleEntityId != "10579" and .moduleEntityId != "9686")) | .moduleIDS |= map(select(.moduleEntityId != "10579" and .moduleEntityId != "9686"))'
-http-response-jq ^https:\/\/mobile-thor\.api\.mgtv\.com\/v\d+\/vod\/info\? 'delpaths([["data","config","ad"]])'
-http-response-jq ^https:\/\/mobile-thor\.api\.mgtv\.com\/v\d+\/vod\/info\? 'delpaths([["data","config","vipNav"]])'
-http-response-jq ^https:\/\/mobile-thor\.api\.mgtv\.com\/v\d+\/vod\/info\? 'delpaths([["data","template","skinList"]])'
-http-response-jq ^https:\/\/mobile-thor\.api\.mgtv\.com\/v\d+\/vod\/info\? 'delpaths([["data","template","theme"]])'
-http-response-jq ^https:\/\/mobile-thor\.api\.mgtv\.com\/v\d+\/vod\/info\? '.data.tabs |= map(select(.name == "视频" or .name == "讨论")) | .data.template.modules |= map(if .clipInfo.ext?.ipPublishEntrance then .clipInfo |= del(.ext) else . end) | .data.template.modules |= map(select(.dataType == 101 or .dataType == 201)) | .data.template.modules |= map(.media.list |= (if type == "array" then map(select(.type != 0)) else . end))'
-http-response-jq ^https:\/\/comment\.mgtv\.com\/v\d\/comment\/getCommentList\? '.data.list |= map(select(.type == 0))'
+http-response-jq ^https:\/\/me\.bz\.mg{{{tv}}}\.com\/v3\/module\/list\? '.data.list |= map(select(.id | IN(1, 2, 4, 7))) | .data.list |= map(if .moduleType == 2 then .data |= map(select(.moduleType == 11)) elif .moduleType == 4 then .data |= map(select(.moduleType == 14 or .moduleType == 23)) elif .moduleType == 7 then .data |= map(select(.moduleType == 16 and .title != "音乐广场")) else . end)'
+http-response-jq ^https:\/\/me\.bz\.mg{{{tv}}}\.com\/v4\/module\/list\? '.data.list |= (map(select(.id != 3 and .id != 7))|map(if .id==2 then .data|=map(select(.id!=65))elif .id==4 then .data|=map(select(.title!="追更banner" and .id!=57))elif .id==5 then .data|=(map(select(.id==9 or .id==13))|map(if .id==9 then .list|=map(select(.id==20 or .id==60 or .id==18)) else . end))elif .id==6 then .data|=map(select(.id==15)) else . end))'
+http-response-jq ^https?:\/\/dc\d?\.bz\.mg{{{tv}}}\.com\/dynamic\/v\d\/channel\/index\/\w 'delpaths([["adInfo"]])'
+http-response-jq ^https?:\/\/dc\d?\.bz\.mg{{{tv}}}\.com\/dynamic\/v\d\/channel\/index\/\w '.data |= map(select(.moduleEntityId != "10579" and .moduleEntityId != "9686")) | .moduleIDS |= map(select(.moduleEntityId != "10579" and .moduleEntityId != "9686"))'
+http-response-jq ^https:\/\/mobile-thor\.api\.mg{{{tv}}}\.com\/v\d+\/vod\/info\? 'delpaths([["data","config","ad"]])'
+http-response-jq ^https:\/\/mobile-thor\.api\.mg{{{tv}}}\.com\/v\d+\/vod\/info\? 'delpaths([["data","config","vipNav"]])'
+http-response-jq ^https:\/\/mobile-thor\.api\.mg{{{tv}}}\.com\/v\d+\/vod\/info\? 'delpaths([["data","template","skinList"]])'
+http-response-jq ^https:\/\/mobile-thor\.api\.mg{{{tv}}}\.com\/v\d+\/vod\/info\? 'delpaths([["data","template","theme"]])'
+http-response-jq ^https:\/\/mobile-thor\.api\.mg{{{tv}}}\.com\/v\d+\/vod\/info\? '.data.tabs |= map(select(.name == "视频" or .name == "讨论")) | .data.template.modules |= map(if .clipInfo.ext?.ipPublishEntrance then .clipInfo |= del(.ext) else . end) | .data.template.modules |= map(select(.dataType == 101 or .dataType == 201)) | .data.template.modules |= map(.media.list |= (if type == "array" then map(select(.type != 0)) else . end))'
+http-response-jq ^https:\/\/comment\.mg{{{tv}}}\.com\/v\d\/comment\/getCommentList\? '.data.list |= map(select(.type == 0))'
 
 # > 墨迹天气去广告 · 2025-05-13
 # desc = 移除天气页面横幅、工具栏，移除时景关注页面推荐，精简我的页面。
-http-response-jq ^https:\/\/mme\.api\.moji\.com\/json\/entrance\/list$ 'del(.entrance_region_res_list[] | select(.region_name == "皇冠区域" or .region_name == "banner区")) | .entrance_region_res_list[].entrance_res_list |= if . then map(select(.entrance_name | . != "墨迹钱包" and . != "墨圈")) else . end'
+http-response-jq ^https:\/\/mme\.api\.{{{moji}}}\.com\/json\/entrance\/list$ 'del(.entrance_region_res_list[] | select(.region_name == "皇冠区域" or .region_name == "banner区")) | .entrance_region_res_list[].entrance_res_list |= if . then map(select(.entrance_name | . != "墨迹钱包" and . != "墨圈")) else . end'
 
 # > 拼多多去广告 · 2026-02-28
 # desc = 移除开屏广告、底栏多多视频、会场入口、聊天页面精选推荐及推广，精简首页和个人中心。
-http-response-jq ^https:\/\/api\.pinduoduo\.com\/api\/alexa\/homepage\/hub\? 'delpaths([["result","dy_module","irregular_banner_dy"]])'
-http-response-jq ^https:\/\/api\.pinduoduo\.com\/api\/alexa\/homepage\/hub\? 'delpaths([["result","icon_set"]])'
-http-response-jq ^https:\/\/api\.pinduoduo\.com\/api\/alexa\/homepage\/hub\? 'delpaths([["result","search_bar_hot_query"]])'
-http-response-jq ^https:\/\/api\.pinduoduo\.com\/api\/alexa\/homepage\/hub\? 'delpaths([["result","dy_module","irregular_banner_dy"]])'
-http-response-jq ^https:\/\/api\.pinduoduo\.com\/api\/alexa\/homepage\/hub\? '.result.bottom_tabs? |= map(select(.link | IN("index.html", "chat_list.html", "personal.html"))) | .result.buffer_bottom_tabs? |= map(select(.link | IN("index.html", "chat_list.html", "personal.html"))) | .result.all_top_opts |= map(del(.selected_image, .image, .height, .width))'
-http-response-jq ^https:\/\/api\.pinduoduo\.com\/search\? 'delpaths([["expansion"]])'
-http-response-jq ^https:\/\/api\.pinduoduo\.com\/api\/philo\/personal\/hub\? 'delpaths([["monthly_card_entrance"]])'
-http-response-jq ^https:\/\/api\.pinduoduo\.com\/api\/philo\/personal\/hub\? 'delpaths([["personal_center_style_v2_vo"]])'
-http-response-jq ^https:\/\/api\.pinduoduo\.com\/api\/philo\/personal\/hub\? 'delpaths([["icon_set","icons"]])'
-http-response-jq ^https:\/\/api\.pinduoduo\.com\/api\/philo\/personal\/hub\? 'delpaths([["icon_set","top_personal_icons"]])'
-http-response-jq ^https:\/\/api\.pinduoduo\.com\/api\/oak\/integration\/render\? 'delpaths([["bottom_section_list"]])'
-http-response-jq ^https:\/\/api\.pinduoduo\.com\/api\/oak\/integration\/render\? 'delpaths([["ui","bottom_section"]])'
-http-response-jq ^https:\/\/api\.pinduoduo\.com\/api\/oak\/integration\/render\? 'delpaths([["ui","live_section","float_info"]])'
-http-response-jq ^https:\/\/api\.pinduoduo\.com\/api\/caterham\/v3\/query\/order_detail_group\? 'delpaths([["data","goods_list"]])'
-http-response-jq ^https:\/\/api\.pinduoduo\.com\/order\/ 'delpaths([["marketing_banner_vo"]])'
-http-response-jq ^https:\/\/api\.pinduoduo\.com\/order\/ 'delpaths([["shipping","banner_above_recommend"]])'
-http-response-jq ^https:\/\/api\.pinduoduo\.com\/api\/aristotle\/order_list_v4\? '.orders |= map(.order_buttons |= map(del(.order_growth_tip)))'
+http-response-jq ^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/alexa\/homepage\/hub\? 'delpaths([["result","dy_module","irregular_banner_dy"]])'
+http-response-jq ^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/alexa\/homepage\/hub\? 'delpaths([["result","icon_set"]])'
+http-response-jq ^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/alexa\/homepage\/hub\? 'delpaths([["result","search_bar_hot_query"]])'
+http-response-jq ^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/alexa\/homepage\/hub\? 'delpaths([["result","dy_module","irregular_banner_dy"]])'
+http-response-jq ^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/alexa\/homepage\/hub\? '.result.bottom_tabs? |= map(select(.link | IN("index.html", "chat_list.html", "personal.html"))) | .result.buffer_bottom_tabs? |= map(select(.link | IN("index.html", "chat_list.html", "personal.html"))) | .result.all_top_opts |= map(del(.selected_image, .image, .height, .width))'
+http-response-jq ^https:\/\/api\.{{{pinduoduo}}}\.com\/search\? 'delpaths([["expansion"]])'
+http-response-jq ^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/philo\/personal\/hub\? 'delpaths([["monthly_card_entrance"]])'
+http-response-jq ^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/philo\/personal\/hub\? 'delpaths([["personal_center_style_v2_vo"]])'
+http-response-jq ^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/philo\/personal\/hub\? 'delpaths([["icon_set","icons"]])'
+http-response-jq ^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/philo\/personal\/hub\? 'delpaths([["icon_set","top_personal_icons"]])'
+http-response-jq ^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/oak\/integration\/render\? 'delpaths([["bottom_section_list"]])'
+http-response-jq ^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/oak\/integration\/render\? 'delpaths([["ui","bottom_section"]])'
+http-response-jq ^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/oak\/integration\/render\? 'delpaths([["ui","live_section","float_info"]])'
+http-response-jq ^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/caterham\/v3\/query\/order_detail_group\? 'delpaths([["data","goods_list"]])'
+http-response-jq ^https:\/\/api\.{{{pinduoduo}}}\.com\/order\/ 'delpaths([["marketing_banner_vo"]])'
+http-response-jq ^https:\/\/api\.{{{pinduoduo}}}\.com\/order\/ 'delpaths([["shipping","banner_above_recommend"]])'
+http-response-jq ^https:\/\/api\.{{{pinduoduo}}}\.com\/api\/aristotle\/order_list_v4\? '.orders |= map(.order_buttons |= map(del(.order_growth_tip)))'
 
 # > 什么值得买去广告 · 2025-11-27
 # desc = 移除开屏广告、信息流广告、各类横幅广告、搜索页广告、文章内广告，移除活动皮肤、精简我的页面。
-http-response-jq ^https:\/\/app-api\.smzdm\.com\/util\/update$ 'if (getpath(["data"]) | has("silence_local_push")) then (setpath(["data","silence_local_push"]; 0)) else . end'
-http-response-jq ^https:\/\/app-api\.smzdm\.com\/util\/update$ 'if (getpath(["data"]) | has("baichuan_redirect_switch")) then (setpath(["data","baichuan_redirect_switch"]; 0)) else . end'
-http-response-jq ^https:\/\/app-api\.smzdm\.com\/util\/update$ 'delpaths([["data","silence_local_push_msg"]])'
-http-response-jq ^https:\/\/app-api\.smzdm\.com\/util\/update$ 'delpaths([["data","video_cache_num_configs"]])'
-http-response-jq ^https:\/\/app-api\.smzdm\.com\/util\/update$ 'delpaths([["data","haojia_widget"]])'
-http-response-jq ^https:\/\/app-api\.smzdm\.com\/util\/update$ 'delpaths([["data","widget"]])'
-http-response-jq ^https:\/\/app-api\.smzdm\.com\/util\/update$ 'delpaths([["data","operation_float"]])'
-http-response-jq ^https:\/\/app-api\.smzdm\.com\/util\/update$ 'def r: if type=="object" then if has("ad_campaign_name") and (.ad_campaign_name|type=="string") and (.ad_campaign_name|test("\\S")) then empty else . end elif type=="array" then map(r) else . end; .data.operation_float |= map(map(r))'
-http-response-jq ^https:\/\/homepage-api\.smzdm\.com\/v3\/home\? '   .data.component |= map(    if (.zz_content | type) == "array" then     .zz_content |= map(       select(         ( (.ad_campaign_id? | type == "string" and length > 0)// false ) or         ( (.tag? | type == "string" and length > 0)// false ) or         ( (.model_type? == "ads" and (type == "string"))// false )         | not       )     )   else . end )  | .data.component |= map(   select(.zz_type == "circular_banner" or .zz_type == "filter" or .zz_type == "list") )  | .data.component |= map(   .zz_content |= (     if type == "array" then       map(         if type == "object" and (.article_channel_type// "") == "questionnaire" then           empty         else           .         end       )     else       .     end   ) )   | del(.data.theme)  | .data.component |= map(   if .zz_content | type == "object" then     .zz_content |= del(.circular_banner_option)   else     .   end )'
-http-response-jq ^https:\/\/haojia-api\.smzdm\.com\/home\/list\? 'delpaths([["data","header_operation","theme"]])'
-http-response-jq ^https:\/\/haojia-api\.smzdm\.com\/home\/list\? '.data.rows |= map(select(.cell_type == "39001")) | .data.banner_v2 |= map(select(.cell_type == "21028"))'
-http-response-jq ^https:\/\/haojia\.m\.smzdm\.com\/detail_modul\/user_related_modul\? 'delpaths([["data","super_coupon"]])'
-http-response-jq ^https:\/\/haojia\.m\.smzdm\.com\/detail_modul\/other_modul\? 'delpaths([["data","banner"]])'
-http-response-jq ^https:\/\/user-api\.smzdm\.com\/vip$ 'delpaths([["data","activity_entrance_info"]])'
-http-response-jq ^https:\/\/user-api\.smzdm\.com\/vip$ 'delpaths([["data","big_banner"]])'
-http-response-jq ^https:\/\/user-api\.smzdm\.com\/vip$ 'delpaths([["data","top_banner"]])'
-http-response-jq ^https:\/\/user-api\.smzdm\.com\/vip$ 'delpaths([["data","banner_switch"]])'
-http-response-jq ^https:\/\/user-api\.smzdm\.com\/vip$ 'delpaths([["data","yaoqingshaiwu"]])'
-http-response-jq ^https:\/\/s-api\.smzdm\.com\/sou\/list_v10\? '.data.rows |= map(select(.model_type != "ads")) | .data.top_aladdin |= map(select(has("ad") | not))'
-http-response-jq ^https:\/\/s-api\.smzdm\.com\/sou\/filter\/tags\/hot_tags\? 'delpaths([["data","search_faxian"]])'
-http-response-jq ^https:\/\/s-api\.smzdm\.com\/sou\/filter\/tags\/hot_tags\? 'delpaths([["data","tonglan"]])'
-http-response-jq ^https:\/\/s-api\.smzdm\.com\/sou\/filter\/tags\/hot_tags\? 'delpaths([["data","hongbao"]])'
-http-response-jq ^https:\/\/s-api\.smzdm\.com\/sou\/filter\/tags\/hot_tags\? '.data.search_hot.home |= map(select(.article_tag.article_title != "广告")) | .data.search_hot.home |= map(select(has("pos")))'
-http-response-jq ^https:\/\/haojia-api\.smzdm\.com\/detail\/\d+\? 'delpaths([["data","quan_log"]])'
-http-response-jq ^https:\/\/haojia-cdn\.smzdm\.com\/preload\/\d+\/fiphone\/v\d+_\d+_\d+\/wx\d+\/im\d+\/[0-9a-z]+\/[0-9a-z]+\.json$ 'delpaths([["data","quan_log"]])'
-http-response-jq ^https:\/\/post\.m\.smzdm\.com\/ajax_app\/ajax_get_footer_list\? 'delpaths([["data","tuiguang_ad"]])'
-http-response-jq ^https:\/\/post\.m\.smzdm\.com\/ajax_app\/ajax_get_footer_list\? 'delpaths([["data","activity_banner"]])'
+http-response-jq ^https:\/\/app-api\.{{{smzdm}}}\.com\/util\/update$ 'if (getpath(["data"]) | has("silence_local_push")) then (setpath(["data","silence_local_push"]; 0)) else . end'
+http-response-jq ^https:\/\/app-api\.{{{smzdm}}}\.com\/util\/update$ 'if (getpath(["data"]) | has("baichuan_redirect_switch")) then (setpath(["data","baichuan_redirect_switch"]; 0)) else . end'
+http-response-jq ^https:\/\/app-api\.{{{smzdm}}}\.com\/util\/update$ 'delpaths([["data","silence_local_push_msg"]])'
+http-response-jq ^https:\/\/app-api\.{{{smzdm}}}\.com\/util\/update$ 'delpaths([["data","video_cache_num_configs"]])'
+http-response-jq ^https:\/\/app-api\.{{{smzdm}}}\.com\/util\/update$ 'delpaths([["data","haojia_widget"]])'
+http-response-jq ^https:\/\/app-api\.{{{smzdm}}}\.com\/util\/update$ 'delpaths([["data","widget"]])'
+http-response-jq ^https:\/\/app-api\.{{{smzdm}}}\.com\/util\/update$ 'delpaths([["data","operation_float"]])'
+http-response-jq ^https:\/\/app-api\.{{{smzdm}}}\.com\/util\/update$ 'def r: if type=="object" then if has("ad_campaign_name") and (.ad_campaign_name|type=="string") and (.ad_campaign_name|test("\\S")) then empty else . end elif type=="array" then map(r) else . end; .data.operation_float |= map(map(r))'
+http-response-jq ^https:\/\/homepage-api\.{{{smzdm}}}\.com\/v3\/home\? '   .data.component |= map(    if (.zz_content | type) == "array" then     .zz_content |= map(       select(         ( (.ad_campaign_id? | type == "string" and length > 0)// false ) or         ( (.tag? | type == "string" and length > 0)// false ) or         ( (.model_type? == "ads" and (type == "string"))// false )         | not       )     )   else . end )  | .data.component |= map(   select(.zz_type == "circular_banner" or .zz_type == "filter" or .zz_type == "list") )  | .data.component |= map(   .zz_content |= (     if type == "array" then       map(         if type == "object" and (.article_channel_type// "") == "questionnaire" then           empty         else           .         end       )     else       .     end   ) )   | del(.data.theme)  | .data.component |= map(   if .zz_content | type == "object" then     .zz_content |= del(.circular_banner_option)   else     .   end )'
+http-response-jq ^https:\/\/haojia-api\.{{{smzdm}}}\.com\/home\/list\? 'delpaths([["data","header_operation","theme"]])'
+http-response-jq ^https:\/\/haojia-api\.{{{smzdm}}}\.com\/home\/list\? '.data.rows |= map(select(.cell_type == "39001")) | .data.banner_v2 |= map(select(.cell_type == "21028"))'
+http-response-jq ^https:\/\/haojia\.m\.{{{smzdm}}}\.com\/detail_modul\/user_related_modul\? 'delpaths([["data","super_coupon"]])'
+http-response-jq ^https:\/\/haojia\.m\.{{{smzdm}}}\.com\/detail_modul\/other_modul\? 'delpaths([["data","banner"]])'
+http-response-jq ^https:\/\/user-api\.{{{smzdm}}}\.com\/vip$ 'delpaths([["data","activity_entrance_info"]])'
+http-response-jq ^https:\/\/user-api\.{{{smzdm}}}\.com\/vip$ 'delpaths([["data","big_banner"]])'
+http-response-jq ^https:\/\/user-api\.{{{smzdm}}}\.com\/vip$ 'delpaths([["data","top_banner"]])'
+http-response-jq ^https:\/\/user-api\.{{{smzdm}}}\.com\/vip$ 'delpaths([["data","banner_switch"]])'
+http-response-jq ^https:\/\/user-api\.{{{smzdm}}}\.com\/vip$ 'delpaths([["data","yaoqingshaiwu"]])'
+http-response-jq ^https:\/\/s-api\.{{{smzdm}}}\.com\/sou\/list_v10\? '.data.rows |= map(select(.model_type != "ads")) | .data.top_aladdin |= map(select(has("ad") | not))'
+http-response-jq ^https:\/\/s-api\.{{{smzdm}}}\.com\/sou\/filter\/tags\/hot_tags\? 'delpaths([["data","search_faxian"]])'
+http-response-jq ^https:\/\/s-api\.{{{smzdm}}}\.com\/sou\/filter\/tags\/hot_tags\? 'delpaths([["data","tonglan"]])'
+http-response-jq ^https:\/\/s-api\.{{{smzdm}}}\.com\/sou\/filter\/tags\/hot_tags\? 'delpaths([["data","hongbao"]])'
+http-response-jq ^https:\/\/s-api\.{{{smzdm}}}\.com\/sou\/filter\/tags\/hot_tags\? '.data.search_hot.home |= map(select(.article_tag.article_title != "广告")) | .data.search_hot.home |= map(select(has("pos")))'
+http-response-jq ^https:\/\/haojia-api\.{{{smzdm}}}\.com\/detail\/\d+\? 'delpaths([["data","quan_log"]])'
+http-response-jq ^https:\/\/haojia-cdn\.{{{smzdm}}}\.com\/preload\/\d+\/fiphone\/v\d+_\d+_\d+\/wx\d+\/im\d+\/[0-9a-z]+\/[0-9a-z]+\.json$ 'delpaths([["data","quan_log"]])'
+http-response-jq ^https:\/\/post\.m\.{{{smzdm}}}\.com\/ajax_app\/ajax_get_footer_list\? 'delpaths([["data","tuiguang_ad"]])'
+http-response-jq ^https:\/\/post\.m\.{{{smzdm}}}\.com\/ajax_app\/ajax_get_footer_list\? 'delpaths([["data","activity_banner"]])'
 
 # > 顺丰速运去广告 · 2026-02-23
 # desc = 移除开屏广告、首页下拉抽屉、首页推广、应用内悬浮窗、横幅广告，移除主题，精简我的页面。
-http-response-jq ^https:\/\/ccsp-egmas\.sf-express\.com\/cx-app-base\/base\/app\/appHomeConfig\/query$ '.obj |= map(select(.position != 2))'
+http-response-jq ^https:\/\/ccsp-egmas\.{{{sf-express}}}\.com\/cx-app-base\/base\/app\/appHomeConfig\/query$ '.obj |= map(select(.position != 2))'
 
 # > 淘票票去广告 · 2025-11-08
 # desc = 移除开屏广告、悬浮广告、轮播图广告和弹窗广告，移除搜索填充词和为你推荐。
-http-response-jq ^https:\/\/acs\.m\.taobao\.com\/gw\/mtop\.film\.mtopintegrationapi\.homeconfig\/ 'delpaths([["data","returnValue","floatingBanner"]])'
-http-response-jq ^https:\/\/acs\.m\.taobao\.com\/gw\/mtop\.film\.mtopintegrationapi\.homeconfig\/ 'delpaths([["data","returnValue","searchShadeList"]])'
-http-response-jq ^https:\/\/acs\.m\.taobao\.com\/gw\/mtop\.film\.mtopintegrationapi\.homeconfig\/ '.data.returnValue.topTab |= map(select(.activeImage | not)) | .data.returnValue.topTab |= map(del(.backgroundColor))'
-http-response-jq ^https:\/\/acs\.m\.taobao\.com\/gw\/mtop\.film\.life\.aristotle\.get\/ 'def filter_nodes: map(if .data.componentId? and (.data.componentId | type == "string") and (.data.componentId | (contains("tpp_banner") or . == "tpp_guess_like")) then empty else .nodes |= (if . then filter_nodes else . end) end); .data.nodes |= (if . then filter_nodes else . end)'
+http-response-jq ^https:\/\/acs\.m\.{{{taobao}}}\.com\/gw\/mtop\.film\.mtopintegrationapi\.homeconfig\/ 'delpaths([["data","returnValue","floatingBanner"]])'
+http-response-jq ^https:\/\/acs\.m\.{{{taobao}}}\.com\/gw\/mtop\.film\.mtopintegrationapi\.homeconfig\/ 'delpaths([["data","returnValue","searchShadeList"]])'
+http-response-jq ^https:\/\/acs\.m\.{{{taobao}}}\.com\/gw\/mtop\.film\.mtopintegrationapi\.homeconfig\/ '.data.returnValue.topTab |= map(select(.activeImage | not)) | .data.returnValue.topTab |= map(del(.backgroundColor))'
+http-response-jq ^https:\/\/acs\.m\.{{{taobao}}}\.com\/gw\/mtop\.film\.life\.aristotle\.get\/ 'def filter_nodes: map(if .data.componentId? and (.data.componentId | type == "string") and (.data.componentId | (contains("tpp_banner") or . == "tpp_guess_like")) then empty else .nodes |= (if . then filter_nodes else . end) end); .data.nodes |= (if . then filter_nodes else . end)'
 
 # > 网易有道词典去广告 · 2025-05-13
 # desc = 移除开屏广告、弹窗广告、横幅广告、信息流广告、旧版翻译页面广告及搜索填充词。
-http-response-jq ^https:\/\/dict\.youdao\.com\/homepage\/toolbar\/get\? 'delpaths([["data","vipTag"]])'
-http-response-jq ^https:\/\/dict\.youdao\.com\/course\/tab\/translateTab\? 'delpaths([["data"]])'
-http-response-jq ^https:\/\/dict\.youdao\.com\/course\/tab\/home\? 'delpaths([["data","popup"]])'
-http-response-jq ^https:\/\/dict\.youdao\.com\/course\/tab\/home\? 'delpaths([["data","tab"]])'
-http-response-jq ^https:\/\/dict\.youdao\.com\/course\/tab\/home\? 'delpaths([["data","searchSuggestList"]])'
-http-response-jq ^https:\/\/dict\.youdao\.com\/course\/tab\/home\? 'delpaths([["data","newBanner"]])'
-http-response-jq ^https:\/\/dict\.youdao\.com\/course\/tab\/home\? 'delpaths([["data","icon","promotionList"]])'
-http-response-jq ^https:\/\/dict\.youdao\.com\/course\/tab\/home\? 'delpaths([["data","icon","iconList",1,"bubble"]])'
-http-response-jq ^https:\/\/dict\.youdao\.com\/course\/tab\/home\? 'delpaths([["data","icon","iconList",2,"bubble"]])'
-http-response-jq ^https:\/\/dict\.youdao\.com\/course\/tab\/home\? 'delpaths([["data","icon","iconList",8,"bubble"]])'
+http-response-jq ^https:\/\/dict\.{{{youdao}}}\.com\/homepage\/toolbar\/get\? 'delpaths([["data","vipTag"]])'
+http-response-jq ^https:\/\/dict\.{{{youdao}}}\.com\/course\/tab\/translateTab\? 'delpaths([["data"]])'
+http-response-jq ^https:\/\/dict\.{{{youdao}}}\.com\/course\/tab\/home\? 'delpaths([["data","popup"]])'
+http-response-jq ^https:\/\/dict\.{{{youdao}}}\.com\/course\/tab\/home\? 'delpaths([["data","tab"]])'
+http-response-jq ^https:\/\/dict\.{{{youdao}}}\.com\/course\/tab\/home\? 'delpaths([["data","searchSuggestList"]])'
+http-response-jq ^https:\/\/dict\.{{{youdao}}}\.com\/course\/tab\/home\? 'delpaths([["data","newBanner"]])'
+http-response-jq ^https:\/\/dict\.{{{youdao}}}\.com\/course\/tab\/home\? 'delpaths([["data","icon","promotionList"]])'
+http-response-jq ^https:\/\/dict\.{{{youdao}}}\.com\/course\/tab\/home\? 'delpaths([["data","icon","iconList",1,"bubble"]])'
+http-response-jq ^https:\/\/dict\.{{{youdao}}}\.com\/course\/tab\/home\? 'delpaths([["data","icon","iconList",2,"bubble"]])'
+http-response-jq ^https:\/\/dict\.{{{youdao}}}\.com\/course\/tab\/home\? 'delpaths([["data","icon","iconList",8,"bubble"]])'
 
 # > 网易邮箱大师去广告 · 2025-05-13
 # desc = 移除网易邮箱大师开屏广告、签到任务提醒，精简侧拉抽屉和我的页面。
-http-response-jq ^https:\/\/appconf\.mail\.163\.com\/mailmaster\/api\/page\/v2\/conf\.do$ 'delpaths([["data","functionOperatorInfoList"]])'
-http-response-jq ^https:\/\/appconf\.mail\.163\.com\/mailmaster\/api\/page\/v2\/conf\.do$ 'delpaths([["data","memberOperator"]])'
-http-response-jq ^https:\/\/appconf\.mail\.163\.com\/mailmaster\/api\/page\/v2\/conf\.do$ 'delpaths([["data","activityTabInfoList"]])'
-http-response-jq ^https:\/\/appconf\.mail\.163\.com\/mailmaster\/api\/config\/function\.do$ '.data.config[] |= if .result.tools then .result.tools |= map(select(.name == "邮件追踪" or .name == "替身邮箱")) else . end | del(.data.config[] | select(.functionName == "Function-AD"))'
+http-response-jq ^https:\/\/appconf\.mail\.{{{163}}}\.com\/mailmaster\/api\/page\/v2\/conf\.do$ 'delpaths([["data","functionOperatorInfoList"]])'
+http-response-jq ^https:\/\/appconf\.mail\.{{{163}}}\.com\/mailmaster\/api\/page\/v2\/conf\.do$ 'delpaths([["data","memberOperator"]])'
+http-response-jq ^https:\/\/appconf\.mail\.{{{163}}}\.com\/mailmaster\/api\/page\/v2\/conf\.do$ 'delpaths([["data","activityTabInfoList"]])'
+http-response-jq ^https:\/\/appconf\.mail\.{{{163}}}\.com\/mailmaster\/api\/config\/function\.do$ '.data.config[] |= if .result.tools then .result.tools |= map(select(.name == "邮件追踪" or .name == "替身邮箱")) else . end | del(.data.config[] | select(.functionName == "Function-AD"))'
 
 # > 喜马拉雅去广告 · 2025-07-11
 # desc = 移除开屏广告、播放器广告、各类推荐内容，精简频道和我的页面。
-http-response-jq ^https:\/\/(mobile|mobilehera|mobwsa)\.ximalaya\.com\/discovery-feed\/v\d\/mix\/ '.heData |= map(select(.item.list[].bizType != "SceneListenCard"))'
-http-response-jq ^https:\/\/(mobile|mobilehera|mobwsa)\.ximalaya\.com\/discovery-category\/customCategories\/ '.categoryList |= map(.itemList |= map(select(.title | test("直播|123狂欢节|SVIP"; "i") | not))) | .customCategoryList |= map(select(.title | test("直播|123狂欢节|SVIP"; "i") | not))'
-http-response-jq ^https:\/\/(mobile|mobilehera|mobwsa)\.ximalaya\.com\/football-portal\/diff2\/batch\? 'delpaths([["json","ad"]])'
-http-response-jq ^https:\/\/(mobile|mobilehera|mobwsa)\.ximalaya\.com\/football-portal\/diff2\/batch\? 'delpaths([["json","toc"]])'
-http-response-jq ^https:\/\/(mobile|mobilehera|mobwsa)\.ximalaya\.com\/nexus-web\/v\d\/tabs\/customTabs\? '.data.feedTabs |= map(select(.name != "大赛"))'
-http-response-jq ^https:\/\/mobwsa\.ximalaya\.com\/mobile-playpage\/playpage\/tabs\/v2\/ 'delpaths([["data","playpage","resourceMap","defaultResource"]])'
-http-response-jq ^https:\/\/mobwsa\.ximalaya\.com\/mobile-playpage\/playpage\/tabs\/v2\/ 'delpaths([["data","playpage","resourceMap","playPageTip"]])'
-http-response-jq ^https:\/\/(mobile|mobilehera|mobwsa)\.ximalaya\.com\/mobile-user\/v\d\/homePage\/ 'delpaths([["data","freeListenV2"]])'
-http-response-jq ^https:\/\/(mobile|mobilehera|mobwsa)\.ximalaya\.com\/mobile-user\/v\d\/homePage\/ '.data.serviceModule.entrances |= map(select(.name == "全部服务"))'
+http-response-jq ^https:\/\/(mobile|mobilehera|mobwsa)\.{{{ximalaya}}}\.com\/discovery-feed\/v\d\/mix\/ '.heData |= map(select(.item.list[].bizType != "SceneListenCard"))'
+http-response-jq ^https:\/\/(mobile|mobilehera|mobwsa)\.{{{ximalaya}}}\.com\/discovery-category\/customCategories\/ '.categoryList |= map(.itemList |= map(select(.title | test("直播|123狂欢节|SVIP"; "i") | not))) | .customCategoryList |= map(select(.title | test("直播|123狂欢节|SVIP"; "i") | not))'
+http-response-jq ^https:\/\/(mobile|mobilehera|mobwsa)\.{{{ximalaya}}}\.com\/football-portal\/diff2\/batch\? 'delpaths([["json","ad"]])'
+http-response-jq ^https:\/\/(mobile|mobilehera|mobwsa)\.{{{ximalaya}}}\.com\/football-portal\/diff2\/batch\? 'delpaths([["json","toc"]])'
+http-response-jq ^https:\/\/(mobile|mobilehera|mobwsa)\.{{{ximalaya}}}\.com\/nexus-web\/v\d\/tabs\/customTabs\? '.data.feedTabs |= map(select(.name != "大赛"))'
+http-response-jq ^https:\/\/mobwsa\.{{{ximalaya}}}\.com\/mobile-playpage\/playpage\/tabs\/v2\/ 'delpaths([["data","playpage","resourceMap","defaultResource"]])'
+http-response-jq ^https:\/\/mobwsa\.{{{ximalaya}}}\.com\/mobile-playpage\/playpage\/tabs\/v2\/ 'delpaths([["data","playpage","resourceMap","playPageTip"]])'
+http-response-jq ^https:\/\/(mobile|mobilehera|mobwsa)\.{{{ximalaya}}}\.com\/mobile-user\/v\d\/homePage\/ 'delpaths([["data","freeListenV2"]])'
+http-response-jq ^https:\/\/(mobile|mobilehera|mobwsa)\.{{{ximalaya}}}\.com\/mobile-user\/v\d\/homePage\/ '.data.serviceModule.entrances |= map(select(.name == "全部服务"))'
 
 # > 下厨房去广告 · 2026-02-22
 # desc = 移除开屏广告、页面推广及横幅，精简首页标签。
-http-response-jq ^https:\/\/api\.xiachufang\.com\/v2\/homepage\/paged_waterfall_recommendations\.json$ 'del(.multiplex_cells[] | select(.recommendation_cell.impression_sensor_events[]?.properties.target_type? == "ad"))'
-http-response-jq ^https:\/\/api\.xiachufang\.com\/v2\/config\/get\.json$ 'delpaths([["content","recipe_ad"]])'
-http-response-jq ^https:\/\/api\.xiachufang\.com\/v2\/config\/get\.json$ 'delpaths([["content","splash_ad_req_time"]])'
-http-response-jq ^https:\/\/api\.xiachufang\.com\/v2\/config\/get\.json$ 'delpaths([["content","splash_sdk_ad_req_time"]])'
-http-response-jq ^https:\/\/api\.xiachufang\.com\/v2\/config\/get\.json$ 'delpaths([["content","splash_ad_lifecycle_interval"]])'
-http-response-jq ^https:\/\/api\.xiachufang\.com\/v2\/config\/get\.json$ 'delpaths([["content","waterfall_ad_feedback"]])'
-http-response-jq ^https:\/\/api\.xiachufang\.com\/v2\/config\/get\.json$ 'delpaths([["content","homepage_waterfall_test_ad_pos"]])'
-http-response-jq ^https:\/\/api\.xiachufang\.com\/v2\/config\/get\.json$ 'delpaths([["content","ad_app_look_around"]])'
-http-response-jq ^https:\/\/api\.xiachufang\.com\/v2\/config\/get\.json$ 'delpaths([["content","ad_sdk_text_removal_keywords"]])'
-http-response-jq ^https:\/\/api\.xiachufang\.com\/v2\/homepage\/ranking_list\/paged_homepage_ranking_list_section_v2\.json$ '.cells |= map(del(.side_slip_activity_cell, .dish_square_cell))'
+http-response-jq ^https:\/\/api\.{{{xiachufang}}}\.com\/v2\/homepage\/paged_waterfall_recommendations\.json$ 'del(.multiplex_cells[] | select(.recommendation_cell.impression_sensor_events[]?.properties.target_type? == "ad"))'
+http-response-jq ^https:\/\/api\.{{{xiachufang}}}\.com\/v2\/config\/get\.json$ 'delpaths([["content","recipe_ad"]])'
+http-response-jq ^https:\/\/api\.{{{xiachufang}}}\.com\/v2\/config\/get\.json$ 'delpaths([["content","splash_ad_req_time"]])'
+http-response-jq ^https:\/\/api\.{{{xiachufang}}}\.com\/v2\/config\/get\.json$ 'delpaths([["content","splash_sdk_ad_req_time"]])'
+http-response-jq ^https:\/\/api\.{{{xiachufang}}}\.com\/v2\/config\/get\.json$ 'delpaths([["content","splash_ad_lifecycle_interval"]])'
+http-response-jq ^https:\/\/api\.{{{xiachufang}}}\.com\/v2\/config\/get\.json$ 'delpaths([["content","waterfall_ad_feedback"]])'
+http-response-jq ^https:\/\/api\.{{{xiachufang}}}\.com\/v2\/config\/get\.json$ 'delpaths([["content","homepage_waterfall_test_ad_pos"]])'
+http-response-jq ^https:\/\/api\.{{{xiachufang}}}\.com\/v2\/config\/get\.json$ 'delpaths([["content","ad_app_look_around"]])'
+http-response-jq ^https:\/\/api\.{{{xiachufang}}}\.com\/v2\/config\/get\.json$ 'delpaths([["content","ad_sdk_text_removal_keywords"]])'
+http-response-jq ^https:\/\/api\.{{{xiachufang}}}\.com\/v2\/homepage\/ranking_list\/paged_homepage_ranking_list_section_v2\.json$ '.cells |= map(del(.side_slip_activity_cell, .dish_square_cell))'
 
 # > 闲鱼去广告 · 2025-12-26
 # desc = 移除开屏广告、商品信息流广告、关注推荐、搜索栏填充词、首页签到入口及悬浮广告，精简我的页面。
-http-response-jq ^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idlehome\.home\.nextfresh\/ '.data.homeTopList |= map(select(.sectionType == "kingkongDo")) | .data.sections |= map(select(.data.clickParam.args.cardType as $ct | $ct != "homeMultiBanner" and $ct != "mamaAD")) | .data.sections |= map(select((.template.name|type=="string")and(.template.name=="idlefish_home_new_commodity_card"or(.template.name|contains("fish_home_tags_item_card")))))'
-http-response-jq ^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idlehome\.widget\.refresh\.get\/ '.data.homeTopList |= map(select(.sectionType == "kingkongDo"))'
-http-response-jq ^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idle\.home\.whale\.modulet\/ '.data.container.sections |= map(select(.template.name == "fish_home_miniapp"))'
-http-response-jq ^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idle\.fun\.follow\.feed\.list\/ '.data.sections|=map(select(.cardType==2001))'
-http-response-jq ^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idlehome\.home\.community\/ '.data.feedsList |= map(select(.template.name == "idlefish_home_new_commodity_card" or .template.name == "idlefish_home_new_content_card"))'
-http-response-jq ^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idlehome\.home\.newitem\.page\/ '.data.sections |= map(select(.data.clickParam.args.cardType as $ct | $ct != "banner" and $ct != "mamaAD"))'
-http-response-jq ^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idle\.local\.flow\.plat\.section\/ '.data.data.components |= map(select(.data and (.data|type=="object") and .data.template and (.data.template|type=="object") and .data.template.name and (.data.template.name|type=="string") and (.data.template.name|contains("fish_city_kingkong"))))'
-http-response-jq ^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idle\.local\.home\.top\/ '.data.data.components |= map(select(.key == "fish_home_second_stage_top_cardV3"))'
-http-response-jq ^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idle\.local\.home\/ '.data.sections |= map(select((.template.cardEnum != "ads") and (.cardType == "common")))'
-http-response-jq ^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.idle\.user\.page\.my\.adapter\/ '.data.container.sections |= map(select(.template.name | test("^my_fy[0-9]+_(header|user_info|trade|appraise|tools)$"))) | .data.container.sections |= map(.item |= (if .level and .level.exContent and (.level.exContent | has("tips")) then del(.level) else . end))'
-http-response-jq ^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.idle\.user\.page\.my\.adapter\/ '  .data.container.sections[] |= (   if .item.tool then     .item.tool.exContent.tools = [       [         {           "targetUrl": "https://h5.m.goofish.com/wow/moyu/moyu-project/fish-ad/pages/home?kun=true&fromScene=myPage",           "exContent": {             "title": "超级擦亮",             "icon": "https://gw.alicdn.com/imgextra/i2/O1CN01bVNpPu1eGbSDs0GSR_!!6000000003844-2-tps-84-84.png",             "toolId": 23           },           "clickParam": {             "args": {               "toolId": "23"             },             "arg1": "Function"           }         },         {           "targetUrl": "https://h5.m.goofish.com/wow/moyu/moyu-project/moyu-tb-resell/pages/newResell?isNeedRefresh=0&setTab=1",           "exContent": {             "title": "淘宝转卖",             "icon": "https://gw.alicdn.com/imgextra/i2/O1CN01JTbPcx1Qrn3n9w03n_!!6000000002030-2-tps-84-84.png",             "toolId": 11           },           "clickParam": {             "args": {               "toolId": "11"             },             "arg1": "Function"           }         },         {           "targetUrl": "https://h5.m.goofish.com/wow/moyu/moyu-project/experience-officer/pages/home?kun=true",           "exContent": {             "title": "闲鱼体验官",             "icon": "https://gw.alicdn.com/imgextra/i1/O1CN016leRFv1N0Fprgaghl_!!6000000001507-2-tps-84-84.png",             "toolId": 2           },           "clickParam": {             "args": {               "toolId": "2"             },             "arg1": "Function"           }         },         {           "targetUrl": "https://h5.m.goofish.com/wow/moyu/moyu-project/seafood-qa/pages/my-content?useCusFont=true&loadingVisible=false",           "exContent": {             "title": "帖子中心",             "icon": "https://gw.alicdn.com/imgextra/i1/O1CN01Cge0QO1R2K5RfoaOw_!!6000000002053-2-tps-84-84.png",             "toolId": 13           },           "clickParam": {             "args": {               "toolId": "13"             },             "arg1": "Function"           }         }       ],       [         {           "targetUrl": "https://h5.m.goofish.com/app/msd/buyer-aqcenter/index.html?source=316#/notice",           "exContent": {             "title": "闲鱼公约",             "icon": "https://img.alicdn.com/imgextra/i4/O1CN01A9ofQ51t1EOZfykDn_!!6000000005841-2-tps-84-84.png",             "toolId": 20           },           "clickParam": {             "args": {               "toolId": "20"             },             "arg1": "Function"           }         },         {           "targetUrl": "https://h5.m.goofish.com/wow/moyu/moyu-project/cro-security-center/pages/security-center",           "exContent": {             "title": "安全中心",             "icon": "https://gw.alicdn.com/imgextra/i4/O1CN013kllih1NlQd6e3sRv_!!6000000001610-2-tps-84-84.png",             "toolId": 1           },           "clickParam": {             "args": {               "toolId": "1"             },             "arg1": "Function"           }         }       ]     ]   else     .   end )'
-http-response-jq ^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idlehome\.home\.circle\.list\/ '.data.circleList[].showInfo.titleImage |= (.lightUrl="" | .url="" | del(.width, .height))'
-http-response-jq ^https:\/\/g-acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idlemtopsearch\.search\/ '.data.resultList |= map(if .data.item.main.exContent.dislikeFeedback.clickParam.args.bizType == "ad" then empty else . end)'
-http-response-jq ^https:\/\/g-acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idlemtopsearch\.search\/ 'delpaths([["data","resultPrefixBar"]])'
-http-response-jq ^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idlemtopsearch\.search\.discover\/ '.data.resultList |= map(select(.type != "MarketHotSpot"))'
-http-response-jq ^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idlemtopsearch\.item\.search\.activate\/ '.data.cardList |= map(if has("cardData") and (.cardData | has("hotwords")) then .cardData |= del(.hotwords) else . end)'
-http-response-jq ^https:\/\/acs\.m\.goofish\.com\/gw\/mtop\.taobao\.idle\.trade\.full\.info\/ '.data.components |= map(select(.render | . == "orderStatusVO" or . == "addressInfoVO" or . == "orderInfoVO"))'
+http-response-jq ^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idlehome\.home\.nextfresh\/ '.data.homeTopList |= map(select(.sectionType == "kingkongDo")) | .data.sections |= map(select(.data.clickParam.args.cardType as $ct | $ct != "homeMultiBanner" and $ct != "mamaAD")) | .data.sections |= map(select((.template.name|type=="string")and(.template.name=="idlefish_home_new_commodity_card"or(.template.name|contains("fish_home_tags_item_card")))))'
+http-response-jq ^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idlehome\.widget\.refresh\.get\/ '.data.homeTopList |= map(select(.sectionType == "kingkongDo"))'
+http-response-jq ^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idle\.home\.whale\.modulet\/ '.data.container.sections |= map(select(.template.name == "fish_home_miniapp"))'
+http-response-jq ^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idle\.fun\.follow\.feed\.list\/ '.data.sections|=map(select(.cardType==2001))'
+http-response-jq ^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idlehome\.home\.community\/ '.data.feedsList |= map(select(.template.name == "idlefish_home_new_commodity_card" or .template.name == "idlefish_home_new_content_card"))'
+http-response-jq ^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idlehome\.home\.newitem\.page\/ '.data.sections |= map(select(.data.clickParam.args.cardType as $ct | $ct != "banner" and $ct != "mamaAD"))'
+http-response-jq ^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idle\.local\.flow\.plat\.section\/ '.data.data.components |= map(select(.data and (.data|type=="object") and .data.template and (.data.template|type=="object") and .data.template.name and (.data.template.name|type=="string") and (.data.template.name|contains("fish_city_kingkong"))))'
+http-response-jq ^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idle\.local\.home\.top\/ '.data.data.components |= map(select(.key == "fish_home_second_stage_top_cardV3"))'
+http-response-jq ^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idle\.local\.home\/ '.data.sections |= map(select((.template.cardEnum != "ads") and (.cardType == "common")))'
+http-response-jq ^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.idle\.user\.page\.my\.adapter\/ '.data.container.sections |= map(select(.template.name | test("^my_fy[0-9]+_(header|user_info|trade|appraise|tools)$"))) | .data.container.sections |= map(.item |= (if .level and .level.exContent and (.level.exContent | has("tips")) then del(.level) else . end))'
+http-response-jq ^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.idle\.user\.page\.my\.adapter\/ '  .data.container.sections[] |= (   if .item.tool then     .item.tool.exContent.tools = [       [         {           "targetUrl": "https://h5.m.{{{goofish}}}.com/wow/moyu/moyu-project/fish-ad/pages/home?kun=true&fromScene=myPage",           "exContent": {             "title": "超级擦亮",             "icon": "https://gw.alicdn.com/imgextra/i2/O1CN01bVNpPu1eGbSDs0GSR_!!6000000003844-2-tps-84-84.png",             "toolId": 23           },           "clickParam": {             "args": {               "toolId": "23"             },             "arg1": "Function"           }         },         {           "targetUrl": "https://h5.m.{{{goofish}}}.com/wow/moyu/moyu-project/moyu-tb-resell/pages/newResell?isNeedRefresh=0&setTab=1",           "exContent": {             "title": "淘宝转卖",             "icon": "https://gw.alicdn.com/imgextra/i2/O1CN01JTbPcx1Qrn3n9w03n_!!6000000002030-2-tps-84-84.png",             "toolId": 11           },           "clickParam": {             "args": {               "toolId": "11"             },             "arg1": "Function"           }         },         {           "targetUrl": "https://h5.m.{{{goofish}}}.com/wow/moyu/moyu-project/experience-officer/pages/home?kun=true",           "exContent": {             "title": "闲鱼体验官",             "icon": "https://gw.alicdn.com/imgextra/i1/O1CN016leRFv1N0Fprgaghl_!!6000000001507-2-tps-84-84.png",             "toolId": 2           },           "clickParam": {             "args": {               "toolId": "2"             },             "arg1": "Function"           }         },         {           "targetUrl": "https://h5.m.{{{goofish}}}.com/wow/moyu/moyu-project/seafood-qa/pages/my-content?useCusFont=true&loadingVisible=false",           "exContent": {             "title": "帖子中心",             "icon": "https://gw.alicdn.com/imgextra/i1/O1CN01Cge0QO1R2K5RfoaOw_!!6000000002053-2-tps-84-84.png",             "toolId": 13           },           "clickParam": {             "args": {               "toolId": "13"             },             "arg1": "Function"           }         }       ],       [         {           "targetUrl": "https://h5.m.{{{goofish}}}.com/app/msd/buyer-aqcenter/index.html?source=316#/notice",           "exContent": {             "title": "闲鱼公约",             "icon": "https://img.alicdn.com/imgextra/i4/O1CN01A9ofQ51t1EOZfykDn_!!6000000005841-2-tps-84-84.png",             "toolId": 20           },           "clickParam": {             "args": {               "toolId": "20"             },             "arg1": "Function"           }         },         {           "targetUrl": "https://h5.m.{{{goofish}}}.com/wow/moyu/moyu-project/cro-security-center/pages/security-center",           "exContent": {             "title": "安全中心",             "icon": "https://gw.alicdn.com/imgextra/i4/O1CN013kllih1NlQd6e3sRv_!!6000000001610-2-tps-84-84.png",             "toolId": 1           },           "clickParam": {             "args": {               "toolId": "1"             },             "arg1": "Function"           }         }       ]     ]   else     .   end )'
+http-response-jq ^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idlehome\.home\.circle\.list\/ '.data.circleList[].showInfo.titleImage |= (.lightUrl="" | .url="" | del(.width, .height))'
+http-response-jq ^https:\/\/g-acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idlemtopsearch\.search\/ '.data.resultList |= map(if .data.item.main.exContent.dislikeFeedback.clickParam.args.bizType == "ad" then empty else . end)'
+http-response-jq ^https:\/\/g-acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idlemtopsearch\.search\/ 'delpaths([["data","resultPrefixBar"]])'
+http-response-jq ^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idlemtopsearch\.search\.discover\/ '.data.resultList |= map(select(.type != "MarketHotSpot"))'
+http-response-jq ^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idlemtopsearch\.item\.search\.activate\/ '.data.cardList |= map(if has("cardData") and (.cardData | has("hotwords")) then .cardData |= del(.hotwords) else . end)'
+http-response-jq ^https:\/\/acs\.m\.{{{goofish}}}\.com\/gw\/mtop\.taobao\.idle\.trade\.full\.info\/ '.data.components |= map(select(.render | . == "orderStatusVO" or . == "addressInfoVO" or . == "orderInfoVO"))'
 
 # > 香港抖音去广告 · 2025-05-13
 # desc = 精简左右侧边栏、移除底栏切换，其余内容后续再完善。
-http-response-jq ^https:\/\/((aweme\.snssdk\.com|api5-normal-m\.amemv\.com)|api5-normal-m\.amemv\.com)\/aweme\/homepage\/sidebar_data\/\? 'delpaths([["data_map","recently_apps"]])'
-http-response-jq ^https:\/\/((aweme\.snssdk\.com|api5-normal-m\.amemv\.com)|api5-normal-m\.amemv\.com)\/aweme\/homepage\/sidebar_data\/\? 'delpaths([["data_map","recently_users"]])'
-http-response-jq ^https:\/\/(aweme\.snssdk\.com|api5-normal-m\.amemv\.com)\/aweme\/homepage\/render\/\? 'delpaths([["data","tab_config"]])'
-http-response-jq ^https:\/\/(aweme\.snssdk\.com|api5-normal-m\.amemv\.com)\/aweme\/homepage\/render\/\? '.data.tab_list[]? |= (if .extra.side_bar.modules != null then .extra.side_bar.modules[]?.items[]? |= (if .data.first_page_module?.module_title == "常用功能" then .data={} else . end) else . end) | .data.tab_list |= map(if .extra.tab_list != null then .extra.tab_list |= map(select(.tab_id | IN("homepage_tablive", "homepage_follow", "homepage_hot_container"))) else . end) | .data.tab_list |= map(select(.extra.tab_list != null and (.extra.tab_list | length > 0)))'
-http-response-jq ^https:\/\/(aweme\.snssdk\.com|api5-normal-m\.amemv\.com)\/tfe\/api\/request_combine\/v1\/\?need_personal_recommend 'if (getpath(["data","/service/settings/v3/","body","data","settings"]) | has("homepage_two_session_tab_skin_2025")) then (setpath(["data","/service/settings/v3/","body","data","settings","homepage_two_session_tab_skin_2025"]; false)) else . end'
-http-response-jq ^https:\/\/(aweme\.snssdk\.com|api5-normal-m\.amemv\.com)\/tfe\/api\/request_combine\/v1\/\?need_personal_recommend 'if (getpath(["data","/service/settings/v3/","body","data","settings"]) | has("homepage_tab_skin_enable")) then (setpath(["data","/service/settings/v3/","body","data","settings","homepage_tab_skin_enable"]; false)) else . end'
+http-response-jq ^https:\/\/((awe{{{me}}}\.snssdk\.com|api5-normal-m\.amemv\.com)|api5-normal-m\.amemv\.com)\/aweme\/homepage\/sidebar_data\/\? 'delpaths([["data_map","recently_apps"]])'
+http-response-jq ^https:\/\/((awe{{{me}}}\.snssdk\.com|api5-normal-m\.amemv\.com)|api5-normal-m\.amemv\.com)\/aweme\/homepage\/sidebar_data\/\? 'delpaths([["data_map","recently_users"]])'
+http-response-jq ^https:\/\/(awe{{{me}}}\.snssdk\.com|api5-normal-m\.amemv\.com)\/aweme\/homepage\/render\/\? 'delpaths([["data","tab_config"]])'
+http-response-jq ^https:\/\/(awe{{{me}}}\.snssdk\.com|api5-normal-m\.amemv\.com)\/aweme\/homepage\/render\/\? '.data.tab_list[]? |= (if .extra.side_bar.modules != null then .extra.side_bar.modules[]?.items[]? |= (if .data.first_page_module?.module_title == "常用功能" then .data={} else . end) else . end) | .data.tab_list |= map(if .extra.tab_list != null then .extra.tab_list |= map(select(.tab_id | IN("homepage_tablive", "homepage_follow", "homepage_hot_container"))) else . end) | .data.tab_list |= map(select(.extra.tab_list != null and (.extra.tab_list | length > 0)))'
+http-response-jq ^https:\/\/(awe{{{me}}}\.snssdk\.com|api5-normal-m\.amemv\.com)\/tfe\/api\/request_combine\/v1\/\?need_personal_recommend 'if (getpath(["data","/service/settings/v3/","body","data","settings"]) | has("homepage_two_session_tab_skin_2025")) then (setpath(["data","/service/settings/v3/","body","data","settings","homepage_two_session_tab_skin_2025"]; false)) else . end'
+http-response-jq ^https:\/\/(awe{{{me}}}\.snssdk\.com|api5-normal-m\.amemv\.com)\/tfe\/api\/request_combine\/v1\/\?need_personal_recommend 'if (getpath(["data","/service/settings/v3/","body","data","settings"]) | has("homepage_tab_skin_enable")) then (setpath(["data","/service/settings/v3/","body","data","settings","homepage_tab_skin_enable"]; false)) else . end'
 
 # > 小黑盒去广告 · 2025-05-13
 # desc = 移除开屏广告和热点板块信息流广告
-http-response-jq ^https:\/\/api\.xiaoheihe\.cn\/bbs\/app\/feeds\/news '.result.links |= map(if .content_type == 27 then del(.title, .ad_pm, .img_gif, .idea_id, .ad_report, .label, .source, .intranet_only, .ad_cm, .content_type, .PROTOCOL, .img, .ad_ratio) else . end)'
+http-response-jq ^https:\/\/api\.{{{xiaoheihe}}}\.cn\/bbs\/app\/feeds\/news '.result.links |= map(if .content_type == 27 then del(.title, .ad_pm, .img_gif, .idea_id, .ad_report, .label, .source, .intranet_only, .ad_cm, .content_type, .PROTOCOL, .img, .ad_ratio) else . end)'
 
 # > 小红书去广告 · 2026-02-22
 # desc = 过滤信息流推广，移除图片及视频水印，如有异常，请先清除缓存再尝试。
-http-response-jq ^https:\/\/edith\.xiaohongshu\.com\/api\/sns\/v1\/search\/banner_list$ 'if (getpath([]) | has("data")) then (setpath(["data"]; {})) else . end'
-http-response-jq ^https:\/\/edith\.xiaohongshu\.com\/api\/sns\/v1\/search\/hot_list$ 'if (getpath(["data"]) | has("items")) then (setpath(["data","items"]; [])) else . end'
-http-response-jq ^https:\/\/edith\.xiaohongshu\.com\/api\/sns\/v4\/search\/hint 'if (getpath(["data"]) | has("hint_words")) then (setpath(["data","hint_words"]; [])) else . end'
-http-response-jq ^https:\/\/edith\.xiaohongshu\.com\/api\/sns\/v4\/search\/trending\? 'if (getpath(["data"]) | has("queries")) then (setpath(["data","queries"]; [])) else . end'
-http-response-jq ^https:\/\/edith\.xiaohongshu\.com\/api\/sns\/v4\/search\/trending\? 'if (getpath(["data"]) | has("hint_word")) then (setpath(["data","hint_word"]; {})) else . end'
+http-response-jq ^https:\/\/edith\.{{{xiaohongshu}}}\.com\/api\/sns\/v1\/search\/banner_list$ 'if (getpath([]) | has("data")) then (setpath(["data"]; {})) else . end'
+http-response-jq ^https:\/\/edith\.{{{xiaohongshu}}}\.com\/api\/sns\/v1\/search\/hot_list$ 'if (getpath(["data"]) | has("items")) then (setpath(["data","items"]; [])) else . end'
+http-response-jq ^https:\/\/edith\.{{{xiaohongshu}}}\.com\/api\/sns\/v4\/search\/hint 'if (getpath(["data"]) | has("hint_words")) then (setpath(["data","hint_words"]; [])) else . end'
+http-response-jq ^https:\/\/edith\.{{{xiaohongshu}}}\.com\/api\/sns\/v4\/search\/trending\? 'if (getpath(["data"]) | has("queries")) then (setpath(["data","queries"]; [])) else . end'
+http-response-jq ^https:\/\/edith\.{{{xiaohongshu}}}\.com\/api\/sns\/v4\/search\/trending\? 'if (getpath(["data"]) | has("hint_word")) then (setpath(["data","hint_word"]; {})) else . end'
 
 # > 优酷视频去广告 · 2025-11-14
 # desc = 移除开屏广告、视频广告、信息流广告。其余广告由于请求已加密，故无法移除。
-http-response-jq ^https:\/\/un-acs\.youku\.com\/gw\/mtop\.youku\.play\.ups\.appinfo\.get 'delpaths([["data","data","ad"]])'
-http-response-jq ^https:\/\/un-acs\.youku\.com\/gw\/mtop\.youku\.play\.ups\.appinfo\.get 'delpaths([["data","data","watermark"]])'
-http-response-jq ^https:\/\/un-acs\.youku\.com\/gw\/mtop\.youku\.play\.ups\.appinfo\.get 'delpaths([["data","data","ykad"]])'
-http-response-jq ^https:\/\/push\.m\.youku\.com\/collect-api\/get_push_interval_config_wx\? 'delpaths([["data","tipContent"]])'
-http-response-jq ^https:\/\/push\.m\.youku\.com\/collect-api\/get_push_interval_config_wx\? 'delpaths([["data","tipContentNew"]])'
+http-response-jq ^https:\/\/un-acs\.{{{youku}}}\.com\/gw\/mtop\.{{{youku}}}\.play\.ups\.appinfo\.get 'delpaths([["data","data","ad"]])'
+http-response-jq ^https:\/\/un-acs\.{{{youku}}}\.com\/gw\/mtop\.{{{youku}}}\.play\.ups\.appinfo\.get 'delpaths([["data","data","watermark"]])'
+http-response-jq ^https:\/\/un-acs\.{{{youku}}}\.com\/gw\/mtop\.{{{youku}}}\.play\.ups\.appinfo\.get 'delpaths([["data","data","ykad"]])'
+http-response-jq ^https:\/\/push\.m\.{{{youku}}}\.com\/collect-api\/get_push_interval_config_wx\? 'delpaths([["data","tipContent"]])'
+http-response-jq ^https:\/\/push\.m\.{{{youku}}}\.com\/collect-api\/get_push_interval_config_wx\? 'delpaths([["data","tipContentNew"]])'
 
 # > 知乎去广告 · 2026-02-22
 # desc = 移除各部分广告，移除知乎安全中心跳转，建议卸载知乎重新安装。如遇安全中心页面移除失败的，请积极反馈。
-http-response-jq ^https:\/\/api\.zhihu\.com\/bazaar\/vip_tab\/header\? 'delpaths([["activity_banner"]])'
-http-response-jq ^https:\/\/api\.zhihu\.com\/bazaar\/vip_tab\/header\? 'delpaths([["activity_window"]])'
-http-response-jq ^https:\/\/api\.zhihu\.com\/bazaar\/vip_tab\/header\? 'delpaths([["vip_tip"]])'
-http-response ^https:\/\/api\.zhihu\.com\/search\/recommend_query\/v2\? "recommend_queries":\{.+\} "recommend_queries":{}
-http-response-jq ^https:\/\/api\.zhihu\.com\/questions\/\d+(?:\/answers|\/feeds|\?include=) 'del(.ad_info, .data.ad_info?, .query_info) | if (.data | type) == "array" then .data |= map(select(.target?.answer_type?// "" | tostring | contains("paid") | not)) else . end'
+http-response-jq ^https:\/\/api\.{{{zhihu}}}\.com\/bazaar\/vip_tab\/header\? 'delpaths([["activity_banner"]])'
+http-response-jq ^https:\/\/api\.{{{zhihu}}}\.com\/bazaar\/vip_tab\/header\? 'delpaths([["activity_window"]])'
+http-response-jq ^https:\/\/api\.{{{zhihu}}}\.com\/bazaar\/vip_tab\/header\? 'delpaths([["vip_tip"]])'
+http-response ^https:\/\/api\.{{{zhihu}}}\.com\/search\/recommend_query\/v2\? "recommend_queries":\{.+\} "recommend_queries":{}
+http-response-jq ^https:\/\/api\.{{{zhihu}}}\.com\/questions\/\d+(?:\/answers|\/feeds|\?include=) 'del(.ad_info, .data.ad_info?, .query_info) | if (.data | type) == "array" then .data |= map(select(.target?.answer_type?// "" | tostring | contains("paid") | not)) else . end'
 
 # > 中国联通 去广告
 # desc = 去开屏
-# http-response-jq ^https?:\/\/m\.client\.10010\.com\/mobileserviceNine\/api\/v1\/index\/queryIndexWaterfall\/ 'walk(if type == "array" then [] else . end)'
-# http-response-jq ^https?:\/\/m\.client\.10010\.com\/mobileserviceNine\/api\/v1\/index\/queryIndexExclusiveOffers\/ 'walk(if type == "array" then [] else . end)'
+# http-response-jq ^https?:\/\/m\.client\.{{{10010}}}\.com\/mobileserviceNine\/api\/v1\/index\/queryIndexWaterfall\/ 'walk(if type == "array" then [] else . end)'
+# http-response-jq ^https?:\/\/m\.client\.{{{10010}}}\.com\/mobileserviceNine\/api\/v1\/index\/queryIndexExclusiveOffers\/ 'walk(if type == "array" then [] else . end)'
 
 [General]
 # > 中国联通 去广告
 # desc = 去开屏
-force-http-engine-hosts = %APPEND% m.client.10010.com
+force-http-engine-hosts = %APPEND% m.client.{{{10010}}}.com


### PR DESCRIPTION
Each module's alias is now substituted into the domain parts of its rules/scripts/MITM hostnames (ad.12306.cn -> ad.{{{12306}}}.cn), with default value = the keyword itself (enabled). Setting an alias to a non-matching value disables that domain's rules, mirroring GeoLoc.

- Replacement is dot-bounded so script names (移除12306开屏广告) and script-path URLs (.../12306/12306_remove.js) are left untouched.
- #!arguments now always merges the alias toggles with upstream args instead of being skipped when a manual arguments line exists.


Claude-Session: https://claude.ai/code/session_01Mn2cKMp58kuuvoxBSnaByo