### PR TITLE
ci: trigger sync-rules/sync-modules on _common.py changes

### DIFF
--- a/.github/workflows/sync-modules.yml
+++ b/.github/workflows/sync-modules.yml
@@ -7,6 +7,7 @@ on:
       - 'Surge/Module/**'
       - '.github/scripts/sync-modules.txt'
       - '.github/scripts/sync-modules.py'
+      - '.github/scripts/_common.py'
   schedule:
     - cron: '0 16 * * *'   # 每天 UTC 16:00 = UTC+8 00:00
   workflow_dispatch:

--- a/.github/workflows/sync-rules.yml
+++ b/.github/workflows/sync-rules.yml
@@ -7,6 +7,7 @@ on:
       - 'Surge/RULE-SET/**'
       - '.github/scripts/sync-rules.txt'
       - '.github/scripts/sync-rules.py'
+      - '.github/scripts/_common.py'
   schedule:
     - cron: '0 16 * * *'   # 每天 UTC 16:00 = UTC+8 00:00
   workflow_dispatch:


### PR DESCRIPTION
434b078 让 sync-rules.py 与 sync-modules.py 改用共用的 _common.py， 但两个 workflow 的 push paths 过滤器未包含该文件——只改 _common.py 的提交不会触发对应 sync job，master 产物会滞后到当晚定时任务或手动
dispatch 才更新。把 _common.py 加入两者的 paths 过滤器。


Claude-Session: https://claude.ai/code/session_01F4XZtn7wQpEys3Rd4nZseo