### PR TITLE
refactor(scripts): drop dead var, align _UA placement, fix stale comment

### DIFF
--- a/.github/scripts/sync-modules.py
+++ b/.github/scripts/sync-modules.py
@@ -186,7 +186,6 @@ def aggregate():
     existing_meta = read_output_meta()
 
     url_list = [url for url, _ in url_alias_list]
-    url_to_alias = {url: alias for url, alias in url_alias_list if alias}
 
     print(f"并发拉取 {len(url_list)} 个 sgmodule …")
     results = prefetch_urls(url_list, _UA, encode=True)

--- a/.github/scripts/sync-rules.py
+++ b/.github/scripts/sync-rules.py
@@ -26,6 +26,7 @@ QX_DIR = REPO_ROOT / "Quantumult" / "X" / "Filter"
 CLASH_DIR = REPO_ROOT / "Clash" / "RuleSet"
 SINGBOX_DIR = REPO_ROOT / "sing-box" / "source"
 SYNC_RULES_TXT = REPO_ROOT / ".github" / "scripts" / "sync-rules.txt"
+_UA = "sync-rules/1.0"
 
 
 def _recently_changed_files() -> set[str]:
@@ -87,7 +88,7 @@ STREAMING_PLACEHOLDER_RE = re.compile(r"^###\s+Streaming(?:\s+([A-Z]+))?\s*$")
 
 
 # 合并组：含 ### Streaming 占位符且含多个 '# > Name' 节的文件视为合并组
-# 只扫描 streaming 服务文件，排除 AD.list / Unbreak.list 等多节非 streaming 文件
+# 只扫描 streaming 服务文件，排除 Block.list / Unbreak.list 等多节非 streaming 文件
 def _build_merge_maps() -> dict[str, str]:
     """扫描根目录各 streaming .list 文件，将含多个 '# > Name' 节的 section 名映射到其文件 stem。"""
     reverse: dict[str, str] = {}
@@ -719,9 +720,6 @@ def parse_sync_rules() -> dict:
                     overrides[k.strip()] = v.strip()
             result[section].append({"url": url.strip(), "name": name, "overrides": overrides})
     return result
-
-
-_UA = "sync-rules/1.0"
 
 
 def _is_clash_payload(text: str) -> bool:


### PR DESCRIPTION
合并最新 master 后的全局复查清理：
- sync-modules: 删除 aggregate() 中赋值后从未使用的 url_to_alias
- sync-rules: _UA 常量从函数间挪到文件顶部配置区，与 sync-modules 一致
- sync-rules: 注释中的 AD.list 改为 Block.list（master 已重命名该文件）

pyflakes 全干净；改动均为行为中性。


Claude-Session: https://claude.ai/code/session_01F4XZtn7wQpEys3Rd4nZseo