### PR TITLE
feat(clash): action 包装组图标改由 ADVERTISING.list 提供

### DIFF
--- a/.github/scripts/sync-config.py
+++ b/.github/scripts/sync-config.py
@@ -101,13 +101,18 @@ def _gen_loon_proxy_section(proxy_lines: list[str]) -> str:
     return "[Proxy]\n" + "\n".join(entries) if entries else ""
 
 
-def _gen_clash_action_wrapper_groups(proxy_lines: list[str]) -> tuple[list[str], str]:
-    """从 Surge proxy_lines 生成 Clash hidden action wrapper groups（无 icon）。
+def _gen_clash_action_wrapper_groups(
+    proxy_lines: list[str], icon_map: dict[str, str] | None = None
+) -> tuple[list[str], str]:
+    """从 Surge proxy_lines 生成 Clash hidden action wrapper groups。
+
+    icon_map（来自 policy-path 文件的 `# icon:` 注释）按名称提供 icon，缺省则不带 icon。
 
     返回：
       proxy_names  list[str]  按 proxy_lines 顺序的 emoji 名称
       wrapper_yaml str        追加到 pg_inject["block"] 的 YAML 文本
     """
+    icon_map = icon_map or {}
     proxy_names: list[str] = []
     wrapper_blocks: list[str] = []
     for line in proxy_lines:
@@ -121,10 +126,13 @@ def _gen_clash_action_wrapper_groups(proxy_lines: list[str]) -> tuple[list[str],
         clash_val = surge_val.upper()       # reject → REJECT, direct → DIRECT
         comment = strip_emoji(name)         # ⛔️ REJECT → REJECT, 🔘 DIRECT → DIRECT
         proxy_names.append(name)
+        icon = icon_map.get(name, "")
+        icon_line = f"    icon: {icon}\n" if icon else ""
         wrapper_blocks.append(
             f"  # {comment}\n"
             f'  - name: "{name}"\n'
             f"    type: select\n"
+            f"{icon_line}"
             f"    hidden: true\n"
             f"    proxies:\n"
             f"      - {clash_val}"
@@ -1148,9 +1156,10 @@ def gen_proxy_groups(
         # select + policy-path + no explicit proxies → adblock group
         if (g["type"] == "select" and "policy-path" in g["params"]
                 and not g["proxies"] and adblock_proxy_lines is not None):
-            extra_lines = _load_policy_path_proxy_lines(g["params"]["policy-path"]) or []
+            loaded = _load_policy_path_proxy_lines(g["params"]["policy-path"])
+            extra_lines, action_icons = loaded if loaded else ([], {})
             action_lines = _merge_action_lines(adblock_proxy_lines, extra_lines)
-            clash_action_names, wrapper_yaml = _gen_clash_action_wrapper_groups(action_lines)
+            clash_action_names, wrapper_yaml = _gen_clash_action_wrapper_groups(action_lines, action_icons)
             if clash_action_names:
                 icon = g["params"].get("icon-url", "")
                 icon_line = f"\n    icon: {icon}" if icon else ""
@@ -1308,9 +1317,12 @@ def _resolve_builtin_from_repo(name: str, platform: str) -> tuple[str, str] | No
     return None
 
 
-def _load_policy_path_proxy_lines(url: str) -> list[str] | None:
-    """解析 Surge policy-path URL，读取本地文件提取 `NAME = VALUE` action 行。
+def _load_policy_path_proxy_lines(url: str) -> tuple[list[str], dict[str, str]] | None:
+    """解析 Surge policy-path URL，读取本地文件提取 `NAME = VALUE` action 行及图标。
 
+    返回 (action_lines, icon_map)：
+      action_lines  list[str]       `NAME = VALUE` 行（供生成 wrapper group）
+      icon_map      dict[name,url]  `# icon: NAME = URL` 注释行解析的图标（Surge 忽略）
     仅处理 HotKids raw URL（可映射到仓库内文件）。其他来源返回 None，调用方走默认回退。
     """
     if not url.startswith(HOTKIDS_RAW_BASE):
@@ -1319,11 +1331,18 @@ def _load_policy_path_proxy_lines(url: str) -> list[str] | None:
     if not local.exists():
         return None
     out: list[str] = []
+    icons: dict[str, str] = {}
     for line in local.read_text(encoding="utf-8").splitlines():
         s = line.strip()
-        if s and not s.startswith("#") and "=" in s:
+        if not s:
+            continue
+        m = re.match(r"#\s*icon:\s*(.+?)\s*=\s*(\S+)$", s)
+        if m:
+            icons[m.group(1).strip()] = m.group(2).strip()
+            continue
+        if not s.startswith("#") and "=" in s:
             out.append(s)
-    return out
+    return out, icons
 
 
 def _merge_action_lines(base: list[str], extra: list[str]) -> list[str]:

--- a/Clash/Sample.yaml
+++ b/Clash/Sample.yaml
@@ -1,5 +1,5 @@
 # Clash
-# Date: 2026-06-29 12:41:03
+# Date: 2026-06-29 12:52:36
 # Author: @HotKids
 
 # 通用设置
@@ -442,6 +442,7 @@ proxy-groups:
   # DIRECT
   - name: "🔘 DIRECT"
     type: select
+    icon: https://testingcf.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Direct.png
     hidden: true
     proxies:
       - DIRECT
@@ -449,6 +450,7 @@ proxy-groups:
   # REJECT
   - name: "⛔️ REJECT"
     type: select
+    icon: https://testingcf.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Reject.png
     hidden: true
     proxies:
       - REJECT
@@ -456,6 +458,7 @@ proxy-groups:
   # REJECT-DROP
   - name: "📛 REJECT-DROP"
     type: select
+    icon: https://testingcf.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Reject.png
     hidden: true
     proxies:
       - REJECT-DROP

--- a/Surge/ADVERTISING.list
+++ b/Surge/ADVERTISING.list
@@ -1,7 +1,12 @@
 💢 REJECT-TINYGIF = reject-tinygif
-📛 REJECT-DROP = reject-drop  
+📛 REJECT-DROP = reject-drop
 ⛔️ REJECT = reject
-🔘 DIRECT = direct  
+🔘 DIRECT = direct
+
+# Clash 隐藏包装组图标（sync-config 读取并套用到对应 wrapper group，Surge 忽略以下注释）
+# icon: 🔘 DIRECT = https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Direct.png
+# icon: ⛔️ REJECT = https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Reject.png
+# icon: 📛 REJECT-DROP = https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Reject.png
 
 # DIRECT：将该请求直接发往目标服务器
 # REJECT：拒绝该请求，当连接类型为 HTTP 时，会返回一个错误页面。（该行为可被 show-error-page-for-reject 参数控制）


### PR DESCRIPTION
需求：让 Clash 隐藏 action 包装组（🔘 DIRECT / ⛔️ REJECT / 📛 REJECT-DROP） 带上 icon，且图标信息存在 Surge/ADVERTISING.list 里，生成时直接读取。

- ADVERTISING.list：新增 '# icon: NAME = URL' 注释行（整行 # 注释，Surge 拉取 policy-path 时忽略，仅 sync-config 读取）。存原始 raw URL，由既有 gist 反代 自动转 jsdelivr。
- _load_policy_path_proxy_lines：同时解析 action 行与 icon 映射，返回元组。
- _gen_clash_action_wrapper_groups：接收 icon_map，在 type 后输出 icon 行。
- 调用处解构新返回值并传入 icon_map。

验证：sync-config 实跑，三个包装组按 name→type→icon→hidden→proxies 生成且 图标正确；Surge/Loon/QX/Surfboard 无变化；Sample.yaml 可解析。


Claude-Session: https://claude.ai/code/session_01F4XZtn7wQpEys3Rd4nZseo