### PR TITLE
fix(ci/media-check): lint.yml 因 YAML 无效从未运行；HBO Max 改用 max.com 单请求方案

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,38 +17,42 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Syntax check Python
-        run: python3 -m py_compile .github/scripts/sync-rules.py .github/scripts/sync-config.py .github/scripts/sync-modules.py
+        # glob 覆盖全部脚本（含 _common.py 及以后新增文件）；py_compile 不追 import，逐文件列举容易漏
+        run: python3 -m py_compile .github/scripts/*.py
 
+      # 注意：run 块内嵌 Python 必须与块基准缩进对齐（YAML 会剥除公共缩进）。
+      # 此前 Python 顶格书写导致整个 workflow 文件无法被 GitHub 解析，
+      # lint 自创建起从未真正运行（每次 push 记一次零 job 的 failure）。
       - name: Validate generated Clash YAML parseable
         run: |
           python3 -c "
-import yaml, pathlib, sys
-files = sorted(pathlib.Path('Clash/RuleSet').rglob('*.yaml'))
-errors = []
-for f in files:
-    try:
-        yaml.safe_load(f.read_text())
-    except yaml.YAMLError as e:
-        errors.append(f'{f}: {e}')
-if errors:
-    print('FAIL:', *errors, sep='\n')
-    sys.exit(1)
-print(f'All {len(files)} Clash YAML files OK')
-"
+          import yaml, pathlib, sys
+          files = sorted(pathlib.Path('Clash/RuleSet').rglob('*.yaml'))
+          errors = []
+          for f in files:
+              try:
+                  yaml.safe_load(f.read_text())
+              except yaml.YAMLError as e:
+                  errors.append(f'{f}: {e}')
+          if errors:
+              print('FAIL:', *errors, sep='\n')
+              sys.exit(1)
+          print(f'All {len(files)} Clash YAML files OK')
+          "
 
       - name: Validate generated sing-box JSON parseable
         run: |
           python3 -c "
-import json, pathlib, sys
-files = sorted(pathlib.Path('sing-box/source').rglob('*.json'))
-errors = []
-for f in files:
-    try:
-        json.loads(f.read_text())
-    except json.JSONDecodeError as e:
-        errors.append(f'{f}: {e}')
-if errors:
-    print('FAIL:', *errors, sep='\n')
-    sys.exit(1)
-print(f'All {len(files)} sing-box JSON files OK')
-"
+          import json, pathlib, sys
+          files = sorted(pathlib.Path('sing-box/source').rglob('*.json'))
+          errors = []
+          for f in files:
+              try:
+                  json.loads(f.read_text())
+              except json.JSONDecodeError as e:
+                  errors.append(f'{f}: {e}')
+          if errors:
+              print('FAIL:', *errors, sep='\n')
+              sys.exit(1)
+          print(f'All {len(files)} sing-box JSON files OK')
+          "

--- a/Surge/Module/Scripts/media-check.js
+++ b/Surge/Module/Scripts/media-check.js
@@ -13,7 +13,7 @@
  * 🎬 流媒体
  *    ├─ Netflix       含价格显示（可选关闭）、多级地区码提取
  *    ├─ Disney+       支持 Hotstar 地区识别（ID/MY/TH/PH/VN）
- *    ├─ HBO Max       支持第三方平台识别（JP/KR/CA）、VPN 检测
+ *    ├─ HBO Max       单请求方案（max.com 响应头取地区码）、第三方平台识别（JP/KR/CA）
  *    ├─ YouTube       双重请求机制（带/不带 Cookie）
  *    └─ Spotify       标准地区检测
  *
@@ -411,143 +411,45 @@ class ServiceChecker {
   /**
    * HBO Max 解锁检测
    * 特殊处理：JP (U-NEXT)、CA (Crave)、KR (Coupang Play)
-   * 参考 RegionRestrictionCheck 项目逻辑
    *
-   * 已知问题（2026-07 排查）：Step 2 token 接口现在会返回
-   * 400 {"errors":[{"code":"invalid.headers","detail":"disco_params is missing"}]}，
-   * 导致 Step 2 之后必现失败、所有节点一律显示 No，与账号/地区/节点无关。
-   * 这是 HBO Max 后端近期加的未公开参数，非本文件改动引入。已核实：
-   * - Step 1（www.hbomax.com 首页 + 可用地区列表正则）本身仍正常，问题只在
-   *   token 接口
-   * - lmc999/RegionRestrictionCheck 已弃用整条深层 API 链，改用单次首页
-   *   请求（能判可用性，但拿不到具体地区，也就没有 JP/CA/KR/VPN 细分）
-   * - 1-stream/RegionRestrictionCheck 的实现与本文件此前逻辑一致（同一
-   *   token 请求、同一批 header），同样会命中这个 400，说明目前没有任何
-   *   公开参考项目跟进修复
-   * 待上述任一参考项目更新 disco_params 或新流程后，再考虑移植过来。
+   * 2026-07 重写（参考 lmc999/RegionRestrictionCheck 单请求方案）：
+   * 原实现走 token → bootstrap → users/me 深层 API 链，该链的 token 接口
+   * 已被后端加上未公开的 disco_params 必需参数（400 invalid.headers），
+   * 导致所有节点必现 No。现改为单次请求 www.max.com（301 至 hbomax.com）：
+   * - 地区码取自最终响应头中的 countryCode=XX（Set-Cookie，已实测可得）
+   * - 可用地区列表取自正文 "url":"/xx/xx" 正则（与旧 Step 1 相同），补 US
+   * 代价：原依赖 token 的 VPN 检测（playbackInfo）随 API 链一并移除。
    * @returns {Promise<Object>} 检测结果
    */
   static async checkHBOMax() {
     try {
-      // Step 1: 从主页提取可用地区列表
-      let availableRegions = [];
-      try {
-        const homeRes = await Utils.request({ url: `https://www.hbomax.com/?t=${Date.now()}` });
-        if (homeRes.body) {
-          // 提取所有 "url":"/xx/xx" 格式的地区链接
-          const regex = /"url":"\/([a-z]{2})\/[a-z]{2}"/gi;
-          let match;
-          const regions = new Set();
-          while ((match = regex.exec(homeRes.body)) !== null) {
-            regions.add(match[1].toUpperCase());
-          }
-          availableRegions = Array.from(regions);
-        }
-      } catch {}
+      const res = await Utils.request({ url: "https://www.max.com/" });
+      const body = res.body || "";
 
-      // Step 2: Token 获取
-      const tokenRes = await Utils.request({
-        url: "https://default.any-any.prd.api.hbomax.com/token?realm=bolt&deviceId=afbb5daa-c327-461d-9460-d8e4b3ee4a1f",
-        headers: {
-          "x-device-info": "beam/5.0.0 (desktop/desktop; Windows/10; afbb5daa-c327-461d-9460-d8e4b3ee4a1f/da0cdd94-5a39-42ef-aa68-54cbc1b852c3)",
-          "x-disco-client": "WEB:10:beam:5.2.1",
-          "Accept": "application/json, text/plain, */*"
-        }
-      });
-      if (tokenRes.status !== 200) return Utils.createResult(STATUS.FAIL, "No");
-      
-      let tokenData;
-      try {
-        tokenData = JSON.parse(tokenRes.body);
-      } catch {
-        return Utils.createResult(STATUS.FAIL, "No");
-      }
-      
-      const token = tokenData?.data?.attributes?.token;
-      if (!token) return Utils.createResult(STATUS.FAIL, "No");
-      
-      const commonHeaders = { "Cookie": `st=${token}`, "Accept": "application/json, text/plain, */*" };
+      // 地区码：重定向链最终响应头（如 Set-Cookie）中的 countryCode=XX
+      const headerStr = JSON.stringify(res.headers || {});
+      const region = headerStr.match(/countryCode=([A-Za-z]{2})/)?.[1]?.toUpperCase() || "";
+      if (!region) return Utils.createResult(STATUS.FAIL, "No");
 
-      // Step 3: Bootstrap
-      const bootstrapRes = await Utils.request({
-        url: "https://default.any-any.prd.api.hbomax.com/session-context/headwaiter/v1/bootstrap",
-        method: "POST",
-        headers: commonHeaders
-      });
-      
-      let bootstrapData;
-      try {
-        bootstrapData = JSON.parse(bootstrapRes.body);
-      } catch {
-        return Utils.createResult(STATUS.FAIL, "No");
-      }
-      
-      const route = bootstrapData?.routing;
-      if (!route?.domain) return Utils.createResult(STATUS.FAIL, "No");
-
-      // Step 4: User Region
-      const userRes = await Utils.request({
-        url: `https://default.${route.tenant}-${route.homeMarket}.${route.env}.${route.domain}/users/me`,
-        headers: commonHeaders
-      });
-      
-      if (userRes.status === 401 || userRes.status === 403) {
-        return Utils.createResult(STATUS.FAIL, "No");
-      }
-      
-      let region = "";
-      try {
-        const userData = JSON.parse(userRes.body);
-        region = userData?.data?.attributes?.currentLocationTerritory || "";
-      } catch {}
-      
-      if (!region || region.length !== 2) {
-        return Utils.createResult(STATUS.FAIL, "No");
-      }
-
-      // Step 5: JP 特殊处理 - 优先验证 U-NEXT
+      // JP / CA / KR：经由第三方平台提供服务
       if (region === "JP") {
         const unextResult = await ServiceChecker.checkUNext();
-        if (unextResult.status === STATUS.OK) {
-          return Utils.createResult(STATUS.COMING, "JP (U-NEXT)");
-        } else {
-          return Utils.createResult(STATUS.FAIL, "JP (No)");
-        }
+        return unextResult.status === STATUS.OK
+          ? Utils.createResult(STATUS.COMING, "JP (U-NEXT)")
+          : Utils.createResult(STATUS.FAIL, "JP (No)");
       }
-      
-      // Step 5.5: CA 和 KR 特殊处理 - 通过第三方平台提供
-      if (region === "CA") {
-        return Utils.createResult(STATUS.COMING, "CA (Crave)");
-      }
-      if (region === "KR") {
-        return Utils.createResult(STATUS.COMING, "KR (Coupang Play)");
-      }
-      
-      // Step 6: 判断 region 是否在可用地区列表中
-      const isAvailable = availableRegions.includes(region);
-      if (!isAvailable) {
-        return Utils.createResult(STATUS.FAIL, `${region} (No)`);
-      }
-      
-      // Step 7: VPN 检测
-      let isVPN = false;
-      try {
-        const vpnRes = await Utils.request({
-          url: "https://default.any-any.prd.api.hbomax.com/any/playback/v1/playbackInfo",
-          headers: commonHeaders,
-          timeout: 5000
-        });
-        if (vpnRes.body && /VPN/i.test(vpnRes.body)) {
-          isVPN = true;
-        }
-      } catch {}
+      if (region === "CA") return Utils.createResult(STATUS.COMING, "CA (Crave)");
+      if (region === "KR") return Utils.createResult(STATUS.COMING, "KR (Coupang Play)");
 
-      if (isVPN) {
-        return Utils.createResult(STATUS.FAIL, `${region} (VPN)`);
+      // 可用地区列表：正文 "url":"/xx/xx" 地区链接；US 主站首页不含自身，手动补
+      const availableRegions = new Set(["US"]);
+      for (const m of body.matchAll(/"url":"\/([a-z]{2})\/[a-z]{2}"/gi)) {
+        availableRegions.add(m[1].toUpperCase());
       }
-      
-      return Utils.createResult(STATUS.OK, region);
-      
+
+      return availableRegions.has(region)
+        ? Utils.createResult(STATUS.OK, region)
+        : Utils.createResult(STATUS.FAIL, `${region} (No)`);
     } catch {
       return Utils.createResult(STATUS.FAIL, "No");
     }


### PR DESCRIPTION
## Summary
两项修复：

### 1. lint.yml 自创建起从未真正运行（全局审查发现）
- **无效 workflow 文件**：两个校验 step 的 `run: |` 块内嵌 Python 顶格书写，YAML 字面块在首行后即被截断，整个文件无法被 GitHub 解析。查证 Actions 历史：328 次 run 全部 failure、全部 0 job，且不受 paths 过滤约束——Clash YAML / sing-box JSON 校验一直是摆设。修复：内嵌 Python 统一缩进到块基准，YAML 剥除公共缩进后 shell 收到的代码与原意完全等价。
- **`py_compile` 未覆盖 `_common.py`**：py_compile 不追 import（实测验证），`_common.py` 语法错误会通过 lint 但让三个 sync 脚本运行时全崩。改用 `.github/scripts/*.py` glob，以后新增脚本也不会漏。

### 2. HBO Max 检测改用 max.com 单请求方案（修复所有节点必现 No）
原实现走 token → bootstrap → users/me 深层 API 链，token 接口已被后端加上未公开的 `disco_params` 必需参数（`400 invalid.headers`），所有节点必现 No，两个公开参考项目均无修复可抄。新方案（参考 lmc999/RegionRestrictionCheck，经真实节点实测验证）：
- 单次请求 `www.max.com`（301 至 hbomax.com），地区码从最终响应头 `countryCode=XX` 提取（实测 SG 节点正确取得）
- 可用地区列表沿用正文 `"url":"/xx/xx"` 正则，另补 US
- JP→U-NEXT / CA→Crave / KR→Coupang Play 细分判定完整保留；依赖已坏 token 的 VPN 检测随 API 链移除
- 净 −98 行

## Test plan
- [x] lint.yml：`yaml.safe_load` 解析通过；端到端模拟（解析 workflow → 逐 step bash 执行）三个 step 全 PASS（py_compile 4 文件、Clash YAML 81、sing-box JSON 81）
- [x] media-check.js：`node --check` 通过；HBO Max 新逻辑隔离测试六场景（SG 命中/DE 不在列表/US 手动补/CA/无地区码/小写码）全符合预期；关键提取（响应头 countryCode）已在真实 Surge 节点实测验证
- [x] 合并后首次命中 lint paths 的 push 应出现真实 job（此前均为 0 job 空 failure）

https://claude.ai/code/session_01F4XZtn7wQpEys3Rd4nZseo