### PR TITLE
feat(sync-config): overlay 自声明 output 路径，自动发现 Enhanced/ 下所有 overlay

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -63,8 +63,11 @@
 这两个生成产物本体。overlay 还可以用 `extends: "<其他 overlay 文件名>"` 声明基于另一份
 已生成的 overlay 结果继续叠加（`clashbox.overlay.json` extends `myscript.overlay.json`），
 只需要写与被继承者的差异，公共部分（地区 fallback、Relay 中转链等）不必重复声明。
-`Enhanced/` 下每多一份 `<name>.overlay.json` 就会多生成一份 `Clash/Script/<Name>.js`
-（对应关系见 `sync-config.py` 的 `_sync_clash` 里的 `overlay_specs`）。
+
+`_sync_clash` 会自动扫描 `Enhanced/` 下所有 `*.overlay.json`，每份的输出路径由它自己的
+`output` 字段声明（仓库根相对，如 `"Clash/Script/ClashBox.js"`），`extends` 依赖顺序自动
+拓扑解析——因此**新增一份个人配置只需在 `Enhanced/` 下放一个带 `output` 的 `*.overlay.json`
+即可自动生成对应脚本，无需改动 `sync-config.py`**。
 
 **触发**：`Profile.conf`、`sync-config.py`、`sync-config.txt`、`sync-config/**` 变动（push to master）
 

--- a/.github/scripts/sync-config.py
+++ b/.github/scripts/sync-config.py
@@ -2944,38 +2944,53 @@ def _sync_clash(
     script_changed = _write_if_changed(REPO_ROOT / script_path, script_body)
     print(f"  {'✓ ' + str(script_path) + ' 已更新' if script_changed else '✓ ' + str(script_path) + ' 无变化'}")
 
-    # 个人差异声明（Enhanced/ 下）：每个 *.overlay.json 对应一份同名派生脚本，
-    # 均由本函数按同一套逻辑生成，公共部分自动跟随 Script.js 同步。overlay 可用
-    # extends 声明基于另一份已生成的 overlay（而非从 Sample.yaml 重新起步）叠加，
-    # 避免多份个人配置之间重复声明同样的地区/Relay 链差异。
+    # 个人差异声明（Enhanced/ 下）：自动扫描所有 *.overlay.json，每份生成一份派生
+    # 脚本，输出路径由 overlay 自己的 output 字段声明（仓库根相对路径，如
+    # "Clash/Script/ClashBox.js"）——以后新增一份 overlay 文件即可自动生成对应脚本，
+    # 无需改动本脚本。公共部分自动跟随 Script.js 同步；overlay 可用 extends 声明基于
+    # 另一份 overlay（而非从 Sample.yaml 重新起步）叠加，避免多份个人配置之间重复
+    # 声明同样的地区/Relay 链差异，依赖顺序按 extends 自动拓扑解析。
     enhanced_dir = REPO_ROOT / ".github" / "scripts" / "sync-config" / "Enhanced"
-    overlay_specs = [
-        ("myscript.overlay.json", "MyScript.js"),
-        ("clashbox.overlay.json", "ClashBox.js"),
-    ]
-    resolved_states: dict[str, tuple] = {}
-    for overlay_label, out_name in overlay_specs:
-        overlay_path = enhanced_dir / overlay_label
-        if not overlay_path.exists():
-            continue
+    overlays: dict[str, dict] = {}
+    for overlay_path in sorted(enhanced_dir.glob("*.overlay.json")):
         overlay = json.loads(overlay_path.read_text(encoding="utf-8"))
+        if not overlay.get("output"):
+            raise ValueError(
+                f"{overlay_path.name} 缺少必填字段 output（派生脚本的输出路径，"
+                f"仓库根相对，如 \"Clash/Script/{overlay_path.name.split('.')[0].capitalize()}.js\"）"
+            )
+        overlays[overlay_path.name] = overlay
+
+    resolved_states: dict[str, tuple] = {}
+
+    def _resolve_overlay(label: str, chain: list[str]) -> None:
+        if label in resolved_states:
+            return
+        if label in chain:
+            raise ValueError(
+                f"overlay 的 extends 出现循环依赖：{' -> '.join(chain + [label])}"
+            )
+        overlay = overlays[label]
         extends = overlay.get("extends")
         base_state = None
         if extends:
-            if extends not in resolved_states:
+            if extends not in overlays:
                 raise ValueError(
-                    f"{overlay_label} 的 extends 引用了 {extends!r}，但它不在 "
-                    f"_sync_clash 的 overlay_specs 里，或排在本文件之后（extends "
-                    f"只能引用排在自己之前、且已存在的 overlay 文件）"
+                    f"{label} 的 extends 引用了不存在的 overlay 文件 {extends!r}；"
+                    f"Enhanced/ 下现有：{sorted(overlays)}"
                 )
+            _resolve_overlay(extends, chain + [label])
             base_state = resolved_states[extends]
         out_body, state = _gen_clash_script_js(
-            body, overlay=overlay, overlay_label=overlay_label, base_state=base_state
+            body, overlay=overlay, overlay_label=label, base_state=base_state
         )
-        resolved_states[overlay_label] = state
-        out_path = Path(clash_out).parent / "Script" / out_name
-        out_changed = _write_if_changed(REPO_ROOT / out_path, out_body)
-        print(f"  {'✓ ' + str(out_path) + ' 已更新' if out_changed else '✓ ' + str(out_path) + ' 无变化'}")
+        resolved_states[label] = state
+        out_rel = overlay["output"]
+        out_changed = _write_if_changed(REPO_ROOT / out_rel, out_body)
+        print(f"  {'✓ ' + out_rel + ' 已更新' if out_changed else '✓ ' + out_rel + ' 无变化'}")
+
+    for label in overlays:
+        _resolve_overlay(label, [])
 
 
 def _sync_loon(

--- a/.github/scripts/sync-config/Enhanced/clashbox.overlay.json
+++ b/.github/scripts/sync-config/Enhanced/clashbox.overlay.json
@@ -1,6 +1,8 @@
 {
   "_comment": "Clash/Script/ClashBox.js 相对 Clash/Script/Script.js 的私人差异声明，由 sync-config.py 读取并叠加在自动生成的基座上。改这个文件即可调整差异，不要直接手改 ClashBox.js（会被下次同步覆盖）。extends 声明基于 myscript.overlay.json 已经生成的结果继续叠加——ClashBox 相对 MyScript 主要是批量改名（rename_map）+ 换图标（icon_overrides），额外两处独有差异：REJECT-DROP 整组去掉（AdGuard 候选两选一）、OneDrive/Microsoft 默认关闭。日常改地区/Relay链等公共部分只需要维护 myscript.overlay.json，ClashBox 会自动跟着同步。",
 
+  "output": "Clash/Script/ClashBox.js",
+
   "extends": "myscript.overlay.json",
 
   "remove_groups": ["📛 REJECT-DROP"],

--- a/.github/scripts/sync-config/Enhanced/myscript.overlay.json
+++ b/.github/scripts/sync-config/Enhanced/myscript.overlay.json
@@ -1,5 +1,7 @@
 {
-  "_comment": "Clash/Script/MyScript.js 相对 Clash/Script/Script.js 的私人差异声明，由 sync-config.py 读取并叠加在自动生成的基座上。改这个文件即可调整差异，不要直接手改 MyScript.js（会被下次同步覆盖）。",
+  "_comment": "Clash/Script/MyScript.js 相对 Clash/Script/Script.js 的私人差异声明，由 sync-config.py 读取并叠加在自动生成的基座上。改这个文件即可调整差异，不要直接手改 MyScript.js（会被下次同步覆盖）。output 指定生成脚本的输出路径（仓库根相对）。",
+
+  "output": "Clash/Script/MyScript.js",
 
   "group_overrides": {
     "🇭🇰 Hong Kong": { "type": "fallback", "hidden": true, "icon": "https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Flags/HK.png", "filter": "^(?=.*HK)(?!.*GoMaMi)(?!.*Pro)" },

--- a/.github/workflows/sync-config.yml
+++ b/.github/workflows/sync-config.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Clash/Sample.yaml Clash/Script/Script.js Clash/Script/MyScript.js Clash/Script/ClashBox.js Surge/Balloon.lcf Quantumult/Sample.conf Surge/Surfboard.conf sing-box/config.json
+          git add Clash/Sample.yaml Clash/Script/ Surge/Balloon.lcf Quantumult/Sample.conf Surge/Surfboard.conf sing-box/config.json
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else


### PR DESCRIPTION
_sync_clash 不再硬编码 overlay→输出脚本的对应表，改为自动扫描 Enhanced/ 下所有 *.overlay.json：每份的输出路径由它自己的 output 字段声明（仓库根相对，如
"Clash/Script/ClashBox.js"），extends 依赖顺序用递归自动拓扑解析（含循环依赖检测）。 以后新增一份个人配置只需在 Enhanced/ 下放一个带 output 的 *.overlay.json 即可自动 生成对应脚本，无需改动 sync-config.py。

- myscript/clashbox.overlay.json 各补上 output 字段。
- sync-config.yml 的 git add 从逐个列脚本改成整个 Clash/Script/ 目录，新增 overlay 的产物也能被 CI 自动提交。
- README 补充 output 字段与自动发现的说明。

生成逻辑不变，三份脚本产物无变化。


Claude-Session: https://claude.ai/code/session_01F4XZtn7wQpEys3Rd4nZseo