### PR TITLE
解决 snell-panel 部署脚本与文档冲突并合并部署增强功能

### DIFF
--- a/snell-panel/README.md
+++ b/snell-panel/README.md
@@ -7,8 +7,8 @@ Cloudflare Workers + D1 + Hono 后端，Vite / React / HeroUI 前端，同 Worke
 ## 一键部署
 
 ```bash
-git clone https://github.com/HotKids/Rules Rules
-mv Rules/snell-panel snell-panel && rm -rf Rules
+git clone https://github.com/HotKids/Rules snell-panel-source
+ln -s snell-panel-source/snell-panel snell-panel
 cd snell-panel
 chmod +x deploy.sh
 ./deploy.sh
@@ -33,12 +33,18 @@ cd snell-panel
 
 ### D1 已存在怎么办？
 
-运行 `./deploy.sh`，选择复用现有 D1，并粘贴 Cloudflare D1 的 `database_id`。脚本不会覆盖 `apps/server/wrangler.jsonc` 中已有的有效 `database_id`。
+运行 `./deploy.sh`。脚本会自动识别并复用 `apps/server/wrangler.jsonc` 中已有的有效 `database_id`；只有未配置时才会询问是否复用现有 D1。
 
 ### secrets 如何处理？
 
-部署时可以跳过、覆盖、手动隐藏输入或回车自动生成 `ACCESS_TOKEN` / `API_TOKEN`。Cloudflare secret 写入后无法读回原文，请保存自动生成的 token。
+部署时可以跳过、覆盖、手动隐藏输入或回车自动生成 `ACCESS_TOKEN` / `API_TOKEN`。最终摘要默认只显示脱敏 token；确需明文输出时使用 `./deploy.sh --show-secrets`。Cloudflare secret 写入后无法读回原文，请妥善保存自动生成的 token。
 
 ### 如何排查部署问题？
 
-运行 `./doctor.sh`。更多说明见 `docs/DEPLOY.md`、`docs/UPDATE.md`、`docs/BACKUP.md`、`docs/SECURITY.md`、`docs/OPERATIONS.md`。
+运行 `./doctor.sh`。部署脚本也会在发布后自动检查 Worker URL，避免误以为 Cloudflare 默认空 Worker 页面是部署成功。
+
+### update.sh 提示不是 Git checkout 怎么办？
+
+推荐使用上面的一键部署命令：实际 Git 仓库保留在 `snell-panel-source`，日常通过软链接 `snell-panel` 进入项目，终端目录名仍显示 `snell-panel`，`./update.sh` 也可以自动拉取 GitHub 最新代码。旧版如果已经把子目录单独移动出来，可以临时执行 `UPDATE_REPO_URL=https://github.com/HotKids/Rules.git ./update.sh` 让脚本备份当前目录并重新 clone。
+
+更多说明见 `docs/DEPLOY.md`、`docs/UPDATE.md`、`docs/BACKUP.md`、`docs/SECURITY.md`、`docs/OPERATIONS.md`。

--- a/snell-panel/deploy.sh
+++ b/snell-panel/deploy.sh
@@ -4,19 +4,27 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts/deploy-common.sh"
 trap on_error ERR
 
 main() {
+  parse_common_args "$@"
   require_project
   ensure_runtime_tools
   install_dependencies
   ensure_wrangler_login
   ensure_d1_database
   apply_remote_migrations
+  build_panel
+
+  info "Deploying Worker before secret upload so Cloudflare creates a normal first deployment."
+  deploy_worker
+
   if confirm "Configure or overwrite ACCESS_TOKEN/API_TOKEN secrets now?" "Y"; then
     configure_secrets
+    info "Deploying final Worker version after secret upload..."
+    deploy_worker
   else
     success "Skipping secret changes; existing Cloudflare secrets are kept."
   fi
-  build_panel
-  deploy_worker
+
+  health_check_worker
   print_status "Deployment"
 }
 

--- a/snell-panel/docs/DEPLOY.md
+++ b/snell-panel/docs/DEPLOY.md
@@ -1,3 +1,18 @@
 # Deploy
 
-Run `./deploy.sh` from `Rules/snell-panel`. The script checks runtime tools, installs Bun dependencies, ensures Wrangler login, creates or reuses D1, writes `database_id`, applies remote migrations, configures secrets, builds the web app, deploys the Worker, and prints the Worker URL plus configuration status.
+Run `./deploy.sh` from the `snell-panel` directory. The script checks runtime tools, installs Bun dependencies, validates Cloudflare authentication with `wrangler whoami`, creates or reuses D1, writes `database_id`, applies remote migrations, builds and deploys the Worker, uploads secrets, deploys the final Worker version, runs a health check, and prints a masked deployment summary.
+
+## Headless VPS login
+
+For SSH-only servers, the recommended fully non-interactive path is to create a Cloudflare API token with Workers and D1 permissions, then run:
+
+```bash
+export CLOUDFLARE_API_TOKEN=<your-token>
+./deploy.sh
+```
+
+If OAuth is used on a headless VPS, keep the SSH session open, copy Wrangler's authorization URL into your local browser, and follow Wrangler's callback prompt.
+
+## Secrets
+
+Generated or entered secrets are masked by default in the final summary. Use `./deploy.sh --show-secrets` only when you explicitly want the full values printed to the terminal.

--- a/snell-panel/scripts/deploy-common.sh
+++ b/snell-panel/scripts/deploy-common.sh
@@ -6,6 +6,8 @@ SERVER_DIR="$PANEL_ROOT/apps/server"
 WRANGLER_CONFIG="$SERVER_DIR/wrangler.jsonc"
 PLACEHOLDER_DB_ID="replace-with-your-d1-database-id"
 LAST_WORKER_URL=""
+SHOW_SECRETS=0
+HEALTH_CHECK_RESULT="not run"
 
 info() { printf '\033[1;34m[INFO]\033[0m %s\n' "$*"; }
 success() { printf '\033[1;32m[DONE]\033[0m %s\n' "$*"; }
@@ -15,11 +17,29 @@ fail() { error "$*"; exit 1; }
 
 on_error() {
   local exit_code=$?
-  error "Command failed with exit code ${exit_code}. Fix the message above and rerun the script."
+  error "Deployment step failed with exit code ${exit_code}. The command output above contains the complete Wrangler/Bun error. Fix it and rerun the script."
   exit "$exit_code"
 }
 
 command_exists() { command -v "$1" >/dev/null 2>&1; }
+
+parse_common_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --show-secrets) SHOW_SECRETS=1 ;;
+      -h|--help)
+        cat <<HELP
+Usage: $0 [--show-secrets]
+
+--show-secrets  Print full generated/entered tokens in the final summary.
+HELP
+        exit 0
+        ;;
+      *) fail "Unknown option: $1" ;;
+    esac
+    shift
+  done
+}
 
 confirm() {
   local prompt="$1"
@@ -32,6 +52,20 @@ confirm() {
   [[ "$answer" =~ ^[Yy]$|^[Yy][Ee][Ss]$ ]]
 }
 
+run_cmd() {
+  local output status
+  info "Running: $*"
+  set +e
+  output="$($@ 2>&1)"
+  status=$?
+  set -e
+  printf '%s\n' "$output"
+  if [[ "$status" -ne 0 ]]; then
+    error "Command failed: $*"
+    return "$status"
+  fi
+}
+
 require_project() {
   [[ -d "$SERVER_DIR" ]] || fail "apps/server not found. Keep these scripts inside Rules/snell-panel."
   [[ -f "$WRANGLER_CONFIG" ]] || fail "Missing apps/server/wrangler.jsonc."
@@ -40,21 +74,18 @@ require_project() {
 install_with_apt() {
   local package="$1"
   command_exists sudo || fail "sudo is required to install $package with apt. Install $package manually and rerun."
-  sudo apt-get update
-  sudo apt-get install -y "$package"
+  run_cmd sudo apt-get update
+  run_cmd sudo apt-get install -y "$package"
 }
 
 install_with_brew() {
   local package="$1"
   command_exists brew || fail "Homebrew is not installed. Install $package manually and rerun."
-  brew install "$package"
+  run_cmd brew install "$package"
 }
 
 ensure_git() {
-  if command_exists git; then
-    success "git: $(git --version)"
-    return
-  fi
+  if command_exists git; then success "git: $(git --version)"; return; fi
   warn "git is not installed."
   case "$(uname -s)" in
     Linux) command_exists apt-get && install_with_apt git || fail "Only apt-based Debian/Ubuntu Linux is supported for automatic git installation." ;;
@@ -64,15 +95,12 @@ ensure_git() {
 }
 
 ensure_bun() {
-  if command_exists bun; then
-    success "bun: $(bun --version)"
-    return
-  fi
+  if command_exists bun; then success "bun: $(bun --version)"; return; fi
   warn "bun is not installed."
   case "$(uname -s)" in
     Linux|Darwin)
       command_exists curl || fail "curl is required to install bun."
-      curl -fsSL https://bun.sh/install | bash
+      run_cmd bash -c 'curl -fsSL https://bun.sh/install | bash'
       export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
       export PATH="$BUN_INSTALL/bin:$PATH"
       command_exists bun || fail "bun installed, but is not on PATH. Add $BUN_INSTALL/bin to PATH and rerun."
@@ -81,61 +109,61 @@ ensure_bun() {
   esac
 }
 
-ensure_node() {
-  if command_exists node; then success "node: $(node --version)"; else fail "node is required by Wrangler. Install Node.js 20+ and rerun."; fi
-}
+ensure_node() { if command_exists node; then success "node: $(node --version)"; else fail "node is required by Wrangler. Install Node.js 20+ and rerun."; fi; }
+ensure_curl() { if command_exists curl; then success "curl: installed"; else fail "curl is required. Install curl and rerun."; fi; }
+ensure_openssl() { if command_exists openssl; then success "openssl: $(openssl version | awk '{print $1, $2}')"; else warn "openssl is missing; token generation will use a weaker fallback."; fi; }
+ensure_wrangler() { info "Checking Wrangler availability via bunx..."; wrangler --version >/dev/null; success "wrangler: available"; }
+ensure_runtime_tools() { ensure_git; ensure_bun; ensure_node; ensure_curl; ensure_openssl; ensure_wrangler; }
+install_dependencies() { info "Installing Bun workspace dependencies..."; (cd "$PANEL_ROOT" && run_cmd bun install); }
 
-ensure_curl() {
-  if command_exists curl; then success "curl: installed"; else fail "curl is required. Install curl and rerun."; fi
-}
+wrangler() { (cd "$SERVER_DIR" && bunx wrangler "$@"); }
+wrangler_with_config() { (cd "$PANEL_ROOT" && bunx wrangler "$@" -c apps/server/wrangler.jsonc); }
 
-ensure_openssl() {
-  if command_exists openssl; then success "openssl: $(openssl version | awk '{print $1, $2}')"; else warn "openssl is missing; token generation will use a weaker fallback."; fi
-}
-
-ensure_wrangler() {
-  info "Checking Wrangler availability via bunx..."
-  (cd "$SERVER_DIR" && bunx wrangler --version >/dev/null)
-  success "wrangler: available"
-}
-
-ensure_runtime_tools() {
-  ensure_git
-  ensure_bun
-  ensure_node
-  ensure_curl
-  ensure_openssl
-  ensure_wrangler
-}
-
-install_dependencies() {
-  info "Installing Bun workspace dependencies..."
-  (cd "$PANEL_ROOT" && bun install)
-}
-
-wrangler() {
-  (cd "$SERVER_DIR" && bunx wrangler "$@")
-}
+is_headless() { [[ -n "${SSH_CONNECTION:-}${SSH_TTY:-}" || -z "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ]]; }
 
 ensure_wrangler_login() {
-  info "Checking Cloudflare Wrangler login..."
-  if wrangler whoami >/dev/null 2>&1; then
-    success "Wrangler is logged in."
-  else
-    warn "Wrangler is not logged in; starting browser login."
-    wrangler login
+  info "Validating Cloudflare Wrangler authentication with 'wrangler whoami'..."
+  if wrangler whoami; then success "Wrangler authentication is valid."; return; fi
+  if [[ -n "${CLOUDFLARE_API_TOKEN:-}" ]]; then
+    fail "CLOUDFLARE_API_TOKEN is set but 'wrangler whoami' failed. Check the token permissions."
   fi
+  if is_headless; then
+    warn "Detected a headless SSH/no-GUI environment. Wrangler OAuth may print a URL and wait for a browser callback."
+    cat <<'MSG'
+Recommended non-interactive option:
+  export CLOUDFLARE_API_TOKEN=<token with Workers, D1, and Account read permissions>
+  ./deploy.sh
+
+If you continue with OAuth:
+  1. Copy the authorization URL printed by Wrangler into your local browser.
+  2. Complete authorization while keeping this SSH session open.
+  3. If Wrangler shows a localhost callback URL, copy the FULL redirected URL and follow Wrangler's prompt.
+MSG
+  fi
+  run_cmd wrangler login
+  wrangler whoami >/dev/null || fail "Wrangler login did not produce a valid authenticated session."
+  success "Wrangler authentication is valid."
 }
 
 current_database_id() {
-  sed -n 's/.*"database_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$WRANGLER_CONFIG" | head -n 1
+  node - "$WRANGLER_CONFIG" "$PLACEHOLDER_DB_ID" <<'NODE'
+const fs = require('fs');
+const file = process.argv[2];
+const placeholder = process.argv[3];
+let text = fs.readFileSync(file, 'utf8')
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/(^|[^:])\/\/.*$/gm, '$1');
+const ids = [...text.matchAll(/database_id\s*[:=]\s*["']([^"']+)["']/g)].map((m) => m[1]);
+const usable = ids.find((id) => id && id !== placeholder) || ids[0] || '';
+process.stdout.write(usable);
+NODE
 }
 
-has_database_id() {
-  local database_id
-  database_id="$(current_database_id)"
-  [[ -n "$database_id" && "$database_id" != "$PLACEHOLDER_DB_ID" ]]
+current_database_name() {
+  sed -nE 's/.*"database_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' "$WRANGLER_CONFIG" | head -n 1
 }
+
+has_database_id() { local database_id; database_id="$(current_database_id)"; [[ -n "$database_id" && "$database_id" != "$PLACEHOLDER_DB_ID" ]]; }
 
 write_database_id() {
   local database_id="$1"
@@ -145,130 +173,78 @@ write_database_id() {
   success "database_id saved to apps/server/wrangler.jsonc."
 }
 
-extract_database_id() {
-  sed -nE 's/.*database_id[[:space:]]*=[[:space:]]*"?([0-9a-fA-F-]{20,})"?.*/\1/p; s/.*"database_id"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -n 1
-}
+extract_database_id() { sed -nE 's/.*database_id[[:space:]]*=[[:space:]]*"?([0-9a-fA-F-]{20,})"?.*/\1/p; s/.*"database_id"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -n 1; }
 
 ensure_d1_database() {
-  if has_database_id; then
-    success "D1 database configured: $(current_database_id)"
-    return
-  fi
-
+  if has_database_id; then success "D1 database configured: $(current_database_id)"; return; fi
   warn "No usable D1 database_id is configured."
-  if confirm "Reuse an existing D1 database_id?" "N"; then
-    local manual_id
-    read -r -p "Existing D1 database_id: " manual_id
-    write_database_id "$manual_id"
-    return
-  fi
-
+  if confirm "Reuse an existing D1 database_id?" "N"; then local manual_id; read -r -p "Existing D1 database_id: " manual_id; write_database_id "$manual_id"; return; fi
   info "Creating D1 database '$PROJECT_NAME' from apps/server..."
   local output status database_id
-  set +e
-  output="$(wrangler d1 create "$PROJECT_NAME" 2>&1)"
-  status=$?
-  set -e
+  set +e; output="$(wrangler d1 create "$PROJECT_NAME" 2>&1)"; status=$?; set -e
   printf '%s\n' "$output"
-
   if [[ "$status" -ne 0 ]]; then
     warn "D1 creation failed. This usually means the database already exists or the account lacks permission."
     read -r -p "Paste an existing D1 database_id to continue, or leave empty to abort: " database_id
     [[ -n "$database_id" ]] || fail "No D1 database_id provided."
-    write_database_id "$database_id"
-    return
+    write_database_id "$database_id"; return
   fi
-
   database_id="$(printf '%s\n' "$output" | extract_database_id)"
   [[ -n "$database_id" ]] || fail "Could not parse database_id from Wrangler output. Paste it into apps/server/wrangler.jsonc and rerun."
   write_database_id "$database_id"
 }
 
-apply_remote_migrations() {
-  info "Applying remote D1 migrations from apps/server..."
-  wrangler d1 migrations apply "$PROJECT_NAME" --remote
+apply_remote_migrations() { info "Applying remote D1 migrations from apps/server..."; run_cmd wrangler d1 migrations apply "$PROJECT_NAME" --remote; }
+
+generate_token() { if command_exists openssl; then openssl rand -hex 24; elif [[ -r /proc/sys/kernel/random/uuid ]]; then printf '%s%s\n' "$(cat /proc/sys/kernel/random/uuid | tr -d -)" "$(cat /proc/sys/kernel/random/uuid | tr -d -)" | cut -c 1-48; elif command_exists shasum; then printf '%s-%s\n' "$(date +%s%N)" "$RANDOM" | shasum -a 256 | awk '{print substr($1, 1, 48)}'; else printf '%s%s%s\n' "$(date +%s)" "$RANDOM" "$RANDOM"; fi; }
+mask_secret() { local value="$1"; local len=${#value}; (( len <= 4 )) && printf '********' || printf '************%s' "${value: -4}"; }
+
+read_secret_value() { local name="$1" value=""; if confirm "Auto-generate $name?" "Y"; then value="$(generate_token)"; printf '\033[1;32m[DONE]\033[0m %s generated automatically. It will be masked in the final summary unless --show-secrets is used.\n' "$name" >&2; else read -r -s -p "Enter $name: " value; printf '\n'; fi; [[ -n "$value" ]] || fail "$name cannot be empty."; printf '%s' "$value"; }
+put_secret() { local name="$1" value="$2"; info "Uploading secret $name from apps/server..."; printf '%s' "$value" | wrangler secret put "$name"; }
+configure_secrets() { local access_token api_token; access_token="$(read_secret_value ACCESS_TOKEN)"; api_token="$(read_secret_value API_TOKEN)"; put_secret ACCESS_TOKEN "$access_token"; put_secret API_TOKEN "$api_token"; export SNELL_PANEL_ACCESS_TOKEN="$access_token" SNELL_PANEL_API_TOKEN="$api_token"; }
+build_panel() { info "Building web frontend..."; (cd "$PANEL_ROOT" && run_cmd bun run build); }
+extract_worker_url() { sed -nE 's#.*(https://[^[:space:]]+\.workers\.dev).*#\1#p; s#.*(https://[^[:space:]]+)#\1#p' | tail -n 1; }
+deploy_worker() { info "Deploying Worker..."; local output status; set +e; output="$(cd "$PANEL_ROOT" && bunx wrangler deploy -c apps/server/wrangler.jsonc 2>&1)"; status=$?; set -e; printf '%s\n' "$output"; [[ "$status" -eq 0 ]] || return "$status"; LAST_WORKER_URL="$(printf '%s\n' "$output" | extract_worker_url)"; }
+
+health_check_worker() {
+  local url="${1:-$LAST_WORKER_URL}" headers body status content_type
+  [[ -n "$url" ]] || { warn "Skipping health check because Worker URL could not be detected."; HEALTH_CHECK_RESULT="skipped: missing Worker URL"; return 0; }
+  info "Running deployment health check: $url"
+  headers="$(mktemp)"; body="$(mktemp)"
+  status="$(curl -L -sS -D "$headers" -o "$body" -w '%{http_code}' "$url" || true)"
+  content_type="$(awk 'BEGIN{IGNORECASE=1}/^content-type:/{sub(/\r$/,"",$0); print $0; exit}' "$headers")"
+  case "$status" in
+    2*|3*) ;;
+    *)
+      cat "$body"
+      rm -f "$headers" "$body"
+      HEALTH_CHECK_RESULT="failed: HTTP $status"
+      fail "Worker health check failed with HTTP $status."
+      ;;
+  esac
+  if grep -qi "There is nothing here yet" "$body"; then cat "$body"; rm -f "$headers" "$body"; HEALTH_CHECK_RESULT="failed: default empty Worker page"; fail "Worker deployed but Cloudflare returned the default empty Worker page."; fi
+  if ! grep -Eqi '<html|<!doctype|id="root"|application/json|text/html' "$body" "$headers"; then warn "Health check succeeded with HTTP $status, but response did not look like the SPA shell."; fi
+  HEALTH_CHECK_RESULT="ok: HTTP $status ${content_type}"
+  rm -f "$headers" "$body"
+  success "Worker health check passed ($HEALTH_CHECK_RESULT)."
 }
 
-generate_token() {
-  if command_exists openssl; then
-    openssl rand -hex 24
-  elif [[ -r /proc/sys/kernel/random/uuid ]]; then
-    local first second
-    first="$(cat /proc/sys/kernel/random/uuid)"
-    second="$(cat /proc/sys/kernel/random/uuid)"
-    printf '%s%s\n' "${first//-/}" "${second//-/}" | cut -c 1-48
-  elif command_exists shasum; then
-    printf '%s-%s\n' "$(date +%s%N)" "$RANDOM" | shasum -a 256 | awk '{print substr($1, 1, 48)}'
-  else
-    printf '%s%s%s\n' "$(date +%s)" "$RANDOM" "$RANDOM"
-  fi
-}
-
-read_secret_value() {
-  local name="$1"
-  local value=""
-  if confirm "Auto-generate $name?" "Y"; then
-    value="$(generate_token)"
-    printf '\033[1;32m[DONE]\033[0m %s generated automatically. Save it from the final summary.\n' "$name" >&2
-  else
-    read -r -s -p "Enter $name: " value
-    printf '\n'
-  fi
-  [[ -n "$value" ]] || fail "$name cannot be empty."
-  printf '%s' "$value"
-}
-
-put_secret() {
-  local name="$1"
-  local value="$2"
-  info "Uploading secret $name from apps/server..."
-  printf '%s' "$value" | wrangler secret put "$name"
-}
-
-configure_secrets() {
-  local access_token api_token
-  access_token="$(read_secret_value ACCESS_TOKEN)"
-  api_token="$(read_secret_value API_TOKEN)"
-  put_secret ACCESS_TOKEN "$access_token"
-  put_secret API_TOKEN "$api_token"
-  export SNELL_PANEL_ACCESS_TOKEN="$access_token"
-  export SNELL_PANEL_API_TOKEN="$api_token"
-}
-
-build_panel() {
-  info "Building web frontend..."
-  (cd "$PANEL_ROOT" && bun run build)
-}
-
-extract_worker_url() {
-  sed -nE 's#.*(https://[^[:space:]]+\.workers\.dev).*#\1#p; s#.*(https://[^[:space:]]+)#\1#p' | tail -n 1
-}
-
-deploy_worker() {
-  info "Deploying Worker..."
-  local output
-  output="$(cd "$PANEL_ROOT" && bunx wrangler deploy -c apps/server/wrangler.jsonc 2>&1)"
-  printf '%s\n' "$output"
-  LAST_WORKER_URL="$(printf '%s\n' "$output" | extract_worker_url)"
-}
+print_token_line() { local name="$1" value="$2"; if [[ "$SHOW_SECRETS" -eq 1 ]]; then printf '%s: %s\n' "$name" "$value"; else printf '%s: %s (use --show-secrets to print full value)\n' "$name" "$(mask_secret "$value")"; fi; }
 
 print_status() {
-  local mode="$1"
+  local mode="$1" worker_url="${LAST_WORKER_URL:-}"
   printf '\n\033[1;32m%s complete.\033[0m\n' "$mode"
-  printf 'Project: snell-panel\n'
-  printf 'Wrangler config: apps/server/wrangler.jsonc\n'
-  printf 'D1 database_id: %s\n' "$(current_database_id)"
-  printf 'Migrations: applied remotely\n'
-  printf 'Secrets: ACCESS_TOKEN/API_TOKEN configured remotely (values are not readable from Cloudflare)\n'
-  if [[ -n "${SNELL_PANEL_ACCESS_TOKEN:-}" ]]; then
-    printf 'Generated/entered ACCESS_TOKEN: %s\n' "$SNELL_PANEL_ACCESS_TOKEN"
-  fi
-  if [[ -n "${SNELL_PANEL_API_TOKEN:-}" ]]; then
-    printf 'Generated/entered API_TOKEN: %s\n' "$SNELL_PANEL_API_TOKEN"
-  fi
-  if [[ -n "$LAST_WORKER_URL" ]]; then
-    printf 'Worker URL: %s\n' "$LAST_WORKER_URL"
-  else
-    printf 'Worker URL: check the Wrangler deploy output above.\n'
-  fi
+  printf 'Project: snell-panel\nWrangler config: apps/server/wrangler.jsonc\nD1 database_id: %s\n' "$(current_database_id)"
+  [[ -n "$worker_url" ]] && printf 'Worker URL: %s\nAPI Base URL: %s/api\n' "$worker_url" "$worker_url" || printf 'Worker URL: check the Wrangler deploy output above.\n'
+  printf 'Migrations: applied remotely\nSecrets: ACCESS_TOKEN/API_TOKEN configured remotely (Cloudflare secrets are write-only)\nHealth check: %s\n' "$HEALTH_CHECK_RESULT"
+  [[ -n "${SNELL_PANEL_ACCESS_TOKEN:-}" ]] && print_token_line ACCESS_TOKEN "$SNELL_PANEL_ACCESS_TOKEN"
+  [[ -n "${SNELL_PANEL_API_TOKEN:-}" ]] && print_token_line API_TOKEN "$SNELL_PANEL_API_TOKEN"
+  [[ -n "$worker_url" ]] && printf 'Admin login: open %s and sign in with ACCESS_TOKEN.\n' "$worker_url"
+  cat <<'NEXT'
+Next commands:
+  Update:   ./update.sh
+  Redeploy: bun run build && bunx wrangler deploy -c apps/server/wrangler.jsonc
+  Logs:     cd apps/server && bunx wrangler tail
+  Doctor:   ./doctor.sh
+NEXT
 }

--- a/snell-panel/update.sh
+++ b/snell-panel/update.sh
@@ -3,17 +3,70 @@ set -Eeuo pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts/deploy-common.sh"
 trap on_error ERR
 
+refresh_project_paths() {
+  PANEL_ROOT="$1"
+  SERVER_DIR="$PANEL_ROOT/apps/server"
+  WRANGLER_CONFIG="$SERVER_DIR/wrangler.jsonc"
+}
+
+ensure_clean_worktree() {
+  local repo_root="$1"
+  if [[ -n "$(git -C "$repo_root" status --porcelain)" ]]; then
+    fail "Working tree has uncommitted changes. Commit/stash them before update."
+  fi
+}
+
+pull_latest_code() {
+  local repo_root branch
+  if repo_root="$(git -C "$PANEL_ROOT" rev-parse --show-toplevel 2>/dev/null)"; then
+    ensure_clean_worktree "$repo_root"
+    branch="$(git -C "$repo_root" rev-parse --abbrev-ref HEAD)"
+    [[ "$branch" != "HEAD" ]] || fail "Current Git checkout is detached HEAD. Checkout a branch before update."
+
+    info "Fetching latest code from origin..."
+    (cd "$repo_root" && git fetch origin)
+
+    info "Rebasing current branch '$branch' onto origin/$branch..."
+    if ! (cd "$repo_root" && git pull --rebase origin "$branch"); then
+      fail "git pull --rebase failed. Resolve conflicts manually, then rerun ./update.sh."
+    fi
+    success "Git repository updated from origin/$branch."
+    return
+  fi
+
+  if [[ -z "${UPDATE_REPO_URL:-}" ]]; then
+    fail "当前目录不是 Git checkout，无法自动拉取代码。请使用 git clone 方式部署，或设置远程仓库地址。"
+  fi
+
+  local current_dir parent_dir backup_dir new_root
+  current_dir="$(basename "$PANEL_ROOT")"
+  parent_dir="$(dirname "$PANEL_ROOT")"
+  backup_dir="$parent_dir/$current_dir.bak-$(date +%Y%m%d%H%M%S)"
+  new_root="$parent_dir/$current_dir"
+
+  info "Current directory is not a Git checkout; cloning from UPDATE_REPO_URL."
+  info "Moving current directory to $backup_dir"
+  mv "$PANEL_ROOT" "$backup_dir"
+
+  info "Cloning $UPDATE_REPO_URL into $new_root"
+  (cd "$parent_dir" && git clone "$UPDATE_REPO_URL" "$current_dir")
+
+  if [[ -f "$backup_dir/apps/server/wrangler.jsonc" && -f "$new_root/apps/server/wrangler.jsonc" ]]; then
+    info "Preserving existing apps/server/wrangler.jsonc from backup."
+    cp "$backup_dir/apps/server/wrangler.jsonc" "$new_root/apps/server/wrangler.jsonc"
+  fi
+
+  cd "$new_root"
+  refresh_project_paths "$new_root"
+  success "Repository cloned. Backup kept at $backup_dir"
+}
+
 main() {
+  parse_common_args "$@"
   require_project
   ensure_runtime_tools
-
-  local repo_root
-  if repo_root="$(git -C "$PANEL_ROOT" rev-parse --show-toplevel 2>/dev/null)"; then
-    info "Updating repository with git pull from $repo_root..."
-    (cd "$repo_root" && git pull --ff-only)
-  else
-    warn "snell-panel is not inside a git checkout; skipping git pull. Update the files manually before continuing."
-  fi
+  pull_latest_code
+  require_project
 
   install_dependencies
   ensure_wrangler_login
@@ -29,6 +82,7 @@ main() {
 
   build_panel
   deploy_worker
+  health_check_worker
   print_status "Update"
 }
 


### PR DESCRIPTION
### Motivation
- 解决 PR 分支与主分支在 snell-panel 部署相关文件上的冲突，并保留/合并部署流程中的改进项以避免功能回退。 
- 增强部署脚本的可用性与鲁棒性，包括 headless 环境支持、secret 管理可选明文显示、部署后健康检查与更稳健的依赖与命令执行封装。

### Description
- 合并并解决冲突的文件：`snell-panel/README.md`、`snell-panel/deploy.sh`、`snell-panel/docs/DEPLOY.md`、`snell-panel/scripts/deploy-common.sh`、`snell-panel/update.sh`，保留双方有价值的改动并整理成一致实现。 
- 在 `scripts/deploy-common.sh` 中加入参数解析 `parse_common_args`、统一命令包装 `run_cmd`、运行时检查 `ensure_*` 系列改进、Wrangler 登录验证与 headless 提示、对 `database_id` 的更稳健提取与写回逻辑（含小段 Node 解析以跳过注释）、以及 secrets 的生成/掩码与打印策略（支持 `--show-secrets`）。
- 在 `deploy.sh` 中集成参数解析、将部署流程调整为：先构建并预先部署 Worker，再按需上传 secrets 并再次发布最终版本，最后执行健康检查并打印部署摘要。 
- 在 `update.sh` 中加入 git-aware 更新逻辑（检查干净工作树、`fetch` + `pull --rebase`），并保留非 Git checkout 的 fallback：通过 `UPDATE_REPO_URL` 重新 clone 并保留本地 `wrangler.jsonc` 配置。 
- 文档 `docs/DEPLOY.md` 与 `README.md` 同步更新，包含 Headless VPS 使用建议、默认对 secrets 掩码显示及如何使用 `--show-secrets` 查看明文的说明。 

### Testing
- 对三个主要脚本运行语法检查：`bash -n snell-panel/deploy.sh snell-panel/update.sh snell-panel/scripts/deploy-common.sh`，结果通过且无语法错误。 (成功)
- 使用 `git diff --check origin/master...HEAD` 检查 whitespace/冲突残留，未发现问题。 (成功)
- 已在本地完成冲突合并并创建本地提交，但未进行任何远程推送，按约定在推送前请确认远端分支状态与推送策略。 (信息性说明)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4e76e59f188322b820b68ddf184946)