### PR TITLE
snell-panel 安全修复与重构 + 全仓用户可见文案统一

### DIFF
--- a/Surge/Module/APNs.sgmodule
+++ b/Surge/Module/APNs.sgmodule
@@ -1,5 +1,5 @@
 #!name=APNs Fix
-#!desc=改善中国大陆网络环境下部分境外应用的 APNs 推送连接稳定性。移动网络下可能需要开启“包含所有网络请求”，以接管 APNs 及相关网络请求；该选项可能影响 AirDrop、Xcode 调试、USB Dashboard 等功能，仅建议临时使用。
+#!desc=改善中国大陆网络环境下部分境外应用的 APNs 推送连接稳定性。移动网络下可能需要开启“包含所有网络请求”，以接管 APNs 及相关网络请求；该选项可能影响 AirDrop、Xcode 调试、USB Dashboard 等功能，仅建议临时使用
 #!category=HotKids
 #!system=ios
 #!arguments=APNs:🍎 Apple,Tunnel:true

--- a/Surge/Module/Bilibili.sgmodule
+++ b/Surge/Module/Bilibili.sgmodule
@@ -1,5 +1,5 @@
 #!name=哔哩哔哩去广告
-#!desc=哔哩哔哩去广告，部分 App 需清除缓存或重新安装后才会生效。
+#!desc=哔哩哔哩去广告，部分 App 需清除缓存或重新安装后才会生效
 #!author=kokoryh
 #!category=去广告
 #!arguments=动态最常访问:auto,创作中心:0,过滤置顶评论广告:1,优化评论区加载:bilibili.request,空降助手:bilibili.airborne,空降助手策略:DIRECT,日志等级:4

--- a/Surge/Module/BlockAds.sgmodule
+++ b/Surge/Module/BlockAds.sgmodule
@@ -1,5 +1,5 @@
 #!name=去广告合集
-#!desc=（个人向）按需收录自 QingRex/LoonKissSurge，自动同步上游，不另行维护，部分 App 需清除缓存或重新安装后才会生效。
+#!desc=（个人向）按需收录自 QingRex/LoonKissSurge，自动同步上游，不另行维护，部分 App 需清除缓存或重新安装后才会生效
 #!category=去广告
 #!remark=广告平台拦截器是去广告基础，优先级需置于本模块之前: https://raw.githubusercontent.com/HotKids/Rules/master/Surge/Module/BlockAdsBase.sgmodule
 #!arguments=12306:12306,123云盘:123pan,B612咔叽:kaji,ECOVACS HOME:eco,Foodie:kaji,IT之家:ithome,IT之家-removePinnedArticles:false,IT之家-removeAllBanners:false,Keep:gotokeep,Line:line,QQ音乐:tencentmusic,阿里云盘:alipan,爱奇艺:iqiyi,百度地图:baidu,百度网页:baidu,百度网盘:baidu,哔哩哔哩漫画:bilibili,波点音乐:kuwo,菜鸟:cainiao,彩云天气:caiyun,财新:caixin,大麦:taobao,得物:dewu,滴滴出行:didi,叮咚买菜:ddxq,飞客:flyert,飞猪旅行:taobao,高德地图:amap,航旅纵横:umetrip,金山文档:kdocs,京东外卖:jd,酷安:coolapk,快递100:kuaidi100,芒果TV:tv,起点读书:qidian,瑞幸咖啡:lkcoffee,什么值得买:smzdm,淘票票:taobao,网易有道词典:youdao,网易邮箱大师:163,微信公众号:qq,下厨房:xiachufang,闲鱼:goofish,香港抖音:me,小红书:xiaohongshu,小象超市:meituan,小宇宙:xiaoyuzhoufm,萤石云视频:ys7,优酷视频:youku,知乎:zhihu,转转:zhuanzhuan,中国联通:10010

--- a/Surge/Module/BlockAdsBase.sgmodule
+++ b/Surge/Module/BlockAdsBase.sgmodule
@@ -1,5 +1,5 @@
 #!name=广告平台拦截器
-#!desc=此插件是所有去广告插件的基础，只针对广告平台处理。你依然需要安装其他去广告插件来搭配使用，并确保此插件始终排序在顶部。
+#!desc=此插件是所有去广告插件的基础，只针对广告平台处理。你依然需要安装其他去广告插件来搭配使用，并确保此插件始终排序在顶部
 #!author=可莉🅥[https://github.com/luestr/ProxyResource/blob/main/README.md]
 #!icon=https://raw.githubusercontent.com/luestr/IconResource/main/Website_icon/120px/TencentAd.png
 #!category=去广告

--- a/Surge/Module/CloudMusic.sgmodule
+++ b/Surge/Module/CloudMusic.sgmodule
@@ -1,5 +1,5 @@
 #!name=网易云音乐去广告
-#!desc=网易云音乐去广告，部分 App 需清除缓存或重新安装后才会生效。
+#!desc=网易云音乐去广告，部分 App 需清除缓存或重新安装后才会生效
 #!author=Keywos
 #!system= ios
 #!category=去广告

--- a/Surge/Module/Local.sgmodule
+++ b/Surge/Module/Local.sgmodule
@@ -1,4 +1,4 @@
-#!name=LOCAL NETWORK
+#!name=Local Network
 #!desc=个人向直连规则，适用于本地网络、局域网设备及文件传输等需要绕过代理的场景
 #!category=HotKids
 #!arguments=SSID:JOEY,HotspotSSID:HotspotSSID

--- a/Surge/Module/MitM-All.sgmodule
+++ b/Surge/Module/MitM-All.sgmodule
@@ -1,5 +1,5 @@
 #!name=MitM All
-#!desc=临时对所有网站开启MitM，不建议长久开启，比较耗费性能，主profile配置下还是需要进行证书安装/配置
+#!desc=临时对所有网站开启 MitM，不建议长久开启，比较耗费性能，主 profile 配置下还是需要进行证书安装 / 配置
 #!category=HotKids
 
 [MITM]

--- a/Surge/Module/RedNote.sgmodule
+++ b/Surge/Module/RedNote.sgmodule
@@ -1,5 +1,5 @@
 #!name=小红书去广告
-#!desc=小红书去广告，部分 App 需清除缓存或重新安装后才会生效。
+#!desc=小红书去广告，部分 App 需清除缓存或重新安装后才会生效
 #!author=fmz200
 #!category=去广告
 #!homepage=https://github.com/fmz200/wool_scripts

--- a/Surge/Module/VoWiFi.sgmodule
+++ b/Surge/Module/VoWiFi.sgmodule
@@ -1,5 +1,5 @@
 #!name=VoWiFi Proxy
-#!desc=Proxy rules for Wi-Fi Calling / VoWiFi with remote DNS.
+#!desc=Proxy rules for Wi-Fi Calling / VoWiFi with remote DNS
 #!category=HotKids
 #!system=ios
 

--- a/Surge/Module/Weibo.sgmodule
+++ b/Surge/Module/Weibo.sgmodule
@@ -1,5 +1,5 @@
 #!name=微博去广告
-#!desc=微博去广告，部分 App 需清除缓存或重新安装后才会生效。
+#!desc=微博去广告，部分 App 需清除缓存或重新安装后才会生效
 #!author=fmz200
 #!icon=https://raw.githubusercontent.com/fmz200/wool_scripts/main/icons/apps/Weibo-00.png
 #!category=去广告

--- a/snell-panel/README.md
+++ b/snell-panel/README.md
@@ -41,7 +41,7 @@ cd snell-panel
 
 ### 如何排查部署问题？
 
-运行 `./doctor.sh`。部署脚本也会在发布后自动检查 Worker URL，避免误以为 Cloudflare 默认空 Worker 页面是部署成功。
+运行 `./doctor.sh`。部署脚本也会在发布后自动检查 Worker URL，避免误以为 Cloudflare 默认的空 Worker 页面代表部署成功。
 
 ### update.sh 提示不是 Git checkout 怎么办？
 

--- a/snell-panel/apps/server/src/lib/node-repo.ts
+++ b/snell-panel/apps/server/src/lib/node-repo.ts
@@ -1,0 +1,12 @@
+import { eq } from "drizzle-orm";
+import { nodes, type NodeRow } from "../db/schema";
+import type { Db } from "../db/client";
+
+/** Current time in Unix seconds — the unit every timestamp column uses. */
+export const nowSeconds = (): number => Math.floor(Date.now() / 1000);
+
+/** Fetch a single node by its public `nodeId`, or null if it doesn't exist. */
+export async function getNode(db: Db, nodeId: string): Promise<NodeRow | null> {
+  const rows = await db.select().from(nodes).where(eq(nodes.nodeId, nodeId)).limit(1);
+  return rows[0] ?? null;
+}

--- a/snell-panel/apps/server/src/lib/token.ts
+++ b/snell-panel/apps/server/src/lib/token.ts
@@ -7,6 +7,14 @@ export const TOKEN_TTL_SECONDS = 5 * 60;
 
 export type TokenPurpose = "install" | "upgrade" | "uninstall" | "heartbeat";
 
+/** The one-time-token purpose a node's current lifecycle expects: an active or
+ *  mid-upgrade node is being upgraded (upgrade token); anything else (pending /
+ *  installing / failed) is a fresh install. Keeps a provisioner callback from
+ *  being authorized by a token minted for a different lifecycle step. */
+export function expectedPurpose(status: string): TokenPurpose {
+  return status === "active" || status === "upgrading" ? "upgrade" : "install";
+}
+
 /** 32 random bytes, hex-encoded. */
 export function newToken(): string {
   const bytes = new Uint8Array(32);
@@ -41,14 +49,17 @@ export async function mintToken(
 
 /**
  * Validate a token for a node WITHOUT consuming it (provisioner pre-flight, so a
- * doomed install never starts). Looks the token up by its hash.
+ * doomed install never starts). Looks the token up by its hash. When `purposes`
+ * is given, the token's purpose must be one of them (defense against a token
+ * minted for one lifecycle step being replayed against another).
  */
 export async function validateToken(
   db: Db,
   token: string,
   nodeId: string,
   now: number,
-): Promise<{ ok: boolean; reason?: "missing" | "used" | "expired" }> {
+  purposes?: readonly TokenPurpose[],
+): Promise<{ ok: boolean; reason?: "missing" | "used" | "expired" | "purpose" }> {
   const hash = await hashToken(token);
   const rows = await db
     .select()
@@ -60,6 +71,9 @@ export async function validateToken(
   if (!row) return { ok: false, reason: "missing" };
   if (row.usedAt !== null) return { ok: false, reason: "used" };
   if (row.expiresAt < now) return { ok: false, reason: "expired" };
+  if (purposes && !purposes.includes(row.purpose as TokenPurpose)) {
+    return { ok: false, reason: "purpose" };
+  }
   return { ok: true };
 }
 

--- a/snell-panel/apps/server/src/routes/nodes.ts
+++ b/snell-panel/apps/server/src/routes/nodes.ts
@@ -10,26 +10,17 @@ import {
   type NodeVersion,
   type SnellVersion,
 } from "@snell-panel/shared";
-import { installTokens, nodes, type NodeInsert, type NodeRow } from "../db/schema";
+import { installTokens, nodes, type NodeInsert } from "../db/schema";
 import type { AppEnv } from "../env";
-import type { Db } from "../db/client";
 import { requireAccess, requireAccessOrApiToken } from "../middleware/auth";
 import { toNodeDTO } from "../lib/dto";
 import { mintToken } from "../lib/token";
+import { getNode, nowSeconds as now } from "../lib/node-repo";
 import { snellVersionFor } from "../lib/versions";
 import { buildCommand } from "../lib/command";
 import { lookupGeo } from "../lib/geoip";
 
 const router = new Hono<AppEnv>();
-
-function now(): number {
-  return Math.floor(Date.now() / 1000);
-}
-
-async function getNode(db: Db, nodeId: string): Promise<NodeRow | null> {
-  const rows = await db.select().from(nodes).where(eq(nodes.nodeId, nodeId)).limit(1);
-  return rows[0] ?? null;
-}
 
 // GET /api/nodes — list with structured filters and sorting.
 router.get("/", requireAccess, async (c) => {
@@ -196,6 +187,9 @@ router.patch("/:id", requireAccess, zValidator("json", patchNodeSchema), async (
   if (input.enabled !== undefined) update.enabled = input.enabled;
   if (input.ip !== undefined) {
     update.ip = input.ip;
+    // An explicit admin repoint is authoritative — pin it so later node-reported
+    // heartbeats can't silently overwrite it (mirrors create/relay semantics).
+    update.ipPrefilled = true;
     const geo = await lookupGeo(input.ip);
     update.countryCode = geo.countryCode;
     update.isp = geo.isp;

--- a/snell-panel/apps/server/src/routes/register.ts
+++ b/snell-panel/apps/server/src/routes/register.ts
@@ -1,15 +1,52 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { eq } from "drizzle-orm";
 import { heartbeatSchema, installFailedSchema, registerNodeSchema, type NodeProtocol } from "@snell-panel/shared";
-import { nodes } from "../db/schema";
+import { nodes, type NodeInsert, type NodeRow } from "../db/schema";
 import type { AppEnv } from "../env";
+import type { Db } from "../db/client";
 import { extractToken, hasApiToken } from "../middleware/auth";
-import { consumeToken, validateToken } from "../lib/token";
+import { consumeToken, expectedPurpose, validateToken, type TokenPurpose } from "../lib/token";
+import { getNode, nowSeconds } from "../lib/node-repo";
 import { lookupGeo } from "../lib/geoip";
 import { toNodeDTO } from "../lib/dto";
 
 const router = new Hono<AppEnv>();
+
+/**
+ * Authorize a provisioner callback for a node: the master API_TOKEN always
+ * passes; otherwise the request must carry a one-time node token matching the
+ * node's current lifecycle `purpose`. `consume: true` atomically burns it
+ * (register), otherwise it's only validated (pre-flight / failure / heartbeat
+ * callbacks that may fire more than once).
+ */
+async function authorizeNode(
+  c: Context<AppEnv>,
+  db: Db,
+  nodeId: string,
+  purpose: TokenPurpose,
+  ts: number,
+  opts: { consume?: boolean } = {},
+): Promise<boolean> {
+  if (hasApiToken(c)) return true;
+  const token = extractToken(c);
+  if (!token) return false;
+  return opts.consume
+    ? consumeToken(db, token, nodeId, purpose, ts)
+    : (await validateToken(db, token, nodeId, ts, [purpose])).ok;
+}
+
+/**
+ * The ip/port fields a self-reported callback (heartbeat) is allowed to write.
+ * Admin-prefilled ip/port stay authoritative; an undefined report leaves the
+ * stored value untouched. Returns only the keys that should change.
+ */
+function reportedIpPort(row: NodeRow, ip?: string | null, port?: number): Partial<NodeInsert> {
+  const patch: Partial<NodeInsert> = {};
+  if (!row.ipPrefilled && ip !== undefined) patch.ip = ip;
+  if (!row.portPrefilled && port !== undefined) patch.port = port;
+  return patch;
+}
 
 // GET /api/nodes/:id/verify-token — provisioner pre-flight; does NOT consume the token.
 router.get("/:id/verify-token", async (c) => {
@@ -20,8 +57,11 @@ router.get("/:id/verify-token", async (c) => {
   const token = extractToken(c);
   if (!token) return c.json({ ok: false, error: "missing token" }, 401);
 
-  const ts = Math.floor(Date.now() / 1000);
-  const res = await validateToken(db, token, id, ts);
+  const row = await getNode(db, id);
+  if (!row) return c.json({ ok: false, error: "missing" }, 401);
+
+  const ts = nowSeconds();
+  const res = await validateToken(db, token, id, ts, [expectedPurpose(row.status)]);
   if (!res.ok) return c.json({ ok: false, error: res.reason }, 401);
   await db.update(nodes).set({ status: "installing", installStartedAt: ts, lastError: null }).where(eq(nodes.nodeId, id));
   return c.json({ ok: true });
@@ -33,8 +73,7 @@ router.post("/:id/register", zValidator("json", registerNodeSchema), async (c) =
   const id = c.req.param("id");
   const input = c.req.valid("json");
 
-  const rows = await db.select().from(nodes).where(eq(nodes.nodeId, id)).limit(1);
-  const row = rows[0];
+  const row = await getNode(db, id);
   if (!row) return c.json({ error: "Node not found" }, 404);
   const rowProtocol = (row.protocol ?? "snell") as NodeProtocol;
   const inputProtocol = input.protocol ?? (input.version === "2022" ? "ss2022" : "snell");
@@ -42,18 +81,12 @@ router.post("/:id/register", zValidator("json", registerNodeSchema), async (c) =
     return c.json({ error: "Protocol mismatch" }, 400);
   }
 
-  // Authorize via the master API token, else consume a valid one-time token.
   // The token's purpose must match the node's lifecycle: a pending node expects
-  // an 'install' token, an active node an 'upgrade' token.
-  const ts = Math.floor(Date.now() / 1000);
-  const expectedPurpose = row.status === "active" || row.status === "upgrading" ? "upgrade" : "install";
-  let authorized = hasApiToken(c);
-  if (!authorized) {
-    const token = extractToken(c);
-    authorized =
-      token !== null && (await consumeToken(db, token, id, expectedPurpose, ts));
+  // an 'install' token, an active/upgrading node an 'upgrade' token.
+  const ts = nowSeconds();
+  if (!(await authorizeNode(c, db, id, expectedPurpose(row.status), ts, { consume: true }))) {
+    return c.json({ error: "Unauthorized" }, 401);
   }
-  if (!authorized) return c.json({ error: "Unauthorized" }, 401);
 
   // Pre-filled IP/Port stay authoritative; otherwise take the reported values.
   const ip = row.ipPrefilled && row.ip ? row.ip : input.ip ?? row.ip ?? null;
@@ -83,22 +116,19 @@ router.post("/:id/register", zValidator("json", registerNodeSchema), async (c) =
     })
     .where(eq(nodes.nodeId, id));
 
-  const updated = (
-    await db.select().from(nodes).where(eq(nodes.nodeId, id)).limit(1)
-  )[0];
-  return c.json({ node: toNodeDTO(updated) });
+  const updated = await getNode(db, id);
+  return c.json({ node: toNodeDTO(updated!) });
 });
 
 // POST /api/nodes/:id/install-failed — provisioner failure callback.
 router.post("/:id/install-failed", zValidator("json", installFailedSchema), async (c) => {
   const db = c.get("db");
   const id = c.req.param("id");
-  const token = extractToken(c);
-  const ts = Math.floor(Date.now() / 1000);
-  if (!hasApiToken(c)) {
-    if (!token || !(await validateToken(db, token, id, ts)).ok) {
-      return c.json({ error: "Unauthorized" }, 401);
-    }
+  const ts = nowSeconds();
+  const row = await getNode(db, id);
+  if (!row) return c.json({ error: "Node not found" }, 404);
+  if (!(await authorizeNode(c, db, id, expectedPurpose(row.status), ts))) {
+    return c.json({ error: "Unauthorized" }, 401);
   }
   const input = c.req.valid("json");
   await db.update(nodes).set({ status: "failed", installFinishedAt: ts, lastError: input.error }).where(eq(nodes.nodeId, id));
@@ -109,12 +139,11 @@ router.post("/:id/install-failed", zValidator("json", installFailedSchema), asyn
 router.post("/:id/heartbeat", zValidator("json", heartbeatSchema), async (c) => {
   const db = c.get("db");
   const id = c.req.param("id");
-  const token = extractToken(c);
-  const ts = Math.floor(Date.now() / 1000);
-  if (!hasApiToken(c)) {
-    if (!token || !(await validateToken(db, token, id, ts)).ok) {
-      return c.json({ error: "Unauthorized" }, 401);
-    }
+  const ts = nowSeconds();
+  const row = await getNode(db, id);
+  if (!row) return c.json({ error: "Node not found" }, 404);
+  if (!(await authorizeNode(c, db, id, expectedPurpose(row.status), ts))) {
+    return c.json({ error: "Unauthorized" }, 401);
   }
   const input = c.req.valid("json");
   await db.update(nodes).set({
@@ -122,8 +151,7 @@ router.post("/:id/heartbeat", zValidator("json", heartbeatSchema), async (c) => 
     lastSeenAt: ts,
     lastCheckAt: ts,
     lastError: input.error ?? null,
-    port: input.port,
-    ip: input.ip,
+    ...reportedIpPort(row, input.ip, input.port),
   }).where(eq(nodes.nodeId, id));
   return c.json({ ok: true });
 });

--- a/snell-panel/apps/server/src/routes/subscribe.ts
+++ b/snell-panel/apps/server/src/routes/subscribe.ts
@@ -21,7 +21,9 @@ router.get("/", async (c) => {
   }
 
   const format = parseFormat(c.req.query("format"), c.req.query());
-  const via = c.req.query("via") || undefined;
+  // Strip CR/LF so a crafted `via` can't inject extra lines/directives into the
+  // rendered config (it's reflected verbatim into Surge/Mihomo node entries).
+  const via = (c.req.query("via") || "").replace(/[\r\n]+/g, " ").trim() || undefined;
   const filter = c.req.query("filter") || "";
   const showFlag = c.req.query("flag") !== "false";
 

--- a/snell-panel/apps/web/src/components/AddNodeModal.tsx
+++ b/snell-panel/apps/web/src/components/AddNodeModal.tsx
@@ -86,7 +86,7 @@ export function AddNodeModal({
         <Modal.Dialog className="sm:max-w-[460px]">
           <Modal.CloseTrigger />
           <Modal.Header>
-            <Modal.Heading>Add Node</Modal.Heading>
+            <Modal.Heading>Add node</Modal.Heading>
           </Modal.Header>
           <Modal.Body>
             <div className="flex flex-col gap-4">

--- a/snell-panel/apps/web/src/components/NodesTable.tsx
+++ b/snell-panel/apps/web/src/components/NodesTable.tsx
@@ -183,7 +183,7 @@ export function NodesTable({ privacy }: { privacy: boolean }) {
   if (list.length === 0)
     return (
       <p className="rounded-2xl border border-black/5 bg-background-secondary p-8 text-center text-sm text-muted dark:border-white/10">
-        No nodes yet. Click “Add Node” to create a provisioning job.
+        No nodes yet. Click “Add node” to create one.
       </p>
     );
 

--- a/snell-panel/apps/web/src/components/RelayModal.tsx
+++ b/snell-panel/apps/web/src/components/RelayModal.tsx
@@ -37,7 +37,7 @@ export function RelayModal({
   function submit() {
     setError("");
     if (!name.trim() || !ip.trim() || !port.trim()) {
-      return setError("Name, IP and port are required.");
+      return setError("Name, IP, and port are required.");
     }
     if (!/^\d+$/.test(port.trim())) return setError("Port must be a number.");
     mutation.mutate();

--- a/snell-panel/apps/web/src/pages/Dashboard.tsx
+++ b/snell-panel/apps/web/src/pages/Dashboard.tsx
@@ -89,7 +89,7 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
                 onLogout();
               }}
             >
-              Logout
+              Sign out
             </Button>
           </div>
         </header>
@@ -108,7 +108,7 @@ export function Dashboard({ onLogout }: { onLogout: () => void }) {
                 Subscription
               </Button>
               <Button variant="primary" onPress={() => setAddOpen(true)}>
-                Add Node
+                Add node
               </Button>
             </div>
           </div>

--- a/snell-panel/apps/web/src/pages/Login.tsx
+++ b/snell-panel/apps/web/src/pages/Login.tsx
@@ -53,13 +53,13 @@ export function Login({ onAuthed }: { onAuthed: () => void }) {
             selectedKey={storageMode}
             onSelectionChange={(k) => setStorageMode(String(k) as "local" | "session" | "memory")}
           >
-            <Label>Login storage</Label>
+            <Label>Keep signed in</Label>
             <Select.Trigger><Select.Value /><Select.Indicator /></Select.Trigger>
             <Select.Popover>
               <ListBox>
-                <ListBox.Item id="local" textValue="Remember login">Remember login</ListBox.Item>
-                <ListBox.Item id="session" textValue="This session">This session</ListBox.Item>
-                <ListBox.Item id="memory" textValue="High security">High security</ListBox.Item>
+                <ListBox.Item id="local" textValue="On this device">On this device</ListBox.Item>
+                <ListBox.Item id="session" textValue="Until tab closes">Until tab closes</ListBox.Item>
+                <ListBox.Item id="memory" textValue="Clear on refresh">Clear on refresh</ListBox.Item>
               </ListBox>
             </Select.Popover>
           </Select>

--- a/snell-panel/apps/web/src/pages/Login.tsx
+++ b/snell-panel/apps/web/src/pages/Login.tsx
@@ -39,7 +39,7 @@ export function Login({ onAuthed }: { onAuthed: () => void }) {
 
         <div className="px-6 pb-1">
           <TextField value={value} onChange={setValue} type="password">
-            <Label className="sr-only">Access Token</Label>
+            <Label className="sr-only">Access token</Label>
             <Input
               placeholder="Access token"
               autoFocus

--- a/snell-panel/doctor.sh
+++ b/snell-panel/doctor.sh
@@ -12,7 +12,7 @@ main() {
   command_exists git && check_ok "git found: $(git --version)" || check_fail "git is missing."
   command_exists node && check_ok "node found: $(node --version)" || check_fail "node is missing."
   command_exists bun && check_ok "bun found: $(bun --version)" || check_fail "bun is missing. Run ./deploy.sh to install it."
-  command_exists bun && (cd "$SERVER_DIR" && bunx wrangler --version >/dev/null 2>&1) && check_ok "wrangler is available via bunx." || check_fail "wrangler is not available."
+  command_exists bun && (cd "$SERVER_DIR" && bunx wrangler --version >/dev/null 2>&1) && check_ok "Wrangler is available via bunx." || check_fail "Wrangler is not available."
 
   if command_exists bun; then
     if wrangler whoami >/dev/null 2>&1; then

--- a/snell-panel/scripts/panel-install.sh
+++ b/snell-panel/scripts/panel-install.sh
@@ -29,7 +29,7 @@ VARIANT=official; TFO=true; PSK=
 die(){ echo "[ERROR] $*" >&2; exit 1; }
 log(){ echo "[INFO] $*"; }
 ok(){ echo "[OK] $*"; }
-root(){ [ "$(id -u)" -eq 0 ] || die "Please run as root."; }
+root(){ [ "$(id -u)" -eq 0 ] || die "Please run as root"; }
 need(){ [ -n "$2" ] || die "Missing required flag: $1"; }
 yes(){ case "$(printf %s "$1"|tr A-Z a-z)" in 1|true|yes|on) return 0;; *) return 1;; esac; }
 esc(){ local s=$1; s=${s//\\/\\\\}; s=${s//\"/\\\"}; printf %s "$s"; }

--- a/snell-panel/update.sh
+++ b/snell-panel/update.sh
@@ -35,7 +35,7 @@ pull_latest_code() {
   fi
 
   if [[ -z "${UPDATE_REPO_URL:-}" ]]; then
-    fail "当前目录不是 Git checkout，无法自动拉取代码。请使用 git clone 方式部署，或设置远程仓库地址。"
+    fail "Current directory is not a Git checkout, so code can't be pulled automatically. Deploy via 'git clone', or set UPDATE_REPO_URL to a remote repo to re-clone."
   fi
 
   local current_dir parent_dir backup_dir new_root


### PR DESCRIPTION
## 概述

两块内容：**snell-panel 的安全修复 + 轻度重构 + 文案打磨**，以及 **Surge 模块用户可见文案的一致性统一**。（前面的 media-check Viu 检测已随 #226 合并，不在本 PR 内。）

## 1. snell-panel 后端安全修复 + 重构（`7e47c17`）

四处修复，均已用 `bun run typecheck` + `bun run build` 本地验证：

1. **心跳越权改 IP**：心跳回调原先直接用节点自报的 `ip/port` 覆盖存储值，无视 `ipPrefilled/portPrefilled`——管理员手钉的 IP 会被冲掉。新增 `reportedIpPort()`：prefilled 即权威、未上报字段保持不变，与 register/command 契约一致。
2. **token 用途混用**：`validateToken` 不校验用途，install/upgrade/heartbeat 回调能被同节点任意用途的有效 token 通过。新增 `expectedPurpose(status)` 按节点生命周期推导应有用途，`validateToken` 增加 `purposes` 过滤；四个 provisioner 回调全部按用途鉴权。已核对 installer 的 install（verify+register，均 install）与 upgrade（仅 register，active→upgrade）两条路径，鉴权一致、不破坏现有流程。
3. **订阅 `via` 注入**：`via` 参数原样反射进 Surge/Mihomo 节点行、未过滤换行，可注入额外配置行。改为剥除 CR/LF。
4. **PATCH 改 IP 未钉住**：管理员显式重定向 IP 时置 `ipPrefilled=true`，避免后续心跳覆盖，与 create/relay 语义统一。

**轻度重构**：四个回调重复的「API_TOKEN 或一次性 token」鉴权抽成 `authorizeNode()`；`getNode`/`now` 抽到 `lib/node-repo.ts` 供 nodes.ts 与 register.ts 共用。

## 2. snell-panel 文案打磨（`23e67a4` `dafe513` `154a7ce` `fd6018b` `466d31b`）

- **前端**：登录页存储下拉从 "Login storage: Remember login / This session / High security"（"High security" 描述的是好处不是行为）改为 "Keep signed in: On this device / Until tab closes / Clear on refresh"，直述三种存储的实际表现；统一 sentence case（`Add Node`→`Add node`）、登出按钮 `Logout`→`Sign out` 与 `Sign in` 成对、补 Oxford 逗号等。
- **CLI**：`update.sh` 残留的一句中文报错改英文；`doctor.sh` 的 Wrangler 大小写、`panel-install.sh` 的尾句号各统一一处。
- **README**：一处措辞（`是部署成功`→`代表部署成功`），保持中文不变。

## 3. Surge 模块文案统一（`e52bacc` `f272d9f`）

客户端可见的模块元信息，按约定统一：
- `#!desc` 一律不带结尾句号：去掉 8 处 desc 的尾部 `。/.`（仅末尾一个，句内标点保留）；
- `#!name` `LOCAL NETWORK` → `Local Network`（Title Case 一致）；
- MitM All 描述补中英文间距（`开启MitM`→`开启 MitM` 等）；
- 保持中英文混用现状（消费类去广告用中文名、基础设施类用英文名），不翻译。

## 验证

- snell-panel：`bun run typecheck` + `bun run build` 通过（本地实跑）；两条 provisioner 流程逐一核对鉴权无破坏。
- shell 脚本：`bash -n` 通过。
- 模块文案：全仓 `#!desc` 现无一以句号结尾；CJK/拉丁间距扫描无残留。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4XZtn7wQpEys3Rd4nZseo)_