### PR TITLE
fix(snell-panel): current_database_id 正则漏掉 JSON key 的闭合引号

### DIFF
--- a/snell-panel/scripts/deploy-common.sh
+++ b/snell-panel/scripts/deploy-common.sh
@@ -146,16 +146,19 @@ MSG
 }
 
 current_database_id() {
-  node - "$WRANGLER_CONFIG" "$PLACEHOLDER_DB_ID" <<'NODE'
-const fs = require('fs');
+  # Read the first database_id from apps/server/wrangler.jsonc. The key is a
+  # quoted JSON key ("database_id":), so allow an optional closing quote between
+  # the name and the `:`/`=` — otherwise the pattern never matches JSON and the
+  # configured id is silently reported as missing. Placeholder filtering is left
+  # to has_database_id().
+  node - "$WRANGLER_CONFIG" <<'NODE'
+const fs = require("fs");
 const file = process.argv[2];
-const placeholder = process.argv[3];
-let text = fs.readFileSync(file, 'utf8')
-  .replace(/\/\*[\s\S]*?\*\//g, '')
-  .replace(/(^|[^:])\/\/.*$/gm, '$1');
-const ids = [...text.matchAll(/database_id\s*[:=]\s*["']([^"']+)["']/g)].map((m) => m[1]);
-const usable = ids.find((id) => id && id !== placeholder) || ids[0] || '';
-process.stdout.write(usable);
+const text = fs.readFileSync(file, "utf8");
+const ids = [...text.matchAll(/database_id["']?\s*[:=]\s*["']([^"']+)["']/g)]
+  .map((m) => m[1])
+  .filter(Boolean);
+console.log(ids[0] || "");
 NODE
 }
 


### PR DESCRIPTION
deploy-common.sh 的 current_database_id() 用 /database_id\s*[:=]/ 匹配，但 apps/server/wrangler.jsonc 里 key 是带引号的 JSON —— "database_id": "..."， name 与冒号之间还夹着一个闭合引号 "。原正则要求 database_id 紧跟 :/=，因此对 真实 JSON 永远匹配不到，配置好的 database_id 被误判为「未配置」，update.sh 遂 打印 [WARN] No usable D1 database_id is configured. 并追问是否复用。

修复：在 database_id 后允许一个可选闭合引号 ["']?，同时采用更简洁的实现（直接
取首个匹配，placeholder 过滤交给 has_database_id）。注意：这一处正则错误在原 实现与外部建议的替换版本里都存在，仅照搬替换并不能修好，必须补上闭合引号。

验收（本地实测 source 函数）：
- 真实 id 配置 → current_database_id 返回该 id，打印 [DONE] D1 database configured: 3240200f-... ，不再 WARN、不再追问复用；
- placeholder 配置 → 返回 placeholder，has_database_id 过滤后判为未配置（正确）；
- write_database_id 写入 $WRANGLER_CONFIG 后可被正确读回。 WRANGLER_CONFIG 指向 apps/server/wrangler.jsonc、无根级 wrangler.jsonc、 has_database_id/write_database_id 均已用 current_database_id/$WRANGLER_CONFIG。 bash -n 通过。


Claude-Session: https://claude.ai/code/session_01F4XZtn7wQpEys3Rd4nZseo