### PR TITLE
Emit poolGroupFilters in panel (proxyGroups) order

### DIFF
--- a/.github/scripts/sync-config.py
+++ b/.github/scripts/sync-config.py
@@ -2563,6 +2563,12 @@ def _to_js(value, indent: int = 2) -> str:
     return _js_string(str(value))
 
 
+def _sort_by_group_order(pool_filters: dict, groups: list[dict]) -> dict:
+    """把 pool_filters 的键序对齐到组在 proxyGroups 里的出现顺序（未知键排末尾）。"""
+    order = {g["name"]: i for i, g in enumerate(groups)}
+    return dict(sorted(pool_filters.items(), key=lambda kv: order.get(kv[0], len(order))))
+
+
 def _to_js_inline(value) -> str:
     """紧凑单行 JS 字面量（对象/数组不换行），用于 spread 抽公共后的单行条目。"""
     if isinstance(value, dict):
@@ -3143,7 +3149,10 @@ def _gen_clash_script_js(
         "  // 已有静态 proxies（如 📧 Mail 原有的 🔰 Proxy/🔘 DIRECT）会保留在前面，",
         "  // 过滤/全量结果追加在后面，而不是整体覆盖。",
         "  const allProxyNames = config.proxies.map((p) => p.name);",
-        f"  const poolGroupFilters = {_to_js(pool_filters)};",
+        # poolGroupFilters 键序按组在 proxyGroups 里的出现顺序排列（与面板一致，
+        # 避免 overlay 阶段追加的键——如 📧 Mail——被排到地区中间）；仅影响可读性，
+        # 运行时按组名查表、与键序无关。
+        f"  const poolGroupFilters = {_to_js(_sort_by_group_order(pool_filters, groups))};",
         "  for (const g of proxyGroups) {",
         "    if (!(g.name in poolGroupFilters)) continue;",
         "    const filter = poolGroupFilters[g.name];",

--- a/Clash/Script/MyClashBox.js
+++ b/Clash/Script/MyClashBox.js
@@ -494,12 +494,12 @@ function main(config) {
   // 过滤/全量结果追加在后面，而不是整体覆盖。
   const allProxyNames = config.proxies.map((p) => p.name);
   const poolGroupFilters = {
+    Mail: null,
     '🇸🇱 Relay': '(?i)^(?=.*(?:GoMaMi|Neburst|Pro))',
     '🇭🇰 HK Relay': '(?i)^(?=.*\\b(?:HK|HKG)\\d*\\b)(?=.*(?:GoMaMi|Pro))',
     '🇨🇳 TW Relay': '(?i)^(?=.*\\b(?:TW|TWN)\\d*\\b)(?=.*Neburst)',
     '🇯🇵 JP Relay': '(?i)^(?=.*\\b(?:JP|JPN)\\d*\\b)(?=.*Pro)',
     '🇺🇸 US Relay': '(?i)^(?=.*\\b(?:US|USA)\\d*\\b)(?=.*(?:GoMaMi|Pro))',
-    Mail: null,
     Server: null,
     'Hong Kong': '(?i)^(?=.*\\b(?:HK|HKG)\\d*\\b)(?!.*GoMaMi)(?!.*Pro)',
     Taiwan: '(?i)^(?=.*\\b(?:TW|TWN)\\d*\\b)(?!.*Neburst)(?!.*Pro)',

--- a/Clash/Script/MyScript.js
+++ b/Clash/Script/MyScript.js
@@ -504,20 +504,20 @@ function main(config) {
   // 过滤/全量结果追加在后面，而不是整体覆盖。
   const allProxyNames = config.proxies.map((p) => p.name);
   const poolGroupFilters = {
+    '📧 Mail': null,
+    '🇸🇱 Relay': '(?i)^(?=.*(?:GoMaMi|Neburst|Pro))',
+    '🇭🇰 HK Relay': '(?i)^(?=.*\\b(?:HK|HKG)\\d*\\b)(?=.*(?:GoMaMi|Pro))',
+    '🇨🇳 TW Relay': '(?i)^(?=.*\\b(?:TW|TWN)\\d*\\b)(?=.*Neburst)',
+    '🇯🇵 JP Relay': '(?i)^(?=.*\\b(?:JP|JPN)\\d*\\b)(?=.*Pro)',
+    '🇺🇸 US Relay': '(?i)^(?=.*\\b(?:US|USA)\\d*\\b)(?=.*(?:GoMaMi|Pro))',
     '🇺🇳 Server': null,
     '🇭🇰 Hong Kong': '(?i)^(?=.*\\b(?:HK|HKG)\\d*\\b)(?!.*GoMaMi)(?!.*Pro)',
     '🇨🇳 Taiwan': '(?i)^(?=.*\\b(?:TW|TWN)\\d*\\b)(?!.*Neburst)(?!.*Pro)',
     '🇸🇬 Singapore': '(?i)^(?=.*\\b(?:SG|SGP)\\d*\\b)(?!.*Neburst)(?!.*Pro)',
     '🇯🇵 Japan': '(?i)^(?=.*\\b(?:JP|JPN)\\d*\\b)(?!.*Pro)',
     '🇺🇸 America': '(?i)^(?=.*\\b(?:US|USA)\\d*\\b)(?!.*GoMaMi)(?!.*Pro)',
-    '📧 Mail': null,
     '🇬🇧 England': '(?i)^(?=.*\\b(?:UK|GBR)\\d*\\b)',
     '🇩🇪 Germany': '(?i)^(?=.*\\b(?:DE|DEU)\\d*\\b)',
-    '🇸🇱 Relay': '(?i)^(?=.*(?:GoMaMi|Neburst|Pro))',
-    '🇭🇰 HK Relay': '(?i)^(?=.*\\b(?:HK|HKG)\\d*\\b)(?=.*(?:GoMaMi|Pro))',
-    '🇨🇳 TW Relay': '(?i)^(?=.*\\b(?:TW|TWN)\\d*\\b)(?=.*Neburst)',
-    '🇯🇵 JP Relay': '(?i)^(?=.*\\b(?:JP|JPN)\\d*\\b)(?=.*Pro)',
-    '🇺🇸 US Relay': '(?i)^(?=.*\\b(?:US|USA)\\d*\\b)(?=.*(?:GoMaMi|Pro))',
   };
   for (const g of proxyGroups) {
     if (!(g.name in poolGroupFilters)) continue;

--- a/Clash/Script/MyScriptColor.js
+++ b/Clash/Script/MyScriptColor.js
@@ -504,20 +504,20 @@ function main(config) {
   // 过滤/全量结果追加在后面，而不是整体覆盖。
   const allProxyNames = config.proxies.map((p) => p.name);
   const poolGroupFilters = {
+    '📧 Mail': null,
+    '🇸🇱 Relay': '(?i)^(?=.*(?:GoMaMi|Neburst|Pro))',
+    '🇭🇰 HK Relay': '(?i)^(?=.*\\b(?:HK|HKG)\\d*\\b)(?=.*(?:GoMaMi|Pro))',
+    '🇨🇳 TW Relay': '(?i)^(?=.*\\b(?:TW|TWN)\\d*\\b)(?=.*Neburst)',
+    '🇯🇵 JP Relay': '(?i)^(?=.*\\b(?:JP|JPN)\\d*\\b)(?=.*Pro)',
+    '🇺🇸 US Relay': '(?i)^(?=.*\\b(?:US|USA)\\d*\\b)(?=.*(?:GoMaMi|Pro))',
     '🇺🇳 Server': null,
     '🇭🇰 Hong Kong': '(?i)^(?=.*\\b(?:HK|HKG)\\d*\\b)(?!.*GoMaMi)(?!.*Pro)',
     '🇨🇳 Taiwan': '(?i)^(?=.*\\b(?:TW|TWN)\\d*\\b)(?!.*Neburst)(?!.*Pro)',
     '🇸🇬 Singapore': '(?i)^(?=.*\\b(?:SG|SGP)\\d*\\b)(?!.*Neburst)(?!.*Pro)',
     '🇯🇵 Japan': '(?i)^(?=.*\\b(?:JP|JPN)\\d*\\b)(?!.*Pro)',
     '🇺🇸 America': '(?i)^(?=.*\\b(?:US|USA)\\d*\\b)(?!.*GoMaMi)(?!.*Pro)',
-    '📧 Mail': null,
     '🇬🇧 England': '(?i)^(?=.*\\b(?:UK|GBR)\\d*\\b)',
     '🇩🇪 Germany': '(?i)^(?=.*\\b(?:DE|DEU)\\d*\\b)',
-    '🇸🇱 Relay': '(?i)^(?=.*(?:GoMaMi|Neburst|Pro))',
-    '🇭🇰 HK Relay': '(?i)^(?=.*\\b(?:HK|HKG)\\d*\\b)(?=.*(?:GoMaMi|Pro))',
-    '🇨🇳 TW Relay': '(?i)^(?=.*\\b(?:TW|TWN)\\d*\\b)(?=.*Neburst)',
-    '🇯🇵 JP Relay': '(?i)^(?=.*\\b(?:JP|JPN)\\d*\\b)(?=.*Pro)',
-    '🇺🇸 US Relay': '(?i)^(?=.*\\b(?:US|USA)\\d*\\b)(?=.*(?:GoMaMi|Pro))',
   };
   for (const g of proxyGroups) {
     if (!(g.name in poolGroupFilters)) continue;


### PR DESCRIPTION
The generated poolGroupFilters object followed pool_filters' insertion order (base pool groups, then overlay group_overrides additions, then extra_pool_groups), which sandwiched overlay-added entries like 📧 Mail between the base regions and England/Germany. Sort the emitted keys by each group's position in proxyGroups so the object reads in panel order (Mail now precedes the Relay/Server/region block). Cosmetic only — the runtime loop looks filters up by group name, so behavior is unchanged.

Base Script.js is byte-identical (its pool entries were already in group order); only the overlay variants' key order changes.


Claude-Session: https://claude.ai/code/session_01F4XZtn7wQpEys3Rd4nZseo