### PR TITLE
Drop stale ConnersHua and redundant QX Speedtest skip entries

### DIFF
--- a/.github/scripts/sync-config.txt
+++ b/.github/scripts/sync-config.txt
@@ -35,7 +35,6 @@ Speedtest
 # > Gist
 ReverseProxy => fastly.jsdelivr.net
 # > Skip
-ConnersHua
 iCloud
 Apple News
 Apple TV
@@ -62,7 +61,6 @@ rule-providers:
 # > Skip
 iCloud
 Apple News
-Speedtest
 # > Rename
 [policy]
   Proxy => Outbound


### PR DESCRIPTION
RuleGo lists left Profile.conf earlier, so the Clash-side ConnersHua skip matched nothing; QX's Speedtest entry duplicated the global skip. All ten generated products verified unchanged.


Claude-Session: https://claude.ai/code/session_01F4XZtn7wQpEys3Rd4nZseo