### PR TITLE
Roll out Speedtest to every platform now the list is self-hosted

### DIFF
--- a/.github/scripts/sync-config.py
+++ b/.github/scripts/sync-config.py
@@ -215,6 +215,7 @@ def strip_emoji(name: str) -> str:
         cp = ord(result[0])
         if (
             0x1F000 <= cp <= 0x1FFFF  # 杂项符号和象形文字
+            or 0x2300 <= cp <= 0x23FF  # 杂项技术符号（如 ⏱）
             or 0x2600 <= cp <= 0x27BF  # 杂项符号
             or 0xFE00 <= cp <= 0xFE0F  # 变体选择符
             or 0x1F1E0 <= cp <= 0x1F1FF  # 区域指示符（国旗）
@@ -1778,7 +1779,12 @@ def _fmt_loon_group(
         return f"{name} = select,{filter_name}{icon_part}"
 
     if params.get("include-other-group", ""):
-        return None  # Loon 不直接支持，由 builtin inject_names 或 FilterMap 覆盖
+        # select + 借全量节点池（如 ⏱️ Speedtest ← 🇺🇳 Server）→ 全节点 Filter
+        if gtype == "select" and not params.get("policy-regex-filter"):
+            fm_val = filter_map.get(name, "FilterUN")
+            filter_name = fm_val.split(",")[0].strip()
+            return f"{name} = select,{filter_name}{icon_part}"
+        return None  # 其余由 builtin inject_names 或 FilterMap 覆盖
 
     if params.get("policy-path", ""):
         return None  # 由 Builtin inject_names 替换
@@ -2020,6 +2026,10 @@ def _fmt_qx_policy(
     # smart + policy-regex-filter → static with server-tag-regex（必须先于 include-other-group 检查）
     if gtype == "smart" and (regex := params.get("policy-regex-filter", "")):
         return f"static={emit_name}, server-tag-regex={regex}{icon_part}"
+
+    # select + 借全量节点池（如 ⏱️ Speedtest ← 🇺🇳 Server）→ 全节点 server-tag-regex
+    if gtype == "select" and "include-other-group" in params and not params.get("policy-regex-filter"):
+        return f"static={emit_name}, server-tag-regex=.*{icon_part}"
 
     # include-all-proxies / include-other-group / policy-path → 跳过
     if (
@@ -2392,7 +2402,7 @@ def _gen_surfboard_general(lines: list[str]) -> str:
     return "\n".join(out)
 
 
-_SURFBOARD_SKIP_PARAMS = {"icon-url", "evaluate-before-use", "no-alert"}
+_SURFBOARD_SKIP_PARAMS = {"icon-url", "evaluate-before-use", "no-alert", "include-other-group"}
 
 
 def _gen_surfboard_proxy_groups(
@@ -2460,7 +2470,11 @@ def _gen_surfboard_proxy_groups(
             continue
 
         gtype = "url-test" if g["type"] == "smart" else g["type"]
-        tokens = [gtype] + g["proxies"]
+        members = list(g["proxies"])
+        # Surfboard 无 include-other-group：无静态候选时嵌套目标组（如 ⏱️ Speedtest ← 🇺🇳 Server）
+        if not members and (other := g["params"].get("include-other-group", "")):
+            members = [other]
+        tokens = [gtype] + members
         params = dict(g["params"])
         # smart → url-test 降级时显式补 Surge 系默认容差，避免依赖 Surfboard 的隐式默认
         if g["type"] == "smart":
@@ -3715,7 +3729,7 @@ SB_DIRECT_TAG = "🔘 Direct"
 # 仅当出现无法识别的新地区组时才会引用，此时仍需手动订阅工具注入节点）
 SB_PLACEHOLDER = "🚀 Proxy（请用订阅工具注入节点）"
 # 组名含这些关键词的策略组不生成 outbound（与其他平台的 skip 语义一致）
-SB_SKIP_GROUP_KW = ("Speedtest", "Gateway", "Apple TV")
+SB_SKIP_GROUP_KW = ("Gateway", "Apple TV")
 
 # 各地区示例节点（占位用途：sing-box 无订阅机制，先内置一份可直接连通的示例
 # Shadowsocks 节点，方便直接改 server/password 试用；真实使用请用订阅工具替换）
@@ -3852,6 +3866,9 @@ def _gen_singbox_outbounds(group_lines: list[str], skips: list[str]) -> list[dic
                     continue
                 else:
                     outs.append(p)
+            # 无静态候选的 include-other-group 组（如 ⏱️ Speedtest ← 🇺🇳 Server）→ 嵌套目标组
+            if not outs and (other := params.get("include-other-group", "")):
+                outs = [other]
             selectors.append({"type": "selector", "tag": name, "outbounds": outs})
 
     for s in server:                                       # Server 组候选 = 全部示例节点

--- a/.github/scripts/sync-config.txt
+++ b/.github/scripts/sync-config.txt
@@ -26,7 +26,6 @@
 >> Surge/Profile.conf
 # > Skip
 Gateway
-Speedtest
 
 # Clash
 >> Clash/Sample.yaml

--- a/Clash/Mihomo.yaml
+++ b/Clash/Mihomo.yaml
@@ -1,5 +1,5 @@
 # Clash · 锚点改写版（block + YAML 锚点，功能等价 Sample.yaml）
-# Date: 2026-07-12 18:17:12
+# Date: 2026-07-12 18:28:41
 # Author: @HotKids
 #
 # 自动生成（sync-config.py 从 Clash/Sample.yaml 转译），请勿手改；改内容请改 Surge/Profile.conf。
@@ -133,6 +133,8 @@ proxy-groups:
   - {name: 💳 Finance, type: select, proxies: [🇺🇸 America, 🔰 Proxy, 🔘 DIRECT], icon: https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Color/Finance.png}
   # Mail
   - {name: 📧 Mail, type: select, proxies: [🔰 Proxy, 🔘 DIRECT], icon: https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Color/Mail.png}
+  # Speedtest
+  - {name: ⏱️ Speedtest, <<: *Region, icon: https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Color/Speed.png}
   # Adblock
   - {name: 🚧 AdGuard, type: select, proxies: [🔘 DIRECT, ⛔️ REJECT, 📛 REJECT-DROP], icon: https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Color/Block.png}
   # DIRECT
@@ -177,6 +179,7 @@ rule-providers:
   Crypto: {<<: *Remote, behavior: classical, format: yaml, path: ./Provider/RuleSet/Crypto.yaml, url: https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Crypto.yaml}
   Finance: {<<: *Remote, behavior: classical, format: yaml, path: ./Provider/RuleSet/Finance.yaml, url: https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Finance.yaml}
   Spark: {<<: *Remote, behavior: classical, format: yaml, path: ./Provider/RuleSet/Spark.yaml, url: https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Spark.yaml}
+  Speedtest: {<<: *Remote, behavior: domain, format: mrs, path: ./Provider/RuleSet/Speedtest.mrs, url: https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Speedtest.mrs}
   Global: {<<: *Remote, behavior: domain, format: mrs, path: ./Provider/RuleSet/Global.mrs, url: https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/geolocation-!cn.mrs}
   China: {<<: *Remote, behavior: domain, format: mrs, path: ./Provider/RuleSet/China.mrs, url: https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/cn.mrs}
   CNASN: {<<: *Remote, behavior: classical, format: yaml, path: ./Provider/RuleSet/CNASN.yaml, url: https://fastly.jsdelivr.net/gh/VirgilClyne/GetSomeFries@main/ruleset/ASN.China.yaml}
@@ -237,6 +240,8 @@ rules:
   - 'RULE-SET,Finance,💳 Finance'
   # > Mail
   - 'RULE-SET,Spark,📧 Mail'
+  # > Speedtest
+  - 'RULE-SET,Speedtest,⏱️ Speedtest'
   # Global (DNS Cache Pollution) / (IP Blackhole) / (Region-Restricted Access Denied) / (Network Jitter)
   - 'RULE-SET,Global,🔰 Proxy'
   # China Area Network

--- a/Clash/Sample.yaml
+++ b/Clash/Sample.yaml
@@ -1,5 +1,5 @@
 # Clash
-# Date: 2026-07-12 18:17:12
+# Date: 2026-07-12 18:28:41
 # Author: @HotKids
 
 # 通用设置
@@ -446,6 +446,13 @@ proxy-groups:
       - 🔰 Proxy
       - 🔘 DIRECT
 
+  # Speedtest
+  - name: "⏱️ Speedtest"
+    type: select
+    icon: https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Color/Speed.png
+    use:
+      - Server
+
   # Adblock
   - name: "🚧 AdGuard"
     type: select
@@ -724,6 +731,14 @@ rule-providers:
     url: https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Spark.yaml
     interval: 86400
 
+  Speedtest:
+    type: http
+    behavior: domain
+    format: mrs
+    path: ./Provider/RuleSet/Speedtest.mrs
+    url: https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Speedtest.mrs
+    interval: 86400
+
   Global:
     type: http
     behavior: domain
@@ -836,6 +851,9 @@ rules:
 
   # > Mail
   - RULE-SET,Spark,📧 Mail
+
+  # > Speedtest
+  - RULE-SET,Speedtest,⏱️ Speedtest
 
   # Global (DNS Cache Pollution) / (IP Blackhole) / (Region-Restricted Access Denied) / (Network Jitter)
   - RULE-SET,Global,🔰 Proxy

--- a/Clash/Script/MyClashBox.js
+++ b/Clash/Script/MyClashBox.js
@@ -145,6 +145,7 @@ function main(config) {
   // null = 不过滤、取全量节点；下方策略组生成后按此表运行时填充候选。
   const poolGroupFilters = {
     'Mail': null,
+    '⏱️ Speedtest': null,
     '🇸🇱 Relay': '(?i)^(?=.*(?:GoMaMi|Neburst|Pro))',
     '🇭🇰 HK Relay': '(?i)^(?=.*\\b(?:HK|HKG)\\d*\\b)(?=.*(?:GoMaMi|Pro))',
     '🇨🇳 TW Relay': '(?i)^(?=.*\\b(?:TW|TWN)\\d*\\b)(?=.*Neburst)',
@@ -188,6 +189,8 @@ function main(config) {
     { name: 'Finance', type: 'select', proxies: ['America', 'Germany', 'Proxy', 'Direct'], icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Liquid%20Glass/Wallet.png' },
     // Mail
     { name: 'Mail', type: 'select', proxies: ['Proxy', 'Direct'], icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Liquid%20Glass/Email.png' },
+    // Speedtest
+    { name: '⏱️ Speedtest', type: 'select', icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Color/Speed.png' },
     // Adblock
     { name: 'AdGuard', type: 'select', proxies: ['Direct', 'Reject'], icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Liquid%20Glass/AdBlock.png' },
     // DIRECT
@@ -267,6 +270,7 @@ function main(config) {
     'Crypto': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/Crypto.yaml', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Crypto.yaml' },
     'Finance': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/Finance.yaml', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Finance.yaml' },
     'Spark': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/Spark.yaml', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Spark.yaml' },
+    'Speedtest': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/Speedtest.mrs', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Speedtest.mrs' },
     'Global': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/Global.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/geolocation-!cn.mrs' },
     'China': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/China.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/cn.mrs' },
     'CNASN': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/CNASN.yaml', url: 'https://fastly.jsdelivr.net/gh/VirgilClyne/GetSomeFries@main/ruleset/ASN.China.yaml' },
@@ -328,6 +332,8 @@ function main(config) {
     'RULE-SET,Finance,Finance',
     // > Mail
     'RULE-SET,Spark,Mail',
+    // > Speedtest
+    'RULE-SET,Speedtest,⏱️ Speedtest',
     // Global (DNS Cache Pollution) / (IP Blackhole) / (Region-Restricted Access Denied) / (Network Jitter)
     'RULE-SET,Global,Proxy',
     // China Area Network

--- a/Clash/Script/MyScript.js
+++ b/Clash/Script/MyScript.js
@@ -145,6 +145,7 @@ function main(config) {
   // null = 不过滤、取全量节点；下方策略组生成后按此表运行时填充候选。
   const poolGroupFilters = {
     '📧 Mail': null,
+    '⏱️ Speedtest': null,
     '🇸🇱 Relay': '(?i)^(?=.*(?:GoMaMi|Neburst|Pro))',
     '🇭🇰 HK Relay': '(?i)^(?=.*\\b(?:HK|HKG)\\d*\\b)(?=.*(?:GoMaMi|Pro))',
     '🇨🇳 TW Relay': '(?i)^(?=.*\\b(?:TW|TWN)\\d*\\b)(?=.*Neburst)',
@@ -188,6 +189,8 @@ function main(config) {
     { name: '💳 Finance', type: 'select', proxies: ['🇺🇸 America', '🇩🇪 Germany', '🔰 Proxy', '🔘 DIRECT'], icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Color/Finance.png' },
     // Mail
     { name: '📧 Mail', type: 'select', proxies: ['🔰 Proxy', '🔘 DIRECT'], icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Color/Mail.png' },
+    // Speedtest
+    { name: '⏱️ Speedtest', type: 'select', icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Color/Speed.png' },
     // Adblock
     { name: '🚧 AdGuard', type: 'select', proxies: ['🔘 DIRECT', '⛔️ REJECT', '📛 REJECT-DROP'], icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Color/Block.png' },
     // DIRECT
@@ -269,6 +272,7 @@ function main(config) {
     'Crypto': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/Crypto.yaml', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Crypto.yaml' },
     'Finance': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/Finance.yaml', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Finance.yaml' },
     'Spark': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/Spark.yaml', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Spark.yaml' },
+    'Speedtest': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/Speedtest.mrs', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Speedtest.mrs' },
     'Global': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/Global.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/geolocation-!cn.mrs' },
     'China': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/China.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/cn.mrs' },
     'CNASN': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/CNASN.yaml', url: 'https://fastly.jsdelivr.net/gh/VirgilClyne/GetSomeFries@main/ruleset/ASN.China.yaml' },
@@ -330,6 +334,8 @@ function main(config) {
     'RULE-SET,Finance,💳 Finance',
     // > Mail
     'RULE-SET,Spark,📧 Mail',
+    // > Speedtest
+    'RULE-SET,Speedtest,⏱️ Speedtest',
     // Global (DNS Cache Pollution) / (IP Blackhole) / (Region-Restricted Access Denied) / (Network Jitter)
     'RULE-SET,Global,🔰 Proxy',
     // China Area Network

--- a/Clash/Script/MyScriptColor.js
+++ b/Clash/Script/MyScriptColor.js
@@ -145,6 +145,7 @@ function main(config) {
   // null = 不过滤、取全量节点；下方策略组生成后按此表运行时填充候选。
   const poolGroupFilters = {
     '📧 Mail': null,
+    '⏱️ Speedtest': null,
     '🇸🇱 Relay': '(?i)^(?=.*(?:GoMaMi|Neburst|Pro))',
     '🇭🇰 HK Relay': '(?i)^(?=.*\\b(?:HK|HKG)\\d*\\b)(?=.*(?:GoMaMi|Pro))',
     '🇨🇳 TW Relay': '(?i)^(?=.*\\b(?:TW|TWN)\\d*\\b)(?=.*Neburst)',
@@ -188,6 +189,8 @@ function main(config) {
     { name: '💳 Finance', type: 'select', proxies: ['🇺🇸 America', '🇩🇪 Germany', '🔰 Proxy', '🔘 DIRECT'], icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Liquid%20Glass/Wallet.png' },
     // Mail
     { name: '📧 Mail', type: 'select', proxies: ['🔰 Proxy', '🔘 DIRECT'], icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Liquid%20Glass/Email.png' },
+    // Speedtest
+    { name: '⏱️ Speedtest', type: 'select', icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Color/Speed.png' },
     // Adblock
     { name: '🚧 AdGuard', type: 'select', proxies: ['🔘 DIRECT', '⛔️ REJECT', '📛 REJECT-DROP'], icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Liquid%20Glass/AdBlock.png' },
     // DIRECT
@@ -269,6 +272,7 @@ function main(config) {
     'Crypto': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/Crypto.yaml', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Crypto.yaml' },
     'Finance': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/Finance.yaml', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Finance.yaml' },
     'Spark': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/Spark.yaml', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Spark.yaml' },
+    'Speedtest': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/Speedtest.mrs', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Speedtest.mrs' },
     'Global': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/Global.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/geolocation-!cn.mrs' },
     'China': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/China.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/cn.mrs' },
     'CNASN': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/CNASN.yaml', url: 'https://fastly.jsdelivr.net/gh/VirgilClyne/GetSomeFries@main/ruleset/ASN.China.yaml' },
@@ -330,6 +334,8 @@ function main(config) {
     'RULE-SET,Finance,💳 Finance',
     // > Mail
     'RULE-SET,Spark,📧 Mail',
+    // > Speedtest
+    'RULE-SET,Speedtest,⏱️ Speedtest',
     // Global (DNS Cache Pollution) / (IP Blackhole) / (Region-Restricted Access Denied) / (Network Jitter)
     'RULE-SET,Global,🔰 Proxy',
     // China Area Network

--- a/Clash/Script/Script.js
+++ b/Clash/Script/Script.js
@@ -145,6 +145,7 @@ function main(config) {
   // 节点池筛选正则（对应 Mihomo.yaml 的 &Region / &Filter* 锚点）：
   // null = 不过滤、取全量节点；下方策略组生成后按此表运行时填充候选。
   const poolGroupFilters = {
+    '⏱️ Speedtest': null,
     '🇺🇳 Server': null,
     '🇭🇰 Hong Kong': '(?i)(?:🇭🇰|香港|Hong Kong|\\b(?:HK|HKG)\\d*\\b)',
     '🇨🇳 Taiwan': '(?i)(?:🇨🇳|🇹🇼|台湾|Taiwan|\\b(?:TW|TWN)\\d*\\b)',
@@ -181,6 +182,8 @@ function main(config) {
     { name: '💳 Finance', type: 'select', proxies: ['🇺🇸 America', '🔰 Proxy', '🔘 DIRECT'], icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Color/Finance.png' },
     // Mail
     { name: '📧 Mail', type: 'select', proxies: ['🔰 Proxy', '🔘 DIRECT'], icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Color/Mail.png' },
+    // Speedtest
+    { name: '⏱️ Speedtest', type: 'select', 'include-all-providers': true, icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Color/Speed.png' },
     // Adblock
     { name: '🚧 AdGuard', type: 'select', proxies: ['🔘 DIRECT', '⛔️ REJECT', '📛 REJECT-DROP'], icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Color/Block.png' },
     // DIRECT
@@ -257,6 +260,7 @@ function main(config) {
     'Crypto': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/Crypto.yaml', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Crypto.yaml' },
     'Finance': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/Finance.yaml', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Finance.yaml' },
     'Spark': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/Spark.yaml', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Spark.yaml' },
+    'Speedtest': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/Speedtest.mrs', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Speedtest.mrs' },
     'Global': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/Global.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/geolocation-!cn.mrs' },
     'China': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/China.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/cn.mrs' },
     'CNASN': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/CNASN.yaml', url: 'https://fastly.jsdelivr.net/gh/VirgilClyne/GetSomeFries@main/ruleset/ASN.China.yaml' },
@@ -318,6 +322,8 @@ function main(config) {
     'RULE-SET,Finance,💳 Finance',
     // > Mail
     'RULE-SET,Spark,📧 Mail',
+    // > Speedtest
+    'RULE-SET,Speedtest,⏱️ Speedtest',
     // Global (DNS Cache Pollution) / (IP Blackhole) / (Region-Restricted Access Denied) / (Network Jitter)
     'RULE-SET,Global,🔰 Proxy',
     // China Area Network

--- a/Quantumult/Sample.conf
+++ b/Quantumult/Sample.conf
@@ -1,5 +1,5 @@
 # Quantumult X
-# Date: 2026-07-12 16:42:11
+# Date: 2026-07-12 18:32:14
 # Author: @HotKids
 
 [general]
@@ -594,6 +594,8 @@ static=Crypto, America, Outbound, direct, img-url=https://raw.githubusercontent.
 static=Finance, America, Outbound, direct, img-url=https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Images/Color/Finance.png
 # Mail
 static=Mail, Outbound, direct, img-url=https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Images/Color/Mail.png
+# Speedtest
+static=Speedtest, server-tag-regex=.*, img-url=https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Images/Color/Speed.png
 # Area
 static=Hong Kong, server-tag-regex=(?i)(?:🇭🇰|香港|Hong Kong|\b(?:HK|HKG)\d*\b), img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Hong_Kong.png
 static=Taiwan, server-tag-regex=(?i)(?:🇨🇳|🇹🇼|台湾|Taiwan|\b(?:TW|TWN)\d*\b), img-url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Taiwan.png
@@ -652,6 +654,8 @@ https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/Crypt
 https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/Finance.list, tag=Finance, force-policy=Finance, update-interval=86400, opt-parser=false, enabled=true
 # > Mail
 https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/Spark.list, tag=Mail, force-policy=Mail, update-interval=86400, opt-parser=false, enabled=true
+# > Speedtest
+https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/Speedtest.list, tag=Speedtest, force-policy=Speedtest, update-interval=86400, opt-parser=false, enabled=true
 # Global (DNS Cache Pollution) / (IP Blackhole) / (Region-Restricted Access Denied) / (Network Jitter)
 https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/proxy.txt, tag=Global, force-policy=Outbound, update-interval=86400, opt-parser=true, enabled=true
 # China Area Network

--- a/Surge/Balloon.lcf
+++ b/Surge/Balloon.lcf
@@ -1,5 +1,5 @@
 # Loon
-# Date: 2026-07-12 16:42:11
+# Date: 2026-07-12 18:32:14
 # Author: @HotKids
 
 [General]
@@ -88,6 +88,8 @@ FilterUS = NameRegex, FilterKey = "^(?=.*(?i)(?:🇺🇸|美国|United States|\b
 💳 Finance = select,🇺🇸 America,🔰 Proxy,🔘 DIRECT,img-url = https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Images/Color/Finance.png
 # Mail
 📧 Mail = select,🔰 Proxy,🔘 DIRECT,img-url = https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Images/Color/Mail.png
+# Speedtest
+⏱️ Speedtest = select,FilterUN,img-url = https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Images/Color/Speed.png
 # Adblock
 🚧 AdGuard = select,🔘 DIRECT,⛔️ REJECT,img-url = https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Images/Color/Block.png
 # Nodes
@@ -160,6 +162,8 @@ https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Crypto.lis
 https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Finance.list, policy=💳 Finance, tag=Finance, enabled=true
 # > Mail
 https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Spark.list, policy=📧 Mail, tag=Mail, enabled=true
+# > Speedtest
+https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Speedtest.list, policy=⏱️ Speedtest, tag=Speedtest, enabled=true
 # Global (DNS Cache Pollution) / (IP Blackhole) / (Region-Restricted Access Denied) / (Network Jitter)
 https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/proxy.txt, policy=🔰 Proxy, tag=Global, enabled=true
 # China Area Network

--- a/Surge/Surfboard.conf
+++ b/Surge/Surfboard.conf
@@ -33,16 +33,18 @@ always-real-ip = *.lan, *.local, *.localhost, *.home.arpa, *.msftncsi.com, *.msf
 💳 Finance = select, 🇺🇸 America, 🔰 Proxy, 🔘 DIRECT
 # Mail
 📧 Mail = select, 🔰 Proxy, 🔘 DIRECT
+# Speedtest
+⏱️ Speedtest = select, 🇺🇳 Server
 # Adblock
 🚧 AdGuard = select, 🔘 DIRECT, ⛔️ REJECT
 # Nodes
 🇺🇳 Server = select, policy-path=https://hotkids.me
 # Area
-🇭🇰 Hong Kong = url-test, include-other-group=🇺🇳 Server, policy-regex-filter=(?i)(?:🇭🇰|香港|Hong Kong|\b(?:HK|HKG)\d*\b), interval=600, hidden=1, include-all-proxies=0, tolerance=100
-🇨🇳 Taiwan = url-test, include-other-group=🇺🇳 Server, policy-regex-filter=(?i)(?:🇨🇳|🇹🇼|台湾|Taiwan|\b(?:TW|TWN)\d*\b), interval=600, hidden=1, include-all-proxies=0, tolerance=100
-🇸🇬 Singapore = url-test, include-other-group=🇺🇳 Server, policy-regex-filter=(?i)(?:🇸🇬|新加坡|Singapore|\b(?:SG|SGP)\d*\b), interval=600, hidden=1, include-all-proxies=0, tolerance=100
-🇯🇵 Japan = url-test, include-other-group=🇺🇳 Server, policy-regex-filter=(?i)(?:🇯🇵|日本|Japan|\b(?:JP|JPN)\d*\b), interval=600, hidden=1, include-all-proxies=0, tolerance=100
-🇺🇸 America = url-test, include-other-group=🇺🇳 Server, policy-regex-filter=(?i)(?:🇺🇸|美国|United States|\b(?:US|USA)\d*\b), interval=600, hidden=1, include-all-proxies=0, tolerance=100
+🇭🇰 Hong Kong = url-test, 🇺🇳 Server, policy-regex-filter=(?i)(?:🇭🇰|香港|Hong Kong|\b(?:HK|HKG)\d*\b), interval=600, hidden=1, include-all-proxies=0, tolerance=100
+🇨🇳 Taiwan = url-test, 🇺🇳 Server, policy-regex-filter=(?i)(?:🇨🇳|🇹🇼|台湾|Taiwan|\b(?:TW|TWN)\d*\b), interval=600, hidden=1, include-all-proxies=0, tolerance=100
+🇸🇬 Singapore = url-test, 🇺🇳 Server, policy-regex-filter=(?i)(?:🇸🇬|新加坡|Singapore|\b(?:SG|SGP)\d*\b), interval=600, hidden=1, include-all-proxies=0, tolerance=100
+🇯🇵 Japan = url-test, 🇺🇳 Server, policy-regex-filter=(?i)(?:🇯🇵|日本|Japan|\b(?:JP|JPN)\d*\b), interval=600, hidden=1, include-all-proxies=0, tolerance=100
+🇺🇸 America = url-test, 🇺🇳 Server, policy-regex-filter=(?i)(?:🇺🇸|美国|United States|\b(?:US|USA)\d*\b), interval=600, hidden=1, include-all-proxies=0, tolerance=100
 
 [Rule]
 # REJECT-NO-DROP 表示不使用默认的自动丢包逻辑，这样 Surge 每次都会返回 ICMP Port Unreachable，应用会立刻回退而不是等超时。
@@ -99,6 +101,8 @@ RULE-SET, https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/
 RULE-SET, https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Finance.list, 💳 Finance
 # > Mail
 RULE-SET, https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Spark.list, 📧 Mail
+# > Speedtest
+DOMAIN-SET, https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Speedtest.list, ⏱️ Speedtest
 # Global (DNS Cache Pollution) / (IP Blackhole) / (Region-Restricted Access Denied) / (Network Jitter)
 DOMAIN-SET, https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/proxy.txt, 🔰 Proxy
 # China Area Network

--- a/sing-box/config.json
+++ b/sing-box/config.json
@@ -155,6 +155,13 @@
     },
     {
       "type": "selector",
+      "tag": "⏱️ Speedtest",
+      "outbounds": [
+        "🇺🇳 Server"
+      ]
+    },
+    {
+      "type": "selector",
       "tag": "🇺🇳 Server",
       "outbounds": [
         "🇭🇰 HK",
@@ -363,6 +370,10 @@
         "outbound": "📧 Mail"
       },
       {
+        "rule_set": "Speedtest",
+        "outbound": "⏱️ Speedtest"
+      },
+      {
         "rule_set": "geolocation-!cn",
         "outbound": "🔰 Proxy"
       },
@@ -537,6 +548,14 @@
         "tag": "Spark",
         "format": "binary",
         "url": "https://raw.githubusercontent.com/HotKids/Rules/master/sing-box/rule-set/Spark.srs",
+        "download_detour": "🔘 Direct",
+        "update_interval": "1440m"
+      },
+      {
+        "type": "remote",
+        "tag": "Speedtest",
+        "format": "binary",
+        "url": "https://raw.githubusercontent.com/HotKids/Rules/master/sing-box/rule-set/Speedtest.srs",
         "download_detour": "🔘 Direct",
         "update_interval": "1440m"
       },


### PR DESCRIPTION
Remove the global Speedtest skip and the sing-box group-skip keyword. Each converter renders the select + include-other-group pool group in its native idiom: Clash gets use:[Server] (and the mrs provider via the auto-mapping), Loon select,FilterUN, QX static with server-tag-regex=.* (strip_emoji learns the U+23xx block so ⏱️ strips like other emoji), Surfboard and sing-box nest 🇺🇳 Server as the sole member.


Claude-Session: https://claude.ai/code/session_01F4XZtn7wQpEys3Rd4nZseo