### PR TITLE
style(sync): China 规则集三件套改名 China / China IP / China ASN

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -25,7 +25,7 @@ domain 语义转换：QX 展开为 `DOMAIN` / `DOMAIN-SUFFIX` 行、Clash 出 do
 > `Clash/RuleSet/` 产物（payload 无逗号 → domain / CIDR → ipcidr，classical 跳过），
 > 用 `convert-ruleset` 编译出同名 `.mrs` 与源文件并存一同提交；`sync-config.py` 里
 > 自有 domain/ipcidr provider 已指向 `.mrs`（`format: mrs`），外部 Private/China/
-> Global/CNCIDR 则指向 MetaCubeX meta-rules-dat 官方 mrs。
+> Global/China IP 则指向 MetaCubeX meta-rules-dat 官方 mrs。
 
 > sing-box 二进制规则集 `sing-box/rule-set/*.srs` 不由本脚本生成：`.srs` 只能用官方 sing-box CLI 编译，故在 `sync-rules.yml` workflow 里下载 sing-box 后对 `source/*.json` 执行 `rule-set compile` 得到，与 `.json` 并存一同提交。
 

--- a/.github/scripts/sync-config.txt
+++ b/.github/scripts/sync-config.txt
@@ -52,13 +52,13 @@ https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/reject.txt =>
 rule-providers:
   Block => AdBlock
   HTTPDNS.Block => HTTPDNS
-  ASN.China => CNASN
+  ASN.China => China ASN
   Gemini => Google AI Studio
   GenAI => AIGC
   geolocation-!cn => Global
   geosite/cn => China
   private => Private
-  geoip/cn => CNCIDR
+  geoip/cn => China IP
 
 # Quantumult X
 >> Quantumult/Sample.conf
@@ -75,13 +75,13 @@ Apple News
   Block => Adblock
   HTTPDNS.Block => HTTPDNS
   Spark => Mail
-  ASN.China => ASN China
+  ASN.China => China ASN
   iCloud.PrivateRelay => iCloud Private Relay
   proxy => Global
   direct => China
   private => Private
   reject => Reject
-  cncidr => CNCIDR
+  cncidr => China IP
 
 # Loon
 >> Surge/Balloon.lcf
@@ -92,13 +92,13 @@ Apple News
   Block => Adblock
   HTTPDNS.Block => HTTPDNS
   Spark => Mail
-  ASN.China => ASN China
+  ASN.China => China ASN
   iCloud.PrivateRelay => iCloud Private Relay
   proxy => Global
   direct => China
   private => Private
   reject => Reject
-  cncidr => CNCIDR
+  cncidr => China IP
 
 # Surfboard
 >> Surge/Surfboard.conf

--- a/Clash/Mihomo.yaml
+++ b/Clash/Mihomo.yaml
@@ -1,5 +1,5 @@
 # Clash · 锚点改写版（block + YAML 锚点，功能等价 Sample.yaml）
-# Date: 2026-07-13 10:40:40
+# Date: 2026-07-13 11:43:31
 # Author: @HotKids
 #
 # 自动生成（sync-config.py 从 Clash/Sample.yaml 转译），请勿手改；改内容请改 Surge/Profile.conf。
@@ -182,8 +182,8 @@ rule-providers:
   Speedtest: {<<: *Remote, behavior: domain, format: mrs, path: ./Provider/RuleSet/Speedtest.mrs, url: https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Speedtest.mrs}
   Global: {<<: *Remote, behavior: domain, format: mrs, path: ./Provider/RuleSet/Global.mrs, url: https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/geolocation-!cn.mrs}
   China: {<<: *Remote, behavior: domain, format: mrs, path: ./Provider/RuleSet/China.mrs, url: https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/cn.mrs}
-  CNASN: {<<: *Remote, behavior: classical, format: yaml, path: ./Provider/RuleSet/CNASN.yaml, url: https://fastly.jsdelivr.net/gh/VirgilClyne/GetSomeFries@main/ruleset/ASN.China.yaml}
-  CNCIDR: {<<: *Remote, behavior: ipcidr, format: mrs, path: ./Provider/RuleSet/CNCIDR.mrs, url: https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geoip/cn.mrs}
+  China ASN: {<<: *Remote, behavior: classical, format: yaml, path: ./Provider/RuleSet/China_ASN.yaml, url: https://fastly.jsdelivr.net/gh/VirgilClyne/GetSomeFries@main/ruleset/ASN.China.yaml}
+  China IP: {<<: *Remote, behavior: ipcidr, format: mrs, path: ./Provider/RuleSet/China_IP.mrs, url: https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geoip/cn.mrs}
   LAN: {<<: *Remote, behavior: ipcidr, format: mrs, path: ./Provider/RuleSet/LAN.mrs, url: https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/lancidr.mrs}
 
 # ── 规则 ──
@@ -245,8 +245,8 @@ rules:
   - 'RULE-SET,Global,🔰 Proxy'
   # China Area Network
   - 'RULE-SET,China,🔘 DIRECT'
-  - 'RULE-SET,CNASN,🔘 DIRECT,no-resolve'
-  - 'RULE-SET,CNCIDR,🔘 DIRECT,no-resolve'
+  - 'RULE-SET,China ASN,🔘 DIRECT,no-resolve'
+  - 'RULE-SET,China IP,🔘 DIRECT,no-resolve'
   # Local Area Network
   - 'RULE-SET,LAN,🔘 DIRECT,no-resolve'
   # GeoIP

--- a/Clash/Sample.yaml
+++ b/Clash/Sample.yaml
@@ -1,5 +1,5 @@
 # Clash
-# Date: 2026-07-13 10:40:40
+# Date: 2026-07-13 11:43:31
 # Author: @HotKids
 
 # 通用设置
@@ -755,19 +755,19 @@ rule-providers:
     url: https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/cn.mrs
     interval: 86400
 
-  CNASN:
+  China ASN:
     type: http
     behavior: classical
     format: yaml
-    path: ./Provider/RuleSet/CNASN.yaml
+    path: ./Provider/RuleSet/China_ASN.yaml
     url: https://fastly.jsdelivr.net/gh/VirgilClyne/GetSomeFries@main/ruleset/ASN.China.yaml
     interval: 86400
 
-  CNCIDR:
+  China IP:
     type: http
     behavior: ipcidr
     format: mrs
-    path: ./Provider/RuleSet/CNCIDR.mrs
+    path: ./Provider/RuleSet/China_IP.mrs
     url: https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geoip/cn.mrs
     interval: 86400
 
@@ -859,8 +859,8 @@ rules:
 
   # China Area Network
   - RULE-SET,China,🔘 DIRECT
-  - RULE-SET,CNASN,🔘 DIRECT,no-resolve
-  - RULE-SET,CNCIDR,🔘 DIRECT,no-resolve
+  - RULE-SET,China ASN,🔘 DIRECT,no-resolve
+  - RULE-SET,China IP,🔘 DIRECT,no-resolve
 
   # Local Area Network
   - RULE-SET,LAN,🔘 DIRECT,no-resolve

--- a/Clash/Script/MyClashBox.js
+++ b/Clash/Script/MyClashBox.js
@@ -274,8 +274,8 @@ function main(config) {
     'Speedtest': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/Speedtest.mrs', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Speedtest.mrs' },
     'Global': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/Global.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/geolocation-!cn.mrs' },
     'China': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/China.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/cn.mrs' },
-    'CNASN': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/CNASN.yaml', url: 'https://fastly.jsdelivr.net/gh/VirgilClyne/GetSomeFries@main/ruleset/ASN.China.yaml' },
-    'CNCIDR': { ...remoteRuleProvider, behavior: 'ipcidr', format: 'mrs', path: './Provider/RuleSet/CNCIDR.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geoip/cn.mrs' },
+    'China ASN': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/China_ASN.yaml', url: 'https://fastly.jsdelivr.net/gh/VirgilClyne/GetSomeFries@main/ruleset/ASN.China.yaml' },
+    'China IP': { ...remoteRuleProvider, behavior: 'ipcidr', format: 'mrs', path: './Provider/RuleSet/China_IP.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geoip/cn.mrs' },
     'LAN': { ...remoteRuleProvider, behavior: 'ipcidr', format: 'mrs', path: './Provider/RuleSet/LAN.mrs', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/lancidr.mrs' },
   };
 
@@ -338,8 +338,8 @@ function main(config) {
     'RULE-SET,Global,Proxy',
     // China Area Network
     'RULE-SET,China,Direct',
-    'RULE-SET,CNASN,Direct,no-resolve',
-    'RULE-SET,CNCIDR,Direct,no-resolve',
+    'RULE-SET,China ASN,Direct,no-resolve',
+    'RULE-SET,China IP,Direct,no-resolve',
     // Local Area Network
     'RULE-SET,LAN,Direct,no-resolve',
     // GeoIP

--- a/Clash/Script/MyScript.js
+++ b/Clash/Script/MyScript.js
@@ -276,8 +276,8 @@ function main(config) {
     'Speedtest': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/Speedtest.mrs', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Speedtest.mrs' },
     'Global': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/Global.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/geolocation-!cn.mrs' },
     'China': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/China.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/cn.mrs' },
-    'CNASN': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/CNASN.yaml', url: 'https://fastly.jsdelivr.net/gh/VirgilClyne/GetSomeFries@main/ruleset/ASN.China.yaml' },
-    'CNCIDR': { ...remoteRuleProvider, behavior: 'ipcidr', format: 'mrs', path: './Provider/RuleSet/CNCIDR.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geoip/cn.mrs' },
+    'China ASN': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/China_ASN.yaml', url: 'https://fastly.jsdelivr.net/gh/VirgilClyne/GetSomeFries@main/ruleset/ASN.China.yaml' },
+    'China IP': { ...remoteRuleProvider, behavior: 'ipcidr', format: 'mrs', path: './Provider/RuleSet/China_IP.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geoip/cn.mrs' },
     'LAN': { ...remoteRuleProvider, behavior: 'ipcidr', format: 'mrs', path: './Provider/RuleSet/LAN.mrs', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/lancidr.mrs' },
   };
 
@@ -340,8 +340,8 @@ function main(config) {
     'RULE-SET,Global,🔰 Proxy',
     // China Area Network
     'RULE-SET,China,🔘 DIRECT',
-    'RULE-SET,CNASN,🔘 DIRECT,no-resolve',
-    'RULE-SET,CNCIDR,🔘 DIRECT,no-resolve',
+    'RULE-SET,China ASN,🔘 DIRECT,no-resolve',
+    'RULE-SET,China IP,🔘 DIRECT,no-resolve',
     // Local Area Network
     'RULE-SET,LAN,🔘 DIRECT,no-resolve',
     // GeoIP

--- a/Clash/Script/MyScriptColor.js
+++ b/Clash/Script/MyScriptColor.js
@@ -276,8 +276,8 @@ function main(config) {
     'Speedtest': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/Speedtest.mrs', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Speedtest.mrs' },
     'Global': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/Global.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/geolocation-!cn.mrs' },
     'China': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/China.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/cn.mrs' },
-    'CNASN': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/CNASN.yaml', url: 'https://fastly.jsdelivr.net/gh/VirgilClyne/GetSomeFries@main/ruleset/ASN.China.yaml' },
-    'CNCIDR': { ...remoteRuleProvider, behavior: 'ipcidr', format: 'mrs', path: './Provider/RuleSet/CNCIDR.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geoip/cn.mrs' },
+    'China ASN': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/China_ASN.yaml', url: 'https://fastly.jsdelivr.net/gh/VirgilClyne/GetSomeFries@main/ruleset/ASN.China.yaml' },
+    'China IP': { ...remoteRuleProvider, behavior: 'ipcidr', format: 'mrs', path: './Provider/RuleSet/China_IP.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geoip/cn.mrs' },
     'LAN': { ...remoteRuleProvider, behavior: 'ipcidr', format: 'mrs', path: './Provider/RuleSet/LAN.mrs', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/lancidr.mrs' },
   };
 
@@ -340,8 +340,8 @@ function main(config) {
     'RULE-SET,Global,🔰 Proxy',
     // China Area Network
     'RULE-SET,China,🔘 DIRECT',
-    'RULE-SET,CNASN,🔘 DIRECT,no-resolve',
-    'RULE-SET,CNCIDR,🔘 DIRECT,no-resolve',
+    'RULE-SET,China ASN,🔘 DIRECT,no-resolve',
+    'RULE-SET,China IP,🔘 DIRECT,no-resolve',
     // Local Area Network
     'RULE-SET,LAN,🔘 DIRECT,no-resolve',
     // GeoIP

--- a/Clash/Script/Script.js
+++ b/Clash/Script/Script.js
@@ -264,8 +264,8 @@ function main(config) {
     'Speedtest': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/Speedtest.mrs', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/Speedtest.mrs' },
     'Global': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/Global.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/geolocation-!cn.mrs' },
     'China': { ...remoteRuleProvider, behavior: 'domain', format: 'mrs', path: './Provider/RuleSet/China.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/cn.mrs' },
-    'CNASN': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/CNASN.yaml', url: 'https://fastly.jsdelivr.net/gh/VirgilClyne/GetSomeFries@main/ruleset/ASN.China.yaml' },
-    'CNCIDR': { ...remoteRuleProvider, behavior: 'ipcidr', format: 'mrs', path: './Provider/RuleSet/CNCIDR.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geoip/cn.mrs' },
+    'China ASN': { ...remoteRuleProvider, behavior: 'classical', format: 'yaml', path: './Provider/RuleSet/China_ASN.yaml', url: 'https://fastly.jsdelivr.net/gh/VirgilClyne/GetSomeFries@main/ruleset/ASN.China.yaml' },
+    'China IP': { ...remoteRuleProvider, behavior: 'ipcidr', format: 'mrs', path: './Provider/RuleSet/China_IP.mrs', url: 'https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geoip/cn.mrs' },
     'LAN': { ...remoteRuleProvider, behavior: 'ipcidr', format: 'mrs', path: './Provider/RuleSet/LAN.mrs', url: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Clash/RuleSet/lancidr.mrs' },
   };
 
@@ -328,8 +328,8 @@ function main(config) {
     'RULE-SET,Global,🔰 Proxy',
     // China Area Network
     'RULE-SET,China,🔘 DIRECT',
-    'RULE-SET,CNASN,🔘 DIRECT,no-resolve',
-    'RULE-SET,CNCIDR,🔘 DIRECT,no-resolve',
+    'RULE-SET,China ASN,🔘 DIRECT,no-resolve',
+    'RULE-SET,China IP,🔘 DIRECT,no-resolve',
     // Local Area Network
     'RULE-SET,LAN,🔘 DIRECT,no-resolve',
     // GeoIP

--- a/Quantumult/Sample.conf
+++ b/Quantumult/Sample.conf
@@ -1,5 +1,5 @@
 # Quantumult X
-# Date: 2026-07-13 10:34:48
+# Date: 2026-07-13 11:43:31
 # Author: @HotKids
 
 [general]
@@ -656,8 +656,8 @@ https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/Filter/Speed
 https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/proxy.txt, tag=Global, force-policy=Outbound, update-interval=86400, opt-parser=true, enabled=true
 # China Area Network
 https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/direct.txt, tag=China, force-policy=direct, update-interval=86400, opt-parser=true, enabled=true
-https://raw.githubusercontent.com/VirgilClyne/GetSomeFries/main/ruleset/ASN.China.list, tag=ASN China, force-policy=direct, update-interval=86400, opt-parser=true, enabled=true
-https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/cncidr.txt, tag=CNCIDR, force-policy=direct, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/VirgilClyne/GetSomeFries/main/ruleset/ASN.China.list, tag=China ASN, force-policy=direct, update-interval=86400, opt-parser=true, enabled=true
+https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/cncidr.txt, tag=China IP, force-policy=direct, update-interval=86400, opt-parser=true, enabled=true
 
 [rewrite_remote]
 # 引用自脚本作者

--- a/Surge/Balloon.lcf
+++ b/Surge/Balloon.lcf
@@ -1,5 +1,5 @@
 # Loon
-# Date: 2026-07-13 10:34:48
+# Date: 2026-07-13 11:43:31
 # Author: @HotKids
 
 [General]
@@ -168,8 +168,8 @@ https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Speedtest.
 https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/proxy.txt, policy=🔰 Proxy, tag=Global, enabled=true
 # China Area Network
 https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/direct.txt, policy=🔘 DIRECT, tag=China, enabled=true
-https://raw.githubusercontent.com/VirgilClyne/GetSomeFries/main/ruleset/ASN.China.list, policy=🔘 DIRECT, tag=ASN China, enabled=true
-https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/cncidr.txt, policy=🔘 DIRECT, tag=CNCIDR, enabled=true
+https://raw.githubusercontent.com/VirgilClyne/GetSomeFries/main/ruleset/ASN.China.list, policy=🔘 DIRECT, tag=China ASN, enabled=true
+https://raw.githubusercontent.com/Loyalsoldier/surge-rules/release/cncidr.txt, policy=🔘 DIRECT, tag=China IP, enabled=true
 # Local Area Network
 https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/LAN.list, policy=🔘 DIRECT, tag=LAN, enabled=true
 


### PR DESCRIPTION
CNCIDR / CNASN 缩写偏术语，且 ASN 那条各平台叫法不一（Clash=CNASN、
QX/Loon=ASN China）。统一为对仗直白的一组：
  geosite/cn·direct => China      （域名，不变）
  geoip/cn·cncidr   => China IP    （原 CNCIDR）
  ASN.China         => China ASN   （原 CNASN / ASN China，跨平台统一）

改 sync-config.txt Rename 段 + README 说明；重新生成 Clash（含 Script 变体）/ QX / Loon 产物，定义名与 RULE-SET 引用一致，
Provider 文件路径按惯例把空格转下划线（China_IP.mrs 等）。
Surfboard / sing-box 无 Rename 段，用原生命名，不受影响。


Claude-Session: https://claude.ai/code/session_01F4XZtn7wQpEys3Rd4nZseo