### PR TITLE
fix(profile): proxy-test-url 改回 http，修复 Surge 拒绝加载

### DIFF
--- a/Clash/Mihomo.yaml
+++ b/Clash/Mihomo.yaml
@@ -1,5 +1,5 @@
 # Clash · 锚点改写版（block + YAML 锚点，功能等价 Sample.yaml）
-# Date: 2026-07-13 11:43:31
+# Date: 2026-07-13 11:56:08
 # Author: @HotKids
 #
 # 自动生成（sync-config.py 从 Clash/Sample.yaml 转译），请勿手改；改内容请改 Surge/Profile.conf。
@@ -96,14 +96,14 @@ anchors:
   - &FilterJP '(?i)(?:🇯🇵|日本|Japan|\b(?:JP|JPN)\d*\b)'
   - &FilterUS '(?i)(?:🇺🇸|美国|United States|\b(?:US|USA)\d*\b)'
   # —— 以下自动策略锚点当前未被引用，供日后加自动/故障转移/负载均衡组时 <<: 合并 ——
-  - &UrlTest {type: url-test, interval: 300, tolerance: 20, lazy: true, url: 'https://cp.cloudflare.com/generate_204', timeout: 2000, max-failed-times: 3, include-all-providers: true, hidden: true}
-  - &FallBack {type: fallback, interval: 300, lazy: true, url: 'https://cp.cloudflare.com/generate_204', timeout: 2000, max-failed-times: 3, include-all-providers: true, hidden: true}
-  - &LoadBalance {type: load-balance, interval: 300, lazy: true, strategy: consistent-hashing, url: 'https://cp.cloudflare.com/generate_204', timeout: 2000, max-failed-times: 3, include-all-providers: true, hidden: true}
+  - &UrlTest {type: url-test, interval: 300, tolerance: 20, lazy: true, url: 'http://cp.cloudflare.com/generate_204', timeout: 2000, max-failed-times: 3, include-all-providers: true, hidden: true}
+  - &FallBack {type: fallback, interval: 300, lazy: true, url: 'http://cp.cloudflare.com/generate_204', timeout: 2000, max-failed-times: 3, include-all-providers: true, hidden: true}
+  - &LoadBalance {type: load-balance, interval: 300, lazy: true, strategy: consistent-hashing, url: 'http://cp.cloudflare.com/generate_204', timeout: 2000, max-failed-times: 3, include-all-providers: true, hidden: true}
 
 # 本地节点（订阅覆盖此处）
 proxies: []
 # 服务器订阅配置（每小时更新，健康检查用 Cloudflare 204）
-proxy-providers: {Server: {type: http, path: ./Provider/Proxy/Server.yaml, url: 'https://sub.hotkids.me', interval: 3600, proxy: DIRECT, header: {User-Agent: [Clash/v1.18.0, mihomo/1.18.3]}, health-check: {enable: true, url: 'https://cp.cloudflare.com/generate_204', interval: 600, timeout: 5000, expected-status: 204}}}
+proxy-providers: {Server: {type: http, path: ./Provider/Proxy/Server.yaml, url: 'https://sub.hotkids.me', interval: 3600, proxy: DIRECT, header: {User-Agent: [Clash/v1.18.0, mihomo/1.18.3]}, health-check: {enable: true, url: 'http://cp.cloudflare.com/generate_204', interval: 600, timeout: 5000, expected-status: 204}}}
 
 # ── 策略组 ──
 proxy-groups:

--- a/Clash/Sample.yaml
+++ b/Clash/Sample.yaml
@@ -1,5 +1,5 @@
 # Clash
-# Date: 2026-07-13 11:43:31
+# Date: 2026-07-13 11:56:08
 # Author: @HotKids
 
 # 通用设置
@@ -319,7 +319,7 @@ proxy-providers:
       - "mihomo/1.18.3"
     health-check:
       enable: true
-      url: 'https://cp.cloudflare.com/generate_204'
+      url: 'http://cp.cloudflare.com/generate_204'
       interval: 600
       timeout: 5000
       expected-status: 204

--- a/Quantumult/Sample.conf
+++ b/Quantumult/Sample.conf
@@ -1,11 +1,11 @@
 # Quantumult X
-# Date: 2026-07-13 11:43:31
+# Date: 2026-07-13 11:56:08
 # Author: @HotKids
 
 [general]
 profile_img_url=https://raw.githubusercontent.com/Koolson/Qure/master/IconSet/Color/Want_Want.png
 resource_parser_url=https://raw.githubusercontent.com/KOP-XIAO/QuantumultX/master/Scripts/resource-parser.js
-server_check_url=https://cp.cloudflare.com/generate_204
+server_check_url=http://cp.cloudflare.com/generate_204
 network_check_url=http://connectivitycheck.platform.hicloud.com/generate_204
 ;geo_location_checker=http://ifconfig.co/json, https://raw.githubusercontent.com/HotKids/Rules/master/Quantumult/X/GeoIP/IPConfig.js
 geo_location_checker= http://api.live.bilibili.com/ip_service/v1/ip_service/get_ip_addr, https://raw.githubusercontent.com/KOP-XIAO/QuantumultX/master/Scripts/IP_bili.js

--- a/Surge/Balloon.lcf
+++ b/Surge/Balloon.lcf
@@ -1,5 +1,5 @@
 # Loon
-# Date: 2026-07-13 11:43:31
+# Date: 2026-07-13 11:56:08
 # Author: @HotKids
 
 [General]
@@ -34,7 +34,7 @@ disconnect-on-policy-change = false
 # 直连延迟测试 URL
 internet-test-url = http://connectivitycheck.platform.hicloud.com/generate_204
 # 代理延迟测试 URL
-proxy-test-url = https://cp.cloudflare.com/generate_204
+proxy-test-url = http://cp.cloudflare.com/generate_204
 # 资源解析器
 resource-parser = https://raw.githubusercontent.com/sub-store-org/Sub-Store/release/sub-store-parser.loon.min.js
 # GeoIP 数据库

--- a/Surge/Profile.conf
+++ b/Surge/Profile.conf
@@ -11,7 +11,7 @@ wifi-assist = false
 internet-test-url = http://connectivitycheck.platform.hicloud.com/generate_204
 
 # > 代理测速 URL
-proxy-test-url = https://cp.cloudflare.com/generate_204
+proxy-test-url = http://cp.cloudflare.com/generate_204
 
 # > 测试超时（秒）
 test-timeout = 5

--- a/Surge/Surfboard.conf
+++ b/Surge/Surfboard.conf
@@ -1,5 +1,5 @@
 [General]
-proxy-test-url = https://cp.cloudflare.com/generate_204
+proxy-test-url = http://cp.cloudflare.com/generate_204
 skip-proxy = localhost, *.local, *.lan, *.home, *.home.arpa, *.portal.*, captive.*, 10.0.0.0/8, 100.64.0.0/10, 127.0.0.0/8, 169.254.0.0/16, 172.16.0.0/12, 192.168.0.0/16, ::1/128, fe80::/10
 dns-server = 119.29.29.29, 223.5.5.5
 doh-server = https://doh.pub/dns-query, https://dns.alidns.com/dns-query

--- a/sing-box/config.json
+++ b/sing-box/config.json
@@ -174,7 +174,7 @@
       "outbounds": [
         "🇭🇰 HK"
       ],
-      "url": "https://cp.cloudflare.com/generate_204",
+      "url": "http://cp.cloudflare.com/generate_204",
       "interval": "180s",
       "tolerance": 50
     },
@@ -184,7 +184,7 @@
       "outbounds": [
         "🇨🇳 TW"
       ],
-      "url": "https://cp.cloudflare.com/generate_204",
+      "url": "http://cp.cloudflare.com/generate_204",
       "interval": "180s",
       "tolerance": 50
     },
@@ -194,7 +194,7 @@
       "outbounds": [
         "🇸🇬 SG"
       ],
-      "url": "https://cp.cloudflare.com/generate_204",
+      "url": "http://cp.cloudflare.com/generate_204",
       "interval": "180s",
       "tolerance": 50
     },
@@ -204,7 +204,7 @@
       "outbounds": [
         "🇯🇵 JP"
       ],
-      "url": "https://cp.cloudflare.com/generate_204",
+      "url": "http://cp.cloudflare.com/generate_204",
       "interval": "180s",
       "tolerance": 50
     },
@@ -214,7 +214,7 @@
       "outbounds": [
         "🇺🇸 US"
       ],
-      "url": "https://cp.cloudflare.com/generate_204",
+      "url": "http://cp.cloudflare.com/generate_204",
       "interval": "180s",
       "tolerance": 50
     },


### PR DESCRIPTION
Surge 校验 proxy-test-url 只接受 HTTP 探测端点（返回 204 的延迟测试）， https 会被判「无效配置」（SGSettingsModelErrorDomain:0，行 14）导致 整个配置无法加载。这正是它本应用 http 的原因。

单一来源不受影响：http://cp.cloudflare.com/generate_204 在
Surge/Clash/Loon/QX/sing-box 全部可用，https 是唯一会让 Surge 报错的 方案。改 Profile.conf 源值，@@PROXY_TEST_URL@@ 注入使各平台产物一并 回到 http。


Claude-Session: https://claude.ai/code/session_01F4XZtn7wQpEys3Rd4nZseo