### PR TITLE
fix(module): GeoLoc 修复 Twitter 开关占位符多余空格

### DIFF
--- a/Surge/Module/GeoLoc.sgmodule
+++ b/Surge/Module/GeoLoc.sgmodule
@@ -38,7 +38,7 @@ URL-REGEX,https:\/\/api\.{{{Zhihu}}}\.com\/answers,{{{SNS}}}
 URL-REGEX,https:\/\/api\.{{{Zhihu}}}\.com\/comment_v\d\/answers\/\d+\/comment,{{{SNS}}}
 
 # Twitter/X
-{{{Twitter 开关 }}},https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Twitter.list,{{{Twitter 代理}}},extended-matching
+{{{Twitter 开关}}},https://raw.githubusercontent.com/HotKids/Rules/master/Surge/RULE-SET/Twitter.list,{{{Twitter 代理}}},extended-matching
 
 [MITM]
 hostname = %INSERT% api.{{{Bilibili}}}.com, api.{{{Weibo}}}.cn, {{{Weibo}}}.com, api.{{{Zhihu}}}.com


### PR DESCRIPTION
第 41 行引用写成 {{{Twitter 开关 }}}（}}} 前多一个空格），而参数定义为
`Twitter 开关`（无尾空格）。Surge 按精确名替换占位符，带空格的名字匹配
不到 → 占位符不被替换，行首残留字面量 {{{Twitter 开关 }}} → 规则无效，
也让「输入 # 禁用」的技巧失效。去掉空格与参数名对齐；全仓其它模块
（Service+ 等）皆无此空格，本处为唯一特例。


Claude-Session: https://claude.ai/code/session_01F4XZtn7wQpEys3Rd4nZseo