### PR TITLE
feat(clashbox): 恢复 MyClashBox 的 REJECT-DROP 用法

### DIFF
--- a/.github/scripts/sync-config/Enhanced/clashbox.overlay.json
+++ b/.github/scripts/sync-config/Enhanced/clashbox.overlay.json
@@ -1,12 +1,9 @@
 {
-  "_comment": "Clash/Script/MyClashBox.js 相对 Clash/Script/Script.js 的私人差异声明，由 sync-config.py 读取并叠加在自动生成的基座上。改这个文件即可调整差异，不要直接手改 MyClashBox.js（会被下次同步覆盖）。extends 声明基于 myscriptcolor.overlay.json 已经生成的结果继续叠加——Liquid Glass 图标直接继承自 MyScriptColor（同一套，不必重复声明），MyClashBox 在其上批量改名（rename_map），外加两处独有差异：REJECT-DROP 整组去掉（AdGuard 候选两选一，其规则落点重定向到 REJECT 保留拦截）、OneDrive/Microsoft/Speedtest 默认关闭。日常改地区/Relay链等公共部分维护 myscript.overlay.json、改图标维护 myscriptcolor.overlay.json，MyClashBox 都会自动跟着同步。",
+  "_comment": "Clash/Script/MyClashBox.js 相对 Clash/Script/Script.js 的私人差异声明，由 sync-config.py 读取并叠加在自动生成的基座上。改这个文件即可调整差异，不要直接手改 MyClashBox.js（会被下次同步覆盖）。extends 声明基于 myscriptcolor.overlay.json 已经生成的结果继续叠加——Liquid Glass 图标直接继承自 MyScriptColor（同一套，不必重复声明），MyClashBox 在其上批量改名（rename_map），外加 OneDrive/Microsoft/Speedtest 默认关闭。日常改地区/Relay链等公共部分维护 myscript.overlay.json、改图标维护 myscriptcolor.overlay.json，MyClashBox 都会自动跟着同步。",
 
   "output": "Clash/Script/MyClashBox.js",
 
   "extends": "myscriptcolor.overlay.json",
-
-  "rule_policy_redirect": { "📛 REJECT-DROP": "⛔️ REJECT" },
-  "remove_groups": ["📛 REJECT-DROP"],
 
   "disabled_by_default": ["OneDrive", "Microsoft", "Speedtest"],
 
@@ -27,6 +24,7 @@
     "🚧 AdGuard": "AdGuard",
     "🔘 DIRECT": "Direct",
     "⛔️ REJECT": "Reject",
+    "📛 REJECT-DROP": "Reject-Drop",
     "🇺🇳 Server": "Server",
     "🇭🇰 Hong Kong": "Hong Kong",
     "🇨🇳 Taiwan": "Taiwan",

--- a/Clash/Script/MyClashBox.js
+++ b/Clash/Script/MyClashBox.js
@@ -193,11 +193,13 @@ function main(config) {
     // Speedtest
     { name: 'Speedtest', type: 'select', icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Liquid%20Glass/Speed.png' },
     // Adblock
-    { name: 'AdGuard', type: 'select', proxies: ['Direct', 'Reject'], icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Liquid%20Glass/AdBlock.png' },
+    { name: 'AdGuard', type: 'select', proxies: ['Direct', 'Reject', 'Reject-Drop'], icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Liquid%20Glass/AdBlock.png' },
     // DIRECT
     { name: 'Direct', type: 'select', proxies: ['DIRECT'], hidden: true, icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Liquid%20Glass/Direct.png' },
     // REJECT
     { name: 'Reject', type: 'select', proxies: ['REJECT'], hidden: true, icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Liquid%20Glass/Reject.png' },
+    // REJECT-DROP
+    { name: 'Reject-Drop', type: 'select', proxies: ['REJECT-DROP'], hidden: true, icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Liquid%20Glass/Reject.png' },
     { name: '🇸🇱 Relay', type: 'url-test', hidden: true, tolerance: 50, icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Liquid%20Glass/Protect.png' },
     { name: '🇭🇰 HK Relay', type: 'fallback', hidden: true, icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Liquid%20Glass/Protect.png' },
     { name: '🇨🇳 TW Relay', type: 'fallback', hidden: true, icon: 'https://fastly.jsdelivr.net/gh/HotKids/Rules@master/Quantumult/X/Images/Liquid%20Glass/Protect.png' },
@@ -298,7 +300,7 @@ function main(config) {
     // Phishing 钓鱼网站
     'RULE-SET,Phishing,AdGuard',
     // Bogus IP NXDOMAIN 劫持/僵尸网络 C2
-    'RULE-SET,Bogus,Reject,no-resolve',
+    'RULE-SET,Bogus,Reject-Drop,no-resolve',
     // Global Area Network
     // > Streaming by Region
     // >> Streaming TW


### PR DESCRIPTION
此前 clashbox overlay 用 remove_groups + rule_policy_redirect 把 📛 REJECT-DROP 整组删掉、其规则落点重定向到 ⛔️ REJECT。既然
REJECT-DROP 现已在 Profile.conf [Proxy] 正式定义、Clash 原生支持， 不再需要这层规避。

移除两个 override，让 MyClashBox 继承基座的 REJECT-DROP：
- AdGuard 候选恢复 [Direct, Reject, Reject-Drop]
- Reject-Drop 组恢复（→ 内建 REJECT-DROP）
- Bogus 规则落点恢复 RULE-SET,Bogus,Reject-Drop 并把 📛 REJECT-DROP => Reject-Drop 加进 rename_map，与其余去 emoji 组名保持一致。仅 MyClashBox 受影响，MyScript/MyScriptColor 一直用 基座 REJECT-DROP、不变。


Claude-Session: https://claude.ai/code/session_01F4XZtn7wQpEys3Rd4nZseo