### PR TITLE
style(profile): [Proxy] 补齐 REJECT-NO-DROP 别名，统一 reject 变体风格

### DIFF
--- a/Surge/Profile.conf
+++ b/Surge/Profile.conf
@@ -146,6 +146,7 @@ client-proxy-name = 🏠 Gateway
 🔘 DIRECT = direct
 ⛔️ REJECT = reject
 📛 REJECT-DROP = reject-drop
+🚫 REJECT-NO-DROP = reject-no-drop
 💢 REJECT-TINYGIF = reject-tinygif
 
 [Proxy Group]


### PR DESCRIPTION
[Proxy] 已定义 REJECT / REJECT-DROP / REJECT-TINYGIF，唯独 reject-no-drop 之前只在 QUIC 规则里裸用（PROTOCOL,QUIC,REJECT-NO-DROP）。 补一条 🚫 REJECT-NO-DROP = reject-no-drop，让四个 reject 变体在 [Proxy] 风格一致、都有具名别名可引用。

不改名、不动 QUIC 规则。别名为 Surge 内建动作，其他平台不支持
（reject-no-drop 不在 Loon/Clash/Surfboard 的 supported_actions）， 生成时已自动从各平台 [Proxy]/wrapper 过滤，重生后产物仅 Profile.conf
变动、无泄漏。


Claude-Session: https://claude.ai/code/session_01F4XZtn7wQpEys3Rd4nZseo