### PR TITLE
ci: actions/checkout v4 → v5，消除 Node 20 弃用告警

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Syntax check Python
         # glob 覆盖全部脚本（含 _common.py 及以后新增文件）；py_compile 不追 import，逐文件列举容易漏

--- a/.github/workflows/whale.yml
+++ b/.github/workflows/whale.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout（完整历史，force-push 需要全量提交）
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.branch }}
           fetch-depth: 0


### PR DESCRIPTION
分支基于 🐳 改写后的新 master 重建：本轮其余改动已在 master 内，
仅此 checkout v5 升级为未合并项，叠加于新 master 之上。


Claude-Session: https://claude.ai/code/session_01F4XZtn7wQpEys3Rd4nZseo