### PR TITLE
feat(clashbox): Server 组排除名字含 dns 的节点

### DIFF
--- a/.github/scripts/sync-config/Enhanced/clashbox.overlay.json
+++ b/.github/scripts/sync-config/Enhanced/clashbox.overlay.json
@@ -7,6 +7,10 @@
 
   "disabled_by_default": ["OneDrive", "Microsoft", "Speedtest"],
 
+  "group_overrides": {
+    "Server": { "filter": "(?i)^(?!.*dns)" }
+  },
+
   "rename_map": {
     "🔰 Proxy": "Proxy",
     "🎬 Streaming": "Streaming",

--- a/Clash/Script/MyClashBox.js
+++ b/Clash/Script/MyClashBox.js
@@ -152,7 +152,7 @@ function main(config) {
     '🇨🇳 TW Relay': '(?i)^(?=.*\\b(?:TW|TWN)\\d*\\b)(?=.*Neburst)',
     '🇯🇵 JP Relay': '(?i)^(?=.*\\b(?:JP|JPN)\\d*\\b)(?=.*Pro)',
     '🇺🇸 US Relay': '(?i)^(?=.*\\b(?:US|USA)\\d*\\b)(?=.*(?:GoMaMi|Pro))',
-    'Server': null,
+    'Server': '(?i)^(?!.*dns)',
     'Hong Kong': '(?i)^(?=.*\\b(?:HK|HKG)\\d*\\b)(?!.*GoMaMi)(?!.*Pro)',
     'Taiwan': '(?i)^(?=.*\\b(?:TW|TWN)\\d*\\b)(?!.*Neburst)(?!.*Pro)',
     'Singapore': '(?i)^(?=.*\\b(?:SG|SGP)\\d*\\b)(?!.*Neburst)(?!.*Pro)',


### PR DESCRIPTION
clashbox overlay 给 Server 组加 filter '(?i)^(?!.*dns)'（负向前瞻， 忽略大小写），运行时填充候选时剔除名字含 dns/DNS 的节点。
注意 overlay 的 group_overrides 在 rename_map 之后应用，键须用改名后 的 'Server' 而非 '🇺🇳 Server'。仅影响 MyClashBox，其余脚本不变。


Claude-Session: https://claude.ai/code/session_01F4XZtn7wQpEys3Rd4nZseo