### PR TITLE
feat(clash-script): 首行加 Compatible_With_Bettbox 适配可视化开关

### DIFF
--- a/.github/scripts/sync-config.py
+++ b/.github/scripts/sync-config.py
@@ -3242,6 +3242,10 @@ def _gen_clash_script_js(
         ]
 
     lines = [
+        # Bettbox 可视化开关适配：首行声明本脚本用 ruleOptionsEnable 暴露分组开关，
+        # Bettbox 读到后在 UI 里渲染成可视开关；其它客户端把它当普通未用常量、无副作用。
+        "const Compatible_With_Bettbox = { ruleOptionsEnable: true };",
+        "",
         "/**",
         " * mihomo 覆写脚本（Enhance Script）· HotKids/Rules",
         " *",
@@ -3251,7 +3255,8 @@ def _gen_clash_script_js(
         " *",
         *source_lines,
         " *",
-        " * 本地唯一可临时修改的是下方 ruleOptionsEnable 的取值，用于按需开关某个分组。",
+        " * 本地唯一可临时修改的是下方 ruleOptionsEnable 的取值，用于按需开关某个分组；",
+        " * 首行 Compatible_With_Bettbox 声明让 Bettbox 把这些开关渲染成可视 UI。",
         " *",
         " * 仓库：https://github.com/HotKids/Rules",
         " */",

--- a/Clash/Script/MyClashBox.js
+++ b/Clash/Script/MyClashBox.js
@@ -1,3 +1,5 @@
+const Compatible_With_Bettbox = { ruleOptionsEnable: true };
+
 /**
  * mihomo 覆写脚本（Enhance Script）· HotKids/Rules
  *
@@ -11,7 +13,8 @@
  * 私人差异（改名 / 换图标 / 额外分组 / 分组类型 / 候选节点 / 默认开关等）
  * 请改 clashbox.overlay.json。
  *
- * 本地唯一可临时修改的是下方 ruleOptionsEnable 的取值，用于按需开关某个分组。
+ * 本地唯一可临时修改的是下方 ruleOptionsEnable 的取值，用于按需开关某个分组；
+ * 首行 Compatible_With_Bettbox 声明让 Bettbox 把这些开关渲染成可视 UI。
  *
  * 仓库：https://github.com/HotKids/Rules
  */

--- a/Clash/Script/MyScript.js
+++ b/Clash/Script/MyScript.js
@@ -1,3 +1,5 @@
+const Compatible_With_Bettbox = { ruleOptionsEnable: true };
+
 /**
  * mihomo 覆写脚本（Enhance Script）· HotKids/Rules
  *
@@ -11,7 +13,8 @@
  * 私人差异（改名 / 换图标 / 额外分组 / 分组类型 / 候选节点 / 默认开关等）
  * 请改 myscript.overlay.json。
  *
- * 本地唯一可临时修改的是下方 ruleOptionsEnable 的取值，用于按需开关某个分组。
+ * 本地唯一可临时修改的是下方 ruleOptionsEnable 的取值，用于按需开关某个分组；
+ * 首行 Compatible_With_Bettbox 声明让 Bettbox 把这些开关渲染成可视 UI。
  *
  * 仓库：https://github.com/HotKids/Rules
  */

--- a/Clash/Script/MyScriptColor.js
+++ b/Clash/Script/MyScriptColor.js
@@ -1,3 +1,5 @@
+const Compatible_With_Bettbox = { ruleOptionsEnable: true };
+
 /**
  * mihomo 覆写脚本（Enhance Script）· HotKids/Rules
  *
@@ -11,7 +13,8 @@
  * 私人差异（改名 / 换图标 / 额外分组 / 分组类型 / 候选节点 / 默认开关等）
  * 请改 myscriptcolor.overlay.json。
  *
- * 本地唯一可临时修改的是下方 ruleOptionsEnable 的取值，用于按需开关某个分组。
+ * 本地唯一可临时修改的是下方 ruleOptionsEnable 的取值，用于按需开关某个分组；
+ * 首行 Compatible_With_Bettbox 声明让 Bettbox 把这些开关渲染成可视 UI。
  *
  * 仓库：https://github.com/HotKids/Rules
  */

--- a/Clash/Script/Script.js
+++ b/Clash/Script/Script.js
@@ -1,3 +1,5 @@
+const Compatible_With_Bettbox = { ruleOptionsEnable: true };
+
 /**
  * mihomo 覆写脚本（Enhance Script）· HotKids/Rules
  *
@@ -9,7 +11,8 @@
  * Clash/Mihomo.yaml）转译而来，直接改本文件会在下次同步时被覆盖；
  * 要改内容请改 Surge/Profile.conf。
  *
- * 本地唯一可临时修改的是下方 ruleOptionsEnable 的取值，用于按需开关某个分组。
+ * 本地唯一可临时修改的是下方 ruleOptionsEnable 的取值，用于按需开关某个分组；
+ * 首行 Compatible_With_Bettbox 声明让 Bettbox 把这些开关渲染成可视 UI。
  *
  * 仓库：https://github.com/HotKids/Rules
  */


### PR DESCRIPTION
Bettbox 覆写脚本只需首行声明 Compatible_With_Bettbox = {
ruleOptionsEnable: true } 即可把脚本的分组开关渲染成内置可视 UI。
四个生成脚本（Script / MyScript / MyScriptColor / MyClashBox）本就 用 ruleOptionsEnable 暴露分组开关，补上这行声明即接入。

该常量对 Clash Verge Rev / FlClash 等是未用变量、无副作用；node
--check 与 main() 冒烟均通过。


Claude-Session: https://claude.ai/code/session_01F4XZtn7wQpEys3Rd4nZseo