### PR TITLE
style(clash-script): Compatible_With_Bettbox 移到 ruleOptionsEnable 前

### DIFF
--- a/.github/scripts/sync-config.py
+++ b/.github/scripts/sync-config.py
@@ -3242,10 +3242,6 @@ def _gen_clash_script_js(
         ]
 
     lines = [
-        # Bettbox 可视化开关适配：首行声明本脚本用 ruleOptionsEnable 暴露分组开关，
-        # Bettbox 读到后在 UI 里渲染成可视开关；其它客户端把它当普通未用常量、无副作用。
-        "const Compatible_With_Bettbox = { ruleOptionsEnable: true };",
-        "",
         "/**",
         " * mihomo 覆写脚本（Enhance Script）· HotKids/Rules",
         " *",
@@ -3255,11 +3251,13 @@ def _gen_clash_script_js(
         " *",
         *source_lines,
         " *",
-        " * 本地唯一可临时修改的是下方 ruleOptionsEnable 的取值，用于按需开关某个分组；",
-        " * 首行 Compatible_With_Bettbox 声明让 Bettbox 把这些开关渲染成可视 UI。",
+        " * 本地唯一可临时修改的是下方 ruleOptionsEnable 的取值，用于按需开关某个分组。",
         " *",
         " * 仓库：https://github.com/HotKids/Rules",
         " */",
+        "",
+        "// 适配 Bettbox 自定义配置参数",
+        "const Compatible_With_Bettbox = { ruleOptionsEnable: true };",
         "",
         "// 分流分组开关：true 启用 / false 关闭对应分组（连同其专属 rules /",
         "// rule-providers 一并裁剪，无需改动 Profile.conf）。默认值见下方——",

--- a/Clash/Script/MyClashBox.js
+++ b/Clash/Script/MyClashBox.js
@@ -1,5 +1,3 @@
-const Compatible_With_Bettbox = { ruleOptionsEnable: true };
-
 /**
  * mihomo 覆写脚本（Enhance Script）· HotKids/Rules
  *
@@ -13,11 +11,13 @@ const Compatible_With_Bettbox = { ruleOptionsEnable: true };
  * 私人差异（改名 / 换图标 / 额外分组 / 分组类型 / 候选节点 / 默认开关等）
  * 请改 clashbox.overlay.json。
  *
- * 本地唯一可临时修改的是下方 ruleOptionsEnable 的取值，用于按需开关某个分组；
- * 首行 Compatible_With_Bettbox 声明让 Bettbox 把这些开关渲染成可视 UI。
+ * 本地唯一可临时修改的是下方 ruleOptionsEnable 的取值，用于按需开关某个分组。
  *
  * 仓库：https://github.com/HotKids/Rules
  */
+
+// 适配 Bettbox 自定义配置参数
+const Compatible_With_Bettbox = { ruleOptionsEnable: true };
 
 // 分流分组开关：true 启用 / false 关闭对应分组（连同其专属 rules /
 // rule-providers 一并裁剪，无需改动 Profile.conf）。默认值见下方——

--- a/Clash/Script/MyScript.js
+++ b/Clash/Script/MyScript.js
@@ -1,5 +1,3 @@
-const Compatible_With_Bettbox = { ruleOptionsEnable: true };
-
 /**
  * mihomo 覆写脚本（Enhance Script）· HotKids/Rules
  *
@@ -13,11 +11,13 @@ const Compatible_With_Bettbox = { ruleOptionsEnable: true };
  * 私人差异（改名 / 换图标 / 额外分组 / 分组类型 / 候选节点 / 默认开关等）
  * 请改 myscript.overlay.json。
  *
- * 本地唯一可临时修改的是下方 ruleOptionsEnable 的取值，用于按需开关某个分组；
- * 首行 Compatible_With_Bettbox 声明让 Bettbox 把这些开关渲染成可视 UI。
+ * 本地唯一可临时修改的是下方 ruleOptionsEnable 的取值，用于按需开关某个分组。
  *
  * 仓库：https://github.com/HotKids/Rules
  */
+
+// 适配 Bettbox 自定义配置参数
+const Compatible_With_Bettbox = { ruleOptionsEnable: true };
 
 // 分流分组开关：true 启用 / false 关闭对应分组（连同其专属 rules /
 // rule-providers 一并裁剪，无需改动 Profile.conf）。默认值见下方——

--- a/Clash/Script/MyScriptColor.js
+++ b/Clash/Script/MyScriptColor.js
@@ -1,5 +1,3 @@
-const Compatible_With_Bettbox = { ruleOptionsEnable: true };
-
 /**
  * mihomo 覆写脚本（Enhance Script）· HotKids/Rules
  *
@@ -13,11 +11,13 @@ const Compatible_With_Bettbox = { ruleOptionsEnable: true };
  * 私人差异（改名 / 换图标 / 额外分组 / 分组类型 / 候选节点 / 默认开关等）
  * 请改 myscriptcolor.overlay.json。
  *
- * 本地唯一可临时修改的是下方 ruleOptionsEnable 的取值，用于按需开关某个分组；
- * 首行 Compatible_With_Bettbox 声明让 Bettbox 把这些开关渲染成可视 UI。
+ * 本地唯一可临时修改的是下方 ruleOptionsEnable 的取值，用于按需开关某个分组。
  *
  * 仓库：https://github.com/HotKids/Rules
  */
+
+// 适配 Bettbox 自定义配置参数
+const Compatible_With_Bettbox = { ruleOptionsEnable: true };
 
 // 分流分组开关：true 启用 / false 关闭对应分组（连同其专属 rules /
 // rule-providers 一并裁剪，无需改动 Profile.conf）。默认值见下方——

--- a/Clash/Script/Script.js
+++ b/Clash/Script/Script.js
@@ -1,5 +1,3 @@
-const Compatible_With_Bettbox = { ruleOptionsEnable: true };
-
 /**
  * mihomo 覆写脚本（Enhance Script）· HotKids/Rules
  *
@@ -11,11 +9,13 @@ const Compatible_With_Bettbox = { ruleOptionsEnable: true };
  * Clash/Mihomo.yaml）转译而来，直接改本文件会在下次同步时被覆盖；
  * 要改内容请改 Surge/Profile.conf。
  *
- * 本地唯一可临时修改的是下方 ruleOptionsEnable 的取值，用于按需开关某个分组；
- * 首行 Compatible_With_Bettbox 声明让 Bettbox 把这些开关渲染成可视 UI。
+ * 本地唯一可临时修改的是下方 ruleOptionsEnable 的取值，用于按需开关某个分组。
  *
  * 仓库：https://github.com/HotKids/Rules
  */
+
+// 适配 Bettbox 自定义配置参数
+const Compatible_With_Bettbox = { ruleOptionsEnable: true };
 
 // 分流分组开关：true 启用 / false 关闭对应分组（连同其专属 rules /
 // rule-providers 一并裁剪，无需改动 Profile.conf）。默认值见下方——


### PR DESCRIPTION
按需求把 Bettbox 适配声明从首行移到 JSDoc 之后、ruleOptionsEnable
之前，与它逻辑相邻，并加注释「// 适配 Bettbox 自定义配置参数」。
首行恢复为 JSDoc。四脚本 node --check + main() 冒烟通过。


Claude-Session: https://claude.ai/code/session_01F4XZtn7wQpEys3Rd4nZseo